### PR TITLE
feat(skills): 4 secure-config skills + Quick start section in secure-agent-setup.md

### DIFF
--- a/.claude/skills/setup-secure-config/SKILL.md
+++ b/.claude/skills/setup-secure-config/SKILL.md
@@ -1,0 +1,124 @@
+---
+name: setup-secure-config
+description: |
+  Guide an adopter through the first-time install of the framework's
+  secure agent setup — pinned system tools (`bubblewrap`, `socat`,
+  `claude-code`), the project-scope `.claude/settings.json` (sandbox
+  block, `permissions.deny` / `permissions.ask` / `allowedDomains`),
+  the `claude-iso` clean-env wrapper, the `sandbox-bypass-warn` and
+  `sandbox-status-line` user-scope hooks, and the user-scope
+  `~/.claude/settings.json` wiring that turns those hooks on. The
+  skill walks every step interactively, surfaces sudo /
+  shell-rc-edit / settings-file-overwrite operations for explicit
+  approval before applying, and never auto-runs anything
+  privilege-elevating or destructive.
+when_to_use: |
+  Invoke when the user says "set up the secure agent setup",
+  "first-time install of the secure config", "install the secure
+  setup in this tracker", "walk me through the secure-agent-setup
+  install", or starts working on a fresh adopter clone where
+  neither the project nor user-scope settings carry the
+  secure-config wiring yet. Also appropriate after a fresh OS
+  install / new dev machine where `~/.claude/scripts/` is empty.
+  Do **not** invoke when the secure setup is already in place — use
+  `verify-secure-config` (to confirm completeness) or
+  `update-secure-config` (to refresh against the framework's
+  latest) instead.
+---
+
+<!-- Placeholder convention (see AGENTS.md#placeholder-convention-used-in-skill-files):
+     <project-config> → adopting project's `.apache-steward/` directory
+     <tracker>        → value of `tracker_repo:` in <project-config>/project.md
+     <upstream>       → value of `upstream_repo:` in <project-config>/project.md -->
+
+# setup-secure-config
+
+This skill is the **on-ramp** for adopters who do not yet have the
+secure setup running. It is a thin walkthrough wrapper around the
+canonical install path documented in
+[`secure-agent-setup.md`](../../../secure-agent-setup.md). The
+authoritative content lives there; this skill exists so an adopter
+can say *"set up the secure agent setup"* in a fresh session and
+land in the right step-by-step flow without first reading the
+document.
+
+## Golden rules
+
+- **Do not auto-run privilege-elevating commands.** Anything that
+  needs `sudo` (apt / dnf installs, system-wide writes) is *printed*
+  for the user to copy-paste into their own terminal. The skill
+  never invokes `sudo` itself.
+- **Do not edit shell rc files without approval.** `~/.bashrc` /
+  `~/.zshrc` modifications (sourcing `claude-iso.sh`, the optional
+  `alias claude='claude-iso'`) are surfaced as the exact line to
+  add; the user pastes it themselves. The skill confirms the rc
+  file path with the user first; it does not assume.
+- **Do not overwrite an existing settings file silently.** If the
+  user already has a project `.claude/settings.json` or a
+  user-scope `~/.claude/settings.json`, the skill *diffs* the
+  desired merge against the existing file and asks for explicit
+  approval before writing. Re-installs / partial-state recoveries
+  are common — the skill must not blow away an unrelated
+  pre-existing hook or `permissions.ask` rule.
+- **Stop on the first failure.** If a step fails (manifest read
+  fails, framework path wrong, an existing file conflicts in a way
+  the user has not yet decided about), stop and report. Do not
+  push past a failure to the next step.
+
+## Up-front confirmations
+
+Before walking any install step, confirm with the user:
+
+1. **OS / distro.** macOS, Ubuntu / Debian (apt), Fedora / RHEL
+   (dnf), or Arch / NixOS / other. macOS skips bubblewrap +
+   socat (Seatbelt is built-in); Linux installs both per the
+   distro shortcut.
+2. **Framework checkout path.** The path to the user's local
+   `airflow-steward` clone. Required to read
+   `tools/agent-isolation/pinned-versions.toml`,
+   `.claude/settings.json`, and the
+   `tools/agent-isolation/*.sh` scripts. If the user does not
+   have a clone, walk them through `git clone` first.
+3. **Fresh install or re-install.** For a re-install on a partial
+   existing state, the skill must enumerate the existing wiring
+   (project settings.json, user settings.json, hooks dir,
+   shell rc) before any merge so the user knows what is being
+   preserved vs replaced.
+4. **Sync repo (optional).** Whether the user maintains a
+   private dotfile-style `~/.claude-config` repo per
+   [Syncing user-scope config across machines](../../../secure-agent-setup.md#syncing-user-scope-config-across-machines).
+   If yes, the skill installs user-scope scripts as **symlinks**
+   into `~/.claude-config/scripts/` rather than `cp`-ing into
+   `~/.claude/scripts/` — the symlink approach is what makes
+   sync push the upgrades to other machines automatically.
+
+## Walk-through
+
+Follow the canonical step list at
+[secure-agent-setup.md → Adopter setup → Via a Claude Code prompt](../../../secure-agent-setup.md#via-a-claude-code-prompt).
+Each step in that list maps 1:1 to a step in this skill. Do not
+re-write the list here — read the doc, follow it, and surface each
+sub-step with the user. The doc names are the source of truth; the
+skill is the runner.
+
+For the verification step at the end, hand off to the
+`verify-secure-config` skill rather than re-walking the checklist
+inline.
+
+## After the install lands
+
+Suggest two follow-up routines the user can wire later:
+
+- `verify-secure-config` — re-run after every Claude Code upgrade
+  or settings-file edit, to confirm denials still fire as
+  expected. The "did a denial silently turn into an allow?"
+  signal is exactly what this skill exists for.
+- `update-secure-config` — periodic check for framework
+  updates, pinned-tool upgrade candidates, and drift between the
+  installed user-scope copies and the framework's
+  source-of-truth. Recommend a per-Claude-Code-upgrade or
+  monthly cadence, whichever comes first.
+
+If the user has the `~/.claude-config` sync repo in place, also
+mention `sync-shared-config` for committing + pushing local
+modifications to the shared scripts.

--- a/.claude/skills/sync-shared-config/SKILL.md
+++ b/.claude/skills/sync-shared-config/SKILL.md
@@ -1,0 +1,157 @@
+---
+name: sync-shared-config
+description: |
+  Commit + push the user's shared Claude config to the
+  `~/.claude-config` private dotfile-style sync repo (per
+  `secure-agent-setup.md` → Syncing user-scope config across
+  machines). Inspects `~/.claude-config` for uncommitted local
+  edits and unpushed commits, drafts a commit message for any
+  unstaged changes, asks for explicit approval, then commits and
+  pushes. Pull-with-rebase is run *first* if the local checkout is
+  behind, so a push never overwrites concurrent work from another
+  machine. Never force-pushes; never rewrites already-pushed
+  history; never modifies a file outside `~/.claude-config/`.
+when_to_use: |
+  Invoke when the user says "sync my Claude config", "push my
+  ~/.claude-config", "commit shared Claude config", or after
+  modifying a file that lives in `~/.claude-config/` —
+  `~/.claude-config/scripts/*.sh`,
+  `~/.claude-config/CLAUDE.md`,
+  `~/.claude-config/commands/*`, the `sync.sh` itself, etc. Also
+  appropriate after the `update-secure-config` skill surfaces
+  drift on a script that the user keeps in `~/.claude-config/` and
+  the user wants the framework's update propagated to every
+  machine the sync repo is checked out on.
+---
+
+<!-- Placeholder convention (see AGENTS.md#placeholder-convention-used-in-skill-files):
+     <project-config> → adopting project's `.apache-steward/` directory -->
+
+# sync-shared-config
+
+This skill propagates local edits in `~/.claude-config/` to the
+sync repo's remote, so other machines can pull them. It is the
+counterpart to the periodic `git pull --rebase --autostash` that
+the framework's example `sync.sh` runs on a timer — that direction
+pulls *upstream* into the local clone; this skill pushes *local*
+modifications upstream.
+
+## Hardcoded path
+
+The sync repo lives at `~/.claude-config/`. This is the convention
+documented in
+[`secure-agent-setup.md` → Syncing user-scope config across machines](../../../secure-agent-setup.md#syncing-user-scope-config-across-machines).
+Adopters who maintain a sync repo at a different path will need to
+fork this skill — the path is intentionally not parameterised
+because the doc specifies one canonical location and forking the
+skill is cleaner than per-invocation path-passing.
+
+## Golden rules
+
+- **Never force-push.** No `--force`, no `--force-with-lease`, no
+  `--no-verify`, no rewriting commits already pushed to the
+  remote. The sync repo is the source of truth between machines;
+  rewriting its history risks losing work made on another
+  machine that has not yet been pulled here.
+- **Never modify a file outside `~/.claude-config/`.** This skill
+  is scoped strictly to that one directory. If the user's
+  intended change is to a file in `~/.claude/` directly (not via a
+  symlink into `~/.claude-config/`), surface that and stop — the
+  user wants a different action, not this skill.
+- **Pull-with-rebase first.** If `git fetch` shows the local
+  checkout is behind the remote, run `git pull --rebase --autostash`
+  *before* the commit + push. Concurrent work from another
+  machine takes precedence; the local commit lands on top.
+  This matches what the example `sync.sh` does for the periodic
+  pull.
+- **Draft the commit message; never auto-send.** For every
+  uncommitted modification, the skill drafts a one-line commit
+  subject (plus a 2–4 line body if the change merits it) and
+  shows it to the user for approval. The user replies with
+  *"go"* / *"yes"* / edits / *"split into two commits"* etc.
+  before any `git commit` runs.
+- **Use the `Generated-by:` trailer per AGENTS.md.** Commits
+  authored by an agent on the user's behalf carry
+  `Generated-by: Claude Code (Opus <version>)` at the end of
+  the body — never `Co-Authored-By:`. See
+  [AGENTS.md → Commit and PR conventions](../../../AGENTS.md#commit-and-pr-conventions)
+  for the canonical wording.
+- **Stop on lock conflict.** The example `sync.sh` uses
+  `flock --nonblock` on `~/.claude-config/.sync.lock` so two
+  concurrent sync runs do not race. If `.sync.lock` is held, do
+  not steal the lock — surface the conflict and stop. The other
+  process is likely the user's recurring sync timer.
+
+## Walk-through
+
+1. **`cd ~/.claude-config`** and verify it is a git working tree
+   pointing at a private remote. If the directory does not exist
+   or is not a git repo, surface that and stop — the user has
+   not yet set up a sync repo per the doc, and the right next
+   action is for them to follow
+   [Setting up a fresh host](../../../secure-agent-setup.md#setting-up-a-fresh-host).
+
+2. **`git fetch origin`** to learn the remote's current state.
+   Report:
+   - commits behind upstream (will be pulled in step 4),
+   - commits ahead of upstream (already-committed local work
+     that has not yet been pushed),
+   - uncommitted working-tree modifications (`git status --short`),
+   - untracked files the user may want to either add or
+     `.gitignore`.
+
+3. **Decide the action.** The four reachable states:
+   - **In sync, nothing to do.** No uncommitted changes, no
+     unpushed commits, not behind. Report and stop.
+   - **Push-only.** Already-committed local work needs to land
+     on the remote, but no behind / no uncommitted edits.
+     Pull-with-rebase is unnecessary; go straight to push.
+   - **Commit-then-push.** Uncommitted edits exist. Walk each
+     modified file with the user (diff + draft commit message
+     + approval), commit each batch the user accepts, then
+     push.
+   - **Pull-then-commit-then-push.** Uncommitted edits *and*
+     behind upstream. Run `git pull --rebase --autostash`
+     first; if rebase succeeds cleanly, proceed to the
+     commit-then-push flow. If rebase conflicts, stop and
+     surface — conflicts in `~/.claude-config/` are the user's
+     to resolve, not the skill's.
+
+4. **Pull-with-rebase (when applicable).** Run
+   `git pull --rebase --autostash`. Report what changed
+   (commits pulled, files touched).
+
+5. **Stage + commit (when applicable).** For each modification
+   the user approves:
+   - `git add <file>` for the specific file (never `git add -A`
+     or `git add .` — the sync repo is the user's most personal
+     directory and `git add -A` risks staging an editor swap
+     file or a `.DS_Store` you forgot to gitignore),
+   - `git commit -m '<subject>' -m '<body>'` with the
+     approved message. Always include the
+     `Generated-by: Claude Code (Opus <version>)` trailer in
+     the body per AGENTS.md.
+
+6. **Push.** `git push` to the upstream branch. No `--force`.
+   If push is rejected (non-fast-forward) it means another
+   machine pushed concurrently after our `git fetch` in step 2;
+   stop, surface, and recommend re-invoking the skill (which
+   will repeat the fetch + pull-with-rebase). Do not retry
+   in-flight.
+
+## After the push lands
+
+Report:
+- which commit SHA is now on the remote,
+- a one-line summary of what was pushed (so the user can
+  confirm in their terminal scrollback),
+- whether other-machine pulls are needed (the timer-driven
+  `sync.sh` on the user's other hosts will pick the change up
+  on its own next run; the skill does not need to nag about
+  this).
+
+If the modifications touched a file under
+`~/.claude-config/scripts/` that is symlinked from
+`~/.claude/scripts/`, also note that the change is *immediately*
+live on this host — the symlink resolves to the just-modified
+file. No re-`cp` needed.

--- a/.claude/skills/update-secure-config/SKILL.md
+++ b/.claude/skills/update-secure-config/SKILL.md
@@ -1,0 +1,129 @@
+---
+name: update-secure-config
+description: |
+  Surface drift between the user's installed secure agent setup and
+  the framework's latest. Reports framework-checkout updates
+  (`git pull` on `airflow-steward`), pinned-tool upgrade candidates
+  (`bubblewrap`, `socat`, `claude-code` newer than the manifest's
+  7-day-cooldown floor), drift between the user-scope script
+  copies (`~/.claude/scripts/`, `~/.claude/agent-isolation/`) and
+  the framework's source-of-truth, and any newly-allowed denial
+  command that should still be denied. Read-only — surfaces
+  candidates and diffs, never auto-applies. The user decides what
+  to update.
+when_to_use: |
+  Invoke when the user says "update secure setup", "check for
+  secure-config drift", "is my setup at the framework's latest?",
+  "should I bump the pinned tools?", or after a Claude Code
+  upgrade / a substantial tracker-repo merge / when a previously
+  blocked Bash call now appears to succeed. Recommended cadence
+  per the doc: once per Claude Code upgrade or once a month,
+  whichever comes first. Cheap to re-run; never destructive.
+---
+
+<!-- Placeholder convention (see AGENTS.md#placeholder-convention-used-in-skill-files):
+     <project-config> → adopting project's `.apache-steward/` directory -->
+
+# update-secure-config
+
+This skill is the **drift report** for an already-installed secure
+setup. It walks the canonical update-check at
+[`secure-agent-setup.md` → Keeping the setup updated → Via a Claude Code prompt](../../../secure-agent-setup.md#via-a-claude-code-prompt-2)
+and surfaces what is older / newer / has drifted, without applying
+any change.
+
+## Golden rules
+
+- **Read-only.** This skill does not bump the manifest, does not
+  edit `~/.claude/scripts/`, does not `git pull`, does not
+  `npm install -g`, does not modify the user's shell rc. It
+  reports drift and points at the doc / the install skill;
+  the user runs the actual updates by hand or by re-invoking
+  `setup-secure-config` for the touched piece.
+- **Surface upstream changelog links.** For every pinned-tool
+  upgrade candidate, include the upstream changelog / release-
+  notes URL so the user can read the diff before deciding. A
+  bump is not a foregone conclusion — the framework's policy is
+  "wait for a feature you actually want or a security fix",
+  not "always run latest".
+- **Distinguish framework changes from local drift.** "The
+  framework's `tools/agent-isolation/claude-iso.sh` has new
+  comments" is a *framework update* (resolved by `git pull`).
+  "The user's `~/.claude/agent-isolation/claude-iso.sh` no longer
+  matches the framework's copy" is *local drift* (resolved by
+  re-`cp` or, for sync-repo users, by syncing the framework
+  changes into `~/.claude-config/scripts/`). Report each
+  separately.
+- **Re-verify after surfacing the drift.** Run the same denial
+  checks `verify-secure-config` runs (one Bash invocation per
+  command, not chained), so a regression that turned a deny into
+  an allow shows up as part of the update report. A *passing*
+  verification at the end of an update report is the signal that
+  no surprise allow was introduced by something that already
+  drifted.
+
+## What to check
+
+The canonical step list is in
+[secure-agent-setup.md → Keeping the setup updated → Via a Claude Code prompt](../../../secure-agent-setup.md#via-a-claude-code-prompt-2).
+Walk each:
+
+1. **Framework checkout.** `cd` into the user's `airflow-steward`
+   clone, `git fetch origin main`, report what changed under
+   `tools/agent-isolation/`, `.claude/settings.json`, and
+   `secure-agent-setup.md` since the local checkout was last
+   updated. Print the `git pull --ff-only` command for the user
+   to run; do not run it.
+2. **Pinned upstream tools.** Run
+   `tools/agent-isolation/check-tool-updates.sh` and surface every
+   upgrade candidate (`bubblewrap`, `socat`, `claude-code`) that
+   has aged past the framework's 7-day cooldown. Include the
+   upstream changelog link for each. Do not bump the manifest;
+   that is a separate
+   [Bumping a pinned version](../../../secure-agent-setup.md#bumping-a-pinned-version)
+   PR by hand.
+3. **User-scope script-copy drift.** For every user-scope file
+   the doc tells the adopter to install
+   (`~/.claude/scripts/sandbox-bypass-warn.sh`,
+   `~/.claude/scripts/sandbox-status-line.sh` or whatever the
+   user's actual statusLine command resolves to,
+   `~/.claude/agent-isolation/claude-iso.sh` for the global
+   wrapper install), `diff` the user copy against the framework's
+   source-of-truth in `tools/agent-isolation/`. Report any drift
+   as a unified diff; do not re-`cp`.
+4. **Settings.json shape drift.** Diff the user's project
+   `.claude/settings.json` against the framework's dogfooded
+   one — the framework occasionally adds new `denyRead` paths
+   (a credential type the team newly cares about), new
+   `allowedDomains` entries, new `permissions.deny` patterns
+   for newly-discovered exfiltration paths. Report new entries
+   the user does not have; do not auto-merge.
+5. **Re-verify.** Run the three denial commands as standalone
+   Bash invocations (not chained — see
+   [verify-secure-config](../verify-secure-config/SKILL.md) for
+   why). Report any newly-allowed call as a regression that
+   warrants attention.
+
+## After the report
+
+If everything is in sync and verification still passes, say so
+explicitly and stop.
+
+If something is out-of-date or has drifted, name the concrete
+follow-up:
+
+- Framework checkout behind → user runs `git pull --ff-only` in
+  their `airflow-steward` clone.
+- Pinned-tool upgrade candidate worth adopting → manifest bump PR
+  per [Bumping a pinned version](../../../secure-agent-setup.md#bumping-a-pinned-version).
+- User-scope script drift → re-`cp` from the framework checkout,
+  or — if the script lives in `~/.claude-config/` and the user
+  wants the change propagated to other machines — invoke
+  `sync-shared-config` to commit + push.
+- Settings.json shape drift → the user merges the new
+  framework block into their tracker's `.claude/settings.json`
+  by hand (the section to copy from is documented in
+  [The framework's own `.claude/settings.json`](../../../secure-agent-setup.md#the-frameworks-own-claudesettingsjson)).
+- A previously-blocked denial command now succeeds → stop and
+  surface as a regression, not a routine update; the user
+  should investigate before bumping anything.

--- a/.claude/skills/verify-secure-config/SKILL.md
+++ b/.claude/skills/verify-secure-config/SKILL.md
@@ -1,0 +1,121 @@
+---
+name: verify-secure-config
+description: |
+  Walk the verification checklist documented in
+  `secure-agent-setup.md` and report ✓ done / ✗ missing / ⚠ partial
+  for each piece of the secure agent setup — project + user-scope
+  `settings.json` wiring, hook scripts present + executable,
+  `claude-iso` sourced, pinned tool versions installed at the
+  pinned versions, status-line state in this session, and the three
+  denial commands that prove the sandbox + permissions + clean-env
+  layers are actually firing. Read-only — never modifies anything.
+when_to_use: |
+  Invoke when the user says "verify my secure setup", "is my
+  secure config done?", "check that the secure agent setup is
+  installed", "did setup work?", or after running
+  `setup-secure-config` to confirm the install landed completely.
+  Also appropriate as a routine — after every Claude Code upgrade,
+  after every project / user-scope `settings.json` edit, and any
+  time a previously-blocked Bash call appears to have succeeded
+  (the "did a denial silently turn into an allow?" canary). Cheap
+  to re-run; never destructive.
+---
+
+<!-- Placeholder convention (see AGENTS.md#placeholder-convention-used-in-skill-files):
+     <project-config> → adopting project's `.apache-steward/` directory -->
+
+# verify-secure-config
+
+This skill is the **assertion** layer over the secure setup. It
+runs the checklist documented in
+[`secure-agent-setup.md` → Verification → Via a Claude Code prompt](../../../secure-agent-setup.md#via-a-claude-code-prompt-1)
+and reports each check's status to the user with concrete evidence
+(file paths, command output, version strings).
+
+## Golden rules
+
+- **Read-only.** This skill does not edit any file, copy any
+  script, install any package, or modify any settings. If a check
+  surfaces a missing or misconfigured piece, surface the gap and
+  point at the install path (`setup-secure-config` for a missing
+  install, `update-secure-config` for drift); do not auto-fix.
+- **Report every check, even on early failure.** Do not stop at
+  the first ✗ — the value of the report is in the full picture.
+  If check 3 fails, continue to checks 4 / 5 / 6 / 7 anyway and
+  surface every gap so the user can address them in one round.
+- **Distinguish ✗ (missing) from ⚠ (variant or drift).** A missing
+  hook script is ✗. A user installing the doc-allowed "richer
+  custom statusLine" path that embeds the framework's
+  sandbox-prefix logic into a larger script is ⚠ (the by-name
+  helper is not present, but the equivalent functionality is). Use
+  ⚠ for any *intentional* variation from the doc default; ✗ only
+  for genuine gaps.
+- **Surface evidence.** Each check's report line names the file
+  path, the version string, the command output, the
+  `sandbox.enabled` value — never just "✓" or "✗" alone.
+
+## The 7 checks
+
+The canonical list lives in
+[secure-agent-setup.md → Verification → Via a Claude Code prompt](../../../secure-agent-setup.md#via-a-claude-code-prompt-1).
+Walk each in order:
+
+1. Project `.claude/settings.json` shape — `sandbox.enabled: true`,
+   `permissions.deny`, `permissions.ask`, `sandbox.network.allowedDomains`.
+2. User-scope `~/.claude/settings.json` wiring — `PreToolUse`
+   `Bash` matcher → `sandbox-bypass-warn.sh`, `statusLine` →
+   `sandbox-status-line.sh` (or a custom statusline script that
+   embeds the framework's prefix logic — that is the doc-allowed
+   variant; report ⚠).
+3. Hook scripts present + executable — both
+   `~/.claude/scripts/sandbox-bypass-warn.sh` and
+   `~/.claude/scripts/sandbox-status-line.sh`. Symlinks into a
+   `~/.claude-config` sync repo are equivalent to direct files;
+   resolve the link target and check that.
+4. `claude-iso` shell function defined + sourced. The grep
+   pattern is the source line in `~/.bashrc` / `~/.zshrc`. Check
+   whether `alias claude='claude-iso'` is set; report it as a
+   note (it is optional per the doc).
+5. Pinned tool versions installed match
+   `tools/agent-isolation/pinned-versions.toml`. On macOS,
+   skip `bubblewrap` and `socat` (Seatbelt is built-in); only
+   check `claude-code`. Report drift in either direction —
+   newer-than-pin or older-than-pin — as ⚠.
+6. Status-line prefix in this session is `[sandbox]`, not
+   `[NO SANDBOX]`. Resolve the precedence:
+   `<cwd>/.claude/settings.local.json` →
+   `<cwd>/.claude/settings.json` →
+   `~/.claude/settings.local.json` →
+   `~/.claude/settings.json`; report the `sandbox.enabled` value
+   from each.
+7. Denial commands actually deny. **Important: run each as a
+   standalone Bash invocation**, not as a chained pipeline —
+   `permissions.deny` patterns match only on the *first* command
+   of a Bash tool call, so a chained `curl` later in the
+   pipeline can slip past on macOS (where there is no socat
+   network proxy as a backstop). The three commands are:
+   - `cat ~/.aws/credentials` — should deny with
+     `Operation not permitted` (Seatbelt) or
+     `No such file or directory` (bubblewrap).
+   - `echo $AWS_ACCESS_KEY_ID` — should print empty (claude-iso
+     stripped the env).
+   - `curl https://example.com` — should deny at the
+     permission-prompt layer
+     (`Permission to use Bash with command curl … has been denied`).
+
+## After the report
+
+If every check is ✓, say so explicitly and stop — no further
+suggestion needed.
+
+If anything is ✗ or ⚠, suggest the appropriate follow-up skill
+without invoking it:
+
+- ✗ on checks 1 / 2 / 3 / 4 → `setup-secure-config` (missing
+  install pieces).
+- ⚠ on check 5 (pinned-version drift) or any user-scope script
+  copy that is older than the framework's source-of-truth →
+  `update-secure-config`.
+- The user-scope script copies live under `~/.claude-config/`
+  for users who maintain that sync repo; uncommitted local edits
+  there → `sync-shared-config`.

--- a/secure-agent-setup.md
+++ b/secure-agent-setup.md
@@ -3,6 +3,9 @@
 **Table of Contents**  *generated with [DocToc](https://github.com/thlorenz/doctoc)*
 
 - [Secure agent setup](#secure-agent-setup)
+  - [Quick start](#quick-start)
+    - [Agent-guided (recommended)](#agent-guided-recommended)
+    - [Manual (if you do not want the agent-guided path)](#manual-if-you-do-not-want-the-agent-guided-path)
   - [Required tools (pinned versions)](#required-tools-pinned-versions)
     - [Install commands](#install-commands)
     - [Distro-specific shortcut — Linux Mint 22.x / Ubuntu 24.04 Noble](#distro-specific-shortcut--linux-mint-22x--ubuntu-2404-noble)
@@ -66,6 +69,92 @@ attack hidden in an inbound report — exfiltrate cloud credentials,
 SSH keys, GitHub tokens, the Gmail OAuth refresh token, and similar
 host-level secrets. This setup does not eliminate that risk; it
 reduces it to the project tree.
+
+## Quick start
+
+If you just want the secure setup running, follow this short
+path. The rest of the document below expands every bullet here
+with the *why* and the trade-offs; you can return to it whenever
+you want the full picture. For the rationale and mechanism behind
+each layer, see
+[`secure-agent-internals.md`](secure-agent-internals.md).
+
+### Agent-guided (recommended)
+
+If you have Claude Code installed and a clone of `airflow-steward`
+on the host, the framework ships four skills that walk every
+step interactively. Each surfaces sudo / shell-rc / settings-file
+changes for explicit approval before applying — nothing
+privilege-elevating runs without you saying so.
+
+```text
+1. Open Claude Code in your tracker repo (or any directory).
+2. Run /setup-secure-config — guided first-time install.
+3. Run /verify-secure-config — confirms ✓/✗/⚠ for every piece.
+4. Run /update-secure-config periodically (per Claude Code
+   upgrade or once a month) to surface drift + upgrade
+   candidates. Read-only — surfaces, never auto-applies.
+5. Optional: if you maintain a private dotfile-style sync repo
+   per
+   [Syncing user-scope config across machines](#syncing-user-scope-config-across-machines),
+   run /sync-shared-config to push local edits to the remote
+   so other machines pick them up.
+```
+
+The skills are at
+[`.claude/skills/setup-secure-config/`](.claude/skills/setup-secure-config/SKILL.md),
+[`.claude/skills/verify-secure-config/`](.claude/skills/verify-secure-config/SKILL.md),
+[`.claude/skills/update-secure-config/`](.claude/skills/update-secure-config/SKILL.md),
+[`.claude/skills/sync-shared-config/`](.claude/skills/sync-shared-config/SKILL.md).
+Each skill references back into the canonical sections of this
+document rather than duplicating them, so anything the skill walks
+you through has a longer-form section here you can read for
+context.
+
+### Manual (if you do not want the agent-guided path)
+
+The same flow, condensed to commands you run yourself:
+
+```bash
+# 1. Pinned system tools (Linux only — macOS uses built-in
+#    Seatbelt). Exact distro commands and version pins are in
+#    `tools/agent-isolation/pinned-versions.toml`; canonical
+#    section: "Required tools (pinned versions)" below.
+sudo apt-get install --no-install-recommends \
+    bubblewrap=0.11.1-* socat=1.8.1.1-*
+npm install -g --no-save @anthropic-ai/claude-code@2.1.117
+
+# 2. Project-scope `.claude/settings.json`. Copy the framework's
+#    sandbox / permissions.deny / permissions.ask / allowedDomains
+#    blocks into your tracker repo's `.claude/settings.json`.
+#    Section: "The framework's own .claude/settings.json" below.
+
+# 3. The clean-env wrapper. Source `claude-iso.sh` from your rc
+#    file, optionally alias `claude=claude-iso`. Section: "The
+#    clean-env wrapper" below.
+
+# 4. User-scope hooks. Copy `sandbox-bypass-warn.sh` and
+#    `sandbox-status-line.sh` into `~/.claude/scripts/`, wire
+#    them into `~/.claude/settings.json` under `PreToolUse` and
+#    `statusLine`. Sections: "Sandbox-bypass visibility hook"
+#    and "Sandbox-state status line" below.
+
+# 5. Verify the install actually denies what it claims to —
+#    section "Verification" below has both a three-line Bash
+#    check and the agent-guided form.
+```
+
+Both paths converge on the same end state: a sandboxed Claude Code
+session that cannot read `~/.aws/`, cannot exfiltrate via `curl`,
+runs Bash subprocesses inside bubblewrap (Linux) or Seatbelt
+(macOS), and visibly flags `sandbox` / `NO SANDBOX` / bypass
+attempts in the terminal so an unprotected session cannot drift
+unnoticed.
+
+The rest of this document is the long-form reference behind each
+of those steps. If you used the agent-guided path, you can read
+sections on demand when a skill points you at one for more
+detail.
 
 ## Required tools (pinned versions)
 


### PR DESCRIPTION
## Summary

- Four new skills wrap the install / verify / update / sync flows already documented in `secure-agent-setup.md`. Each skill is a thin orchestration layer over the canonical content — the doc stays the single source of truth, the skill is the trigger that lands a user in the right walk-through.
- New `## Quick start` section at the top of `secure-agent-setup.md` (right after the audience-and-why intro, before `## Required tools`) gives an agent-guided 5-line path (the four skills, in order) and a manual 5-step shell snippet, both pointing at the canonical sections below for each step.

| Skill | Triggers | What it does |
|---|---|---|
| `setup-secure-config` | "set up the secure agent setup", "first-time install" | Walks Adopter-setup prompt. Surfaces sudo / shell-rc / settings-file changes for approval. Stops on first failure. |
| `verify-secure-config` | "verify my secure setup", "is my secure config done?" | Read-only checklist. ✓/✗/⚠ with evidence. Calls out macOS chained-curl gap. |
| `update-secure-config` | "update secure setup", "check for drift" | Read-only drift report. Surfaces framework updates, pinned-tool upgrades, user-scope script drift, settings.json shape drift. |
| `sync-shared-config` | "sync my Claude config", "push my ~/.claude-config" | Pushes local edits in `~/.claude-config/` (hardcoded path). Pull-with-rebase first. Drafts commit messages for approval. Never force-pushes. |

## Test plan

- [ ] `prek run --files <changed files>` clean (markdownlint, typos, placeholder linter, doctoc TOC regen).
- [ ] Each `SKILL.md` frontmatter parses (`name` / `description` / `when_to_use` block scalars).
- [ ] Cross-references resolve: skill ↔ skill (`../verify-secure-config/SKILL.md`, etc.), skill → setup-doc anchors (`Adopter setup`, `Verification`, `Keeping the setup updated`, `Setting up a fresh host`).
- [ ] Quick start's section links resolve (`#syncing-user-scope-config-across-machines`).
- [ ] Quick start lands above `## Required tools` and below the audience intro (no theory between intro and quick start).