### PR TITLE
docs: add <framework> placeholder; update Python invocations to use it

### DIFF
--- a/.claude/skills/allocate-cve/SKILL.md
+++ b/.claude/skills/allocate-cve/SKILL.md
@@ -369,7 +369,7 @@ user to confirm. Numbered items:
 4. **Regenerate the CVE JSON attachment** in the tracker body by
    running
    ```bash
-   uv run --project tools/vulnogram/generate-cve-json generate-cve-json <N> --attach
+   uv run --project <framework>/tools/vulnogram/generate-cve-json generate-cve-json <N> --attach
    ```
    This is how the CVE record first gets seeded with the allocated
    ID. The remediation-developer credit (if any) comes from the
@@ -440,7 +440,7 @@ spaces inside the block, one blank line after
 
 Allocated via the ASF Vulnogram form at <https://cveprocess.apache.org/allocatecve>; the CVE ID is now the canonical reference in every downstream artifact (CVE JSON, advisory email, credit lines, cross-links). Scope `<scope label>` → product `<product>` → `packageName` `<packageName>`.
 
-Vulnogram paste-ready JSON was regenerated from the current body state (CWE `<CWE>`, severity `<severity>`, affected `<affected versions>`, `<N>` credits, `<N>` references) and embedded in the issue body. Re-run `uv run --project tools/vulnogram/generate-cve-json generate-cve-json <N> --attach` after any body change to keep the JSON in sync.
+Vulnogram paste-ready JSON was regenerated from the current body state (CWE `<CWE>`, severity `<severity>`, affected `<affected versions>`, `<N>` credits, `<N>` references) and embedded in the issue body. Re-run `uv run --project <framework>/tools/vulnogram/generate-cve-json generate-cve-json <N> --attach` after any body change to keep the JSON in sync.
 
 </details>
 ```
@@ -488,7 +488,7 @@ partial failures stay legible:
    repos/<tracker>/issues/comments/<id> --input …`), or create
    the rollup (`gh issue comment <N> --repo <tracker>
    --body-file <tmp>`) if none exists yet.
-4. `uv run --project tools/vulnogram/generate-cve-json generate-cve-json <N> --attach`
+4. `uv run --project <framework>/tools/vulnogram/generate-cve-json generate-cve-json <N> --attach`
    — embeds the CVE JSON in the body.
 5. Create draft on the original thread (reporter notification, if
    applicable) via the project's configured drafting backend — see

--- a/.claude/skills/deduplicate-security-issue/SKILL.md
+++ b/.claude/skills/deduplicate-security-issue/SKILL.md
@@ -396,7 +396,7 @@ After confirmation, apply **sequentially** (never in parallel):
    (GitHub's `duplicate` close-reason is not exposed by `gh` on
    all versions; `not planned` combined with the `duplicate` label
    carries the same signal)
-6. `uv run --project tools/vulnogram/generate-cve-json generate-cve-json <keep> --attach`
+6. `uv run --project <framework>/tools/vulnogram/generate-cve-json generate-cve-json <keep> --attach`
    — the *Remediation developer* body field is the source of truth
    for remediation-developer credits (populated by the
    `sync-security-issue` skill from the linked PR's author); no CLI

--- a/.claude/skills/sync-security-issue/SKILL.md
+++ b/.claude/skills/sync-security-issue/SKILL.md
@@ -1709,7 +1709,7 @@ In every other case — including already-published CVEs — regenerate.
 The minimum command, from the `<tracker>` clone root:
 
 ```bash
-uv run --project tools/vulnogram/generate-cve-json generate-cve-json <N> --attach
+uv run --project <framework>/tools/vulnogram/generate-cve-json generate-cve-json <N> --attach
 ```
 
 That alone is enough. The script reads every template field from the
@@ -1757,7 +1757,7 @@ reason; the same scoping rule applies if you ever need to resolve
 the author by hand.
 
 ```bash
-uv run --project tools/vulnogram/generate-cve-json generate-cve-json <N> --attach
+uv run --project <framework>/tools/vulnogram/generate-cve-json generate-cve-json <N> --attach
 ```
 
 If the *"Remediation developer"* field is empty at regeneration time

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -286,6 +286,7 @@ the active configuration before executing any command:
 | Placeholder | Resolves to | Source |
 |---|---|---|
 | `<project-config>` | The adopting project's `.apache-steward/` directory in its tracker repo. | Filesystem convention. |
+| `<framework>` | The framework's root — i.e. this repository. In adopting projects, `<project-config>/apache-steward/` (the submodule path); in framework standalone, `.` (the repository root). Used in `uv run` and other invocations that need to address the framework's `tools/<name>/` subtrees from a path the agent can resolve at the agent's current `cwd`. | Filesystem convention. |
 | `<tracker>` | The GitHub slug of the tracker repo (example: `airflow-s/airflow-s` for the Apache Airflow security team). | `<project-config>/project.md` → `tracker_repo` |
 | `<upstream>` | The GitHub slug of the upstream codebase the fixes land in (example: `apache/airflow`). | `<project-config>/project.md` → `upstream_repo` |
 | `<security-list>` | The project's security mailing list (example: `security@airflow.apache.org`). | `<project-config>/project.md` → `mailing_lists.security` |

--- a/tools/vulnogram/generate-cve-json/README.md
+++ b/tools/vulnogram/generate-cve-json/README.md
@@ -38,20 +38,34 @@ workflow for the project itself.
 
 ## Run
 
-From the repository root:
+From the framework's root (this repository when running standalone;
+the `.apache-steward/apache-steward/` submodule path inside an
+adopting tracker repo):
 
 ```bash
 uv run --project tools/vulnogram/generate-cve-json generate-cve-json <ISSUE-NUMBER> [options]
 ```
 
+Skill files reference the same invocation via the `<framework>`
+placeholder so the path resolves in either context:
+
+```bash
+uv run --project <framework>/tools/vulnogram/generate-cve-json generate-cve-json <ISSUE-NUMBER>
+```
+
+`<framework>` substitutes to `.apache-steward/apache-steward` in
+adopting projects and to `.` (the repository root) in framework
+standalone — see the placeholder convention in
+[`AGENTS.md`](../../../AGENTS.md#placeholder-convention-used-in-skill-files).
+
 Equivalent forms:
 
 ```bash
 # as a module
-uv run --project tools/vulnogram/generate-cve-json python -m generate_cve_json <ISSUE-NUMBER>
+uv run --project <framework>/tools/vulnogram/generate-cve-json python -m generate_cve_json <ISSUE-NUMBER>
 
 # from inside the project dir
-cd tools/vulnogram/generate-cve-json
+cd <framework>/tools/vulnogram/generate-cve-json
 uv run generate-cve-json <ISSUE-NUMBER>
 ```
 

--- a/tools/vulnogram/generate-cve-json/SKILL.md
+++ b/tools/vulnogram/generate-cve-json/SKILL.md
@@ -259,7 +259,7 @@ prepares the (cached) virtualenv on first use and reuses it on later
 runs:
 
 ```bash
-uv run --project tools/vulnogram/generate-cve-json generate-cve-json <N> \
+uv run --project <framework>/tools/vulnogram/generate-cve-json generate-cve-json <N> \
   --output /tmp/<CVE-ID>.json \
   --version-start <earliest-affected-version>
 ```
@@ -273,7 +273,7 @@ needed in the normal flow. For a fix that landed in `3.2.2` and was
 first introduced in `3.0.0`, for example:
 
 ```bash
-uv run --project tools/vulnogram/generate-cve-json generate-cve-json 232 \
+uv run --project <framework>/tools/vulnogram/generate-cve-json generate-cve-json 232 \
   --output /tmp/CVE-2026-40913.json \
   --version-start 3.0.0
 ```
@@ -375,7 +375,7 @@ If the user also wants the JSON *attached* to the tracking issue itself
 add `--attach` to the invocation:
 
 ```bash
-uv run --project tools/vulnogram/generate-cve-json generate-cve-json 232 \
+uv run --project <framework>/tools/vulnogram/generate-cve-json generate-cve-json 232 \
   --output /tmp/CVE-2026-40913.json \
   --version-start 3.0.0 \
   --attach


### PR DESCRIPTION
## Summary

PR 2 ported the `generate-cve-json` Python implementation into the framework. Skills currently invoke it via `uv run --project tools/vulnogram/generate-cve-json …` — works in framework standalone (cwd=repo root), but **not** in adopting projects, where the framework lives at the `.apache-steward/apache-steward/` submodule path.

This PR introduces a `<framework>` placeholder. Adopting projects substitute it to `.apache-steward/apache-steward/`; framework-standalone substitutes to `.`. Skills now reference `<framework>/tools/vulnogram/generate-cve-json` everywhere they invoke the tool, and the path resolves in either context after the agent's standard placeholder substitution.

## Files updated

- **AGENTS.md** — new row in the placeholder-convention table for `<framework>`.
- **.claude/skills/{sync-security-issue,allocate-cve,deduplicate-security-issue}/SKILL.md** — 6 invocation sites updated.
- **tools/vulnogram/generate-cve-json/SKILL.md** — 3 invocation sites updated.
- **tools/vulnogram/generate-cve-json/README.md** — documented the dual-context invocation with the placeholder.

## Files NOT changed

Markdown links to SKILL.md (e.g. `[generate-cve-json](../../../tools/vulnogram/generate-cve-json/SKILL.md)`) — those work via the `.claude/skills/` symlink in adopters because the kernel follows the symlink to the file's actual location and resolves the relative path from there.

## Test plan

- ✅ Pre-commit passes (ruff/mypy/pytest + standard hooks).
- ✅ All 100 tests in the generate-cve-json package pass.
- [ ] Future: dogfood a sync run in airflow-s once this lands and the submodule is bumped.

## Coordination

This is the framework-side counterpart to [airflow-s/airflow-s#363 (`delete-local-cve-json-after-port`)](https://github.com/airflow-s/airflow-s/pull/363). After this PR lands, airflow-s PR 3 needs one more commit to bump the submodule pointer to this PR's merge SHA — only then do skills work end-to-end on airflow-s.

🤖 Generated with [Claude Code](https://claude.com/claude-code)