### PR TITLE
fix(secure-agent-setup): allow gpg-agent socket + key paths in sandbox

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -12,7 +12,9 @@
         "~/.cache/uv/",
         "~/.local/share/uv/",
         "~/.local/bin/",
-        "~/.config/apache-steward/"
+        "~/.config/apache-steward/",
+        "~/.gnupg/",
+        "/run/user/*/gnupg/"
       ]
     },
     "network": {

--- a/secure-agent-setup.md
+++ b/secure-agent-setup.md
@@ -187,14 +187,16 @@ below, annotated.
     "filesystem": {
       "denyRead": ["~/"],          // default-deny the entire home dir for Bash subprocesses
       "allowRead": [
-        ".",                       // the project tree (cwd)
-        "~/.gitconfig",            // git's user.name / user.email
-        "~/.config/git/",          // git's per-host config
-        "~/.config/gh/",           // gh CLI auth (token in hosts.yml)
-        "~/.cache/uv/",            // uv's HTTP cache
-        "~/.local/share/uv/",      // uv's tool venvs (prek, etc.)
-        "~/.local/bin/",           // uv-installed tool entry points
-        "~/.config/apache-steward/" // Gmail OAuth refresh token (oauth-draft tool)
+        ".",                          // the project tree (cwd)
+        "~/.gitconfig",               // git's user.name / user.email
+        "~/.config/git/",             // git's per-host config
+        "~/.config/gh/",              // gh CLI auth (token in hosts.yml)
+        "~/.cache/uv/",               // uv's HTTP cache
+        "~/.local/share/uv/",         // uv's tool venvs (prek, etc.)
+        "~/.local/bin/",              // uv-installed tool entry points
+        "~/.config/apache-steward/",  // Gmail OAuth refresh token (oauth-draft tool)
+        "~/.gnupg/",                  // gpg keys (commit signing)
+        "/run/user/*/gnupg/"          // gpg-agent socket dir (ssh-via-gpg-agent commit signing)
       ]
     },
     "network": {


### PR DESCRIPTION
The .claude/settings.json this PR ships denies all of ~/ from the Bash sandbox, with only a tiny allowRead allowlist. That set covers git/gh/uv but not commit signing — git users on Linux who sign commits via gpg-agent (either gpg-format or ssh-format with SSH_AUTH_SOCK pointing at gpg-agent's ssh-compat socket) hit:

    error: Couldn't get agent socket?
    fatal: failed to write commit object

on the first commit attempt inside the sandboxed session, because ~/.gnupg/ and /run/user/<UID>/gnupg/ are both behind the denyRead.

Adds two entries to sandbox.filesystem.allowRead:

  ~/.gnupg/             # gpg keyring + trustdb
  /run/user/*/gnupg/    # gpg-agent socket dir (the * is the UID)

Both are needed: the keyring so gpg can read the signing key material, the runtime socket so gpg-agent / its ssh-compat s can be reached. The * glob in the runtime path lets the same allowRead work for any UID — Claude Code's sandbox allowRead supports glob wildcards.

The matching documentation block in secure-agent-setup.md is updated to mirror the new entries with inline comments.

Generated-by: Claude Code (Claude Opus 4.7)