### PR TITLE
docs(agent-isolation): mention claude=claude-iso alias in README

### DIFF
--- a/tools/agent-isolation/README.md
+++ b/tools/agent-isolation/README.md
@@ -39,6 +39,10 @@ npm install -g --no-save @anthropic-ai/claude-code@2.1.117
 # Source the wrapper into your shell:
 source /path/to/airflow-steward/tools/agent-isolation/claude-iso.sh
 
+# Optional: make claude-iso the default `claude` (see secure-agent-setup.md
+# for the trade-off — the alias also strips env in non-tracker sessions):
+alias claude='claude-iso'
+
 # Launch a session with no inherited credentials:
 cd ~/code/<tracker>
 claude-iso


### PR DESCRIPTION
## Summary

- Follow-up to #15. Add the optional `alias claude='claude-iso'` line to the "Usage at a glance" block in `tools/agent-isolation/README.md`, with a one-line cross-reference to the trade-off discussion in `secure-agent-setup.md`.
- The full discussion (escape hatches, trade-off, why the alias does not recurse) lives in `secure-agent-setup.md`; this is just the visibility hook for users who land on the tool directory's README first.

## Test plan

- [x] `prek run --files tools/agent-isolation/README.md` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)