### PR TITLE
docs(sync-security-issue): codify "rollup is default; standalone comments only for RM"

### DIFF
--- a/.claude/skills/sync-security-issue/SKILL.md
+++ b/.claude/skills/sync-security-issue/SKILL.md
@@ -1297,6 +1297,27 @@ will change and *why*. Group them by category:
   Re-read that file before composing the entry body — the
   zero-extra-spacing rule is load-bearing and easy to miss.
 
+  **Standalone comments are reserved for release-manager
+  instructions only.** The rollup is the default surface for
+  every sync output — status changes, label rationale, milestone
+  moves, assignee swaps, reporter-draft notes, fix-PR links,
+  CVE-review-comment surfacing, legacy-fold entries, recap
+  pointers, blockers, *everything*. The **only** comment shapes
+  this skill posts as separate, first-class comments outside the
+  rollup are the two **release-manager-directed call-to-action**
+  comments documented further down in this Step 2b list: the
+  *Release-manager hand-off comment* (fired at the
+  `pr merged` → `fix released` transition, Step 12) and the
+  *Publication-ready notification comment* (fired at the
+  *Public advisory URL* update, Step 14). Both exist because they
+  tell the RM to *do something next* on a fresh, dated,
+  mention-bearing surface — the rollup's `<details>`-collapsed
+  entries are the wrong shape for an actionable nudge. If a
+  proposal does not fit one of those two shapes, it goes into the
+  rollup. When in doubt, default to the rollup; do not invent a
+  new standalone-comment shape because something "feels important
+  enough".
+
   **Entry shape for a sync pass.** Inside the rollup's
   `<details>` block, emit:
 


### PR DESCRIPTION
## Summary
- The `sync-security-issue` skill already lists two release-manager-directed standalone comments (hand-off at Step 12, publication-ready at Step 14) as exceptions to the rollup model, but never states the closed-list rule itself.
- Add a principle paragraph at the top of Step 2b's comment-policy section so the two RM-comment bullets read as the **exhaustive** exception list — not just two examples among others.
- No behavioural change for the existing two comments; just makes "default to rollup; standalone is RM-only" load-bearing for any future contributor or sync run.

## Test plan
- [ ] Re-read Step 2b in the rendered SKILL.md — the new paragraph slots between the rollup-comment principle and the "Entry shape for a sync pass" subsection.
- [ ] Verify the two existing RM-comment bullets (hand-off, publication-ready) still parse as the natural realisations of the new rule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)