### PR TITLE
feat(agent-isolation): per-tool cooldown_days + bump claude-code to 2.1.123 (1-day cooldown)

### DIFF
--- a/secure-agent-setup.md
+++ b/secure-agent-setup.md
@@ -122,7 +122,7 @@ The same flow, condensed to commands you run yourself:
 #    section: "Required tools (pinned versions)" below.
 sudo apt-get install --no-install-recommends \
     bubblewrap=0.11.1-* socat=1.8.1.1-*
-npm install -g --no-save @anthropic-ai/claude-code@2.1.117
+npm install -g --no-save @anthropic-ai/claude-code@2.1.123
 
 # 2. Project-scope `.claude/settings.json`. Copy the framework's
 #    sandbox / permissions.deny / permissions.ask / allowedDomains
@@ -159,23 +159,32 @@ detail.
 ## Required tools (pinned versions)
 
 Every system-level tool the secure setup depends on is pinned with a
-**7-day cooldown** before the framework adopts a new upstream
+**per-tool cooldown** before the framework adopts a new upstream
 release — same convention as the `[tool.uv] exclude-newer = "7 days"`
 setting in [`pyproject.toml`](pyproject.toml) and the weekly Dependabot
 updates in [`.github/dependabot.yml`](.github/dependabot.yml).
+Default cooldown is 7 days; individual tools can override via
+`cooldown_days = N` in the manifest when their release stream
+warrants it. `claude-code` is the canonical override at 1 day —
+its release cadence is high enough that a longer floor would
+strand the framework many versions behind upstream, and any
+regression that affects the secure setup's permission-rule
+semantics or sandbox flags is caught broadly within hours of
+release.
 
 The current pins live in machine-readable form in
 [`tools/agent-isolation/pinned-versions.toml`](tools/agent-isolation/pinned-versions.toml):
 
-| Tool | Pinned version | Released | Purpose |
-|---|---|---|---|
-| `bubblewrap` | 0.11.1 | 2026-03-21 | Linux user-namespace sandbox (filesystem layer). Required on Linux; macOS uses Seatbelt instead. |
-| `socat` | 1.8.1.1 | 2026-03-13 | TCP relay for the sandbox network allowlist. Linux only. |
-| `claude-code` | 2.1.117 | 2026-04-22 | Agent runtime. Pin separately from any system claude install so behavioural changes don't drift the framework's effective security posture without review. |
+| Tool | Pinned version | Released | Cooldown | Purpose |
+|---|---|---|---|---|
+| `bubblewrap` | 0.11.1 | 2026-03-21 | 7d (default) | Linux user-namespace sandbox (filesystem layer). Required on Linux; macOS uses Seatbelt instead. |
+| `socat` | 1.8.1.1 | 2026-03-13 | 7d (default) | TCP relay for the sandbox network allowlist. Linux only. |
+| `claude-code` | 2.1.123 | 2026-04-29 | 1d (override) | Agent runtime. Pin separately from any system claude install so behavioural changes don't drift the framework's effective security posture without review. |
 
 The pin date floor (`pinned_at` in the manifest) is the day the
 manifest was last touched; it is the framework's promise that every
-version above had at least 7 days to settle before being adopted.
+version above had at least its tool's cooldown to settle before
+being adopted.
 
 ### Install commands
 
@@ -209,7 +218,7 @@ version, no pin enforced — Homebrew rolls forward, so the
 
 ```bash
 # npm distribution (the only stable channel today)
-npm install -g --no-save @anthropic-ai/claude-code@2.1.117
+npm install -g --no-save @anthropic-ai/claude-code@2.1.123
 ```
 
 ### Distro-specific shortcut — Linux Mint 22.x / Ubuntu 24.04 Noble
@@ -261,8 +270,9 @@ follows the same `*.local` convention as Claude Code's
 
 ### Bumping a pinned version
 
-When an upstream release has aged past the 7-day cooldown and you
-want to adopt it:
+When an upstream release has aged past the tool's cooldown (7-day
+default, 1-day for `claude-code` per its manifest override) and
+you want to adopt it:
 
 1. Run `tools/agent-isolation/check-tool-updates.sh`. It compares the
    pinned versions to upstream and prints an "upgrade candidate" line

--- a/tools/agent-isolation/check-tool-updates.sh
+++ b/tools/agent-isolation/check-tool-updates.sh
@@ -20,7 +20,13 @@
 #
 # Read pinned-versions.toml and report on upstream releases that
 # (a) are newer than the pinned versions, AND (b) have themselves
-# aged past the 7-day cooldown the pin convention asks for.
+# aged past each tool's `cooldown_days` (default 7).
+#
+# Cooldown is per-tool — the manifest's `[tools.<name>]` table can
+# carry a `cooldown_days = N` override of the 7-day default. The
+# motivating case is `claude-code`, whose release cadence is high
+# enough that 7 days of settle-time is excessive; it overrides to
+# 1.
 #
 # Output is informational only — the script never installs anything,
 # never edits pinned-versions.toml, never opens a PR. It just
@@ -44,32 +50,36 @@ if [[ ! -r "$MANIFEST" ]]; then
   exit 1
 fi
 
-# Cooldown window. Mirrors `[tool.uv] exclude-newer = "7 days"` in
-# the root pyproject.toml and the dependabot weekly cooldown of 7
-# days in `.github/dependabot.yml`. Tools released within this
-# window are NOT proposed as upgrade candidates yet.
-COOLDOWN_DAYS=7
+# Default cooldown window. Mirrors `[tool.uv] exclude-newer = "7 days"`
+# in the root pyproject.toml and the dependabot weekly cooldown of 7
+# days in `.github/dependabot.yml`. Per-tool overrides via the
+# manifest's `cooldown_days` field take precedence — see
+# `pinned-versions.toml` for the convention. Releases within a tool's
+# cooldown window are NOT proposed as upgrade candidates yet.
+DEFAULT_COOLDOWN_DAYS=7
 
 now_epoch=$(date -u +%s)
-cooldown_cutoff_epoch=$(( now_epoch - COOLDOWN_DAYS * 86400 ))
 
 # ---------------------------------------------------------------------
-# Per-tool upstream lookup. Each function prints the latest aged-past-
-# cooldown release in the form "version<TAB>YYYY-MM-DD". A non-zero
-# exit code means the upstream lookup failed (rate limit, network
-# error, etc.) — the caller continues with other tools.
+# Per-tool upstream lookup. Each function takes a per-tool cooldown
+# window in days as its second argument and prints the latest
+# aged-past-cooldown release in the form "version<TAB>YYYY-MM-DD". A
+# non-zero exit code means the upstream lookup failed (rate limit,
+# network error, etc.) — the caller continues with other tools.
 # ---------------------------------------------------------------------
 
 # GitHub releases lookup (used by bubblewrap and claude-code).
 # Picks the most recent release whose `published_at` is at least
-# `COOLDOWN_DAYS` old.
+# `cooldown_days` old.
 gh_latest_aged() {
   local repo="$1"
+  local cooldown_days="$2"
+  local cutoff=$(( now_epoch - cooldown_days * 86400 ))
   curl -fsSL "https://api.github.com/repos/${repo}/releases?per_page=20" \
     | python3 -c '
 import json, sys
-from datetime import datetime, timezone
-cutoff = '"$cooldown_cutoff_epoch"'
+from datetime import datetime
+cutoff = '"$cutoff"'
 for r in json.load(sys.stdin):
     pub = datetime.fromisoformat(r["published_at"].replace("Z", "+00:00"))
     if pub.timestamp() <= cutoff:
@@ -81,8 +91,10 @@ for r in json.load(sys.stdin):
 }
 
 # socat upstream is a static HTML index; scrape the highest version
-# tarball whose mtime is older than COOLDOWN_DAYS.
+# tarball whose mtime is older than `cooldown_days`.
 socat_latest_aged() {
+  local cooldown_days="$1"
+  local cutoff=$(( now_epoch - cooldown_days * 86400 ))
   # The download index has a fairly stable shape — `socat-X.Y.Z.W.tar.gz`
   # rows in a directory listing. Pick the highest version whose
   # `Last-Modified` (per HEAD) is older than the cutoff.
@@ -99,7 +111,7 @@ socat_latest_aged() {
       continue
     fi
     mtime_epoch=$(date -d "$mtime" +%s 2>/dev/null) || continue
-    if (( mtime_epoch <= cooldown_cutoff_epoch )); then
+    if (( mtime_epoch <= cutoff )); then
       printf '%s\t%s\n' "$ver" "$(date -u -d "$mtime" +%Y-%m-%d)"
       return 0
     fi
@@ -113,12 +125,14 @@ socat_latest_aged() {
 # ---------------------------------------------------------------------
 
 read_pinned() {
-  python3 - "$MANIFEST" <<'PY'
+  python3 - "$MANIFEST" "$DEFAULT_COOLDOWN_DAYS" <<'PY'
 import sys, tomllib
+default_cooldown = int(sys.argv[2])
 with open(sys.argv[1], "rb") as f:
     cfg = tomllib.load(f)
 for name, t in cfg.get("tools", {}).items():
-    print(f"{name}\t{t['version']}\t{t['released']}")
+    cooldown = int(t.get("cooldown_days", default_cooldown))
+    print(f"{name}\t{t['version']}\t{t['released']}\t{cooldown}")
 PY
 }
 
@@ -131,16 +145,16 @@ printf '%-14s %-10s %-12s %-10s %-12s %s\n' \
 printf '%-14s %-10s %-12s %-10s %-12s %s\n' \
   ------ ------ ------- -------- --------- ------
 
-while IFS=$'\t' read -r name pinned_ver pinned_date; do
+while IFS=$'\t' read -r name pinned_ver pinned_date cooldown_days; do
   case "$name" in
     bubblewrap)
-      latest_line="$(gh_latest_aged containers/bubblewrap || true)"
+      latest_line="$(gh_latest_aged containers/bubblewrap "$cooldown_days" || true)"
       ;;
     claude-code)
-      latest_line="$(gh_latest_aged anthropics/claude-code || true)"
+      latest_line="$(gh_latest_aged anthropics/claude-code "$cooldown_days" || true)"
       ;;
     socat)
-      latest_line="$(socat_latest_aged || true)"
+      latest_line="$(socat_latest_aged "$cooldown_days" || true)"
       ;;
     *)
       latest_line=""
@@ -165,7 +179,7 @@ while IFS=$'\t' read -r name pinned_ver pinned_date; do
     # well-formed dotted-version strings, so plain `<` does the
     # right thing for ordered output. The maintainer is the actual
     # decision-maker; the script just surfaces candidates.
-    status="upgrade candidate (aged past ${COOLDOWN_DAYS}-day cooldown)"
+    status="upgrade candidate (aged past ${cooldown_days}-day cooldown)"
   fi
 
   printf '%-14s %-10s %-12s %-10s %-12s %s\n' \
@@ -183,7 +197,9 @@ To bump a pinned tool:
      distro package version has shifted.
   4. Open the bump as its own PR with a short rationale.
 
-The 7-day cooldown above is the floor for *eligibility*, not a
-mandate to upgrade — the framework maintainer is welcome to defer
-a bump indefinitely if the new version doesn't add value.
+Each tool's cooldown is the floor for *eligibility*, not a mandate
+to upgrade — the framework maintainer is welcome to defer a bump
+indefinitely if the new version doesn't add value. The default
+cooldown is 7 days; tools can override via `cooldown_days = N` in
+the manifest (the canonical example is `claude-code`, which uses 1).
 EOF

--- a/tools/agent-isolation/pinned-versions.toml
+++ b/tools/agent-isolation/pinned-versions.toml
@@ -18,30 +18,41 @@
 # pinned-versions.toml
 #
 # Pinned upstream versions of the host-system tools the secure agent
-# setup depends on. The pin shape mirrors the framework's other 7-day
+# setup depends on. The pin shape mirrors the framework's broader
 # cooldown convention (see `[tool.uv] exclude-newer = "7 days"` in
-# the root pyproject.toml and the per-package override for `uv`):
-# every entry below names a version that was released **at least
-# 7 days ago at the time the entry was last touched**, so an upstream
-# retag / withdrawal / fix-forward has had a week to settle before
-# adopters install it.
+# the root pyproject.toml and the dependabot weekly cooldown of 7
+# days in `.github/dependabot.yml`): every entry below names a
+# version that was released **at least `cooldown_days` ago at the
+# time the entry was last touched**, so an upstream retag /
+# withdrawal / fix-forward has had time to settle before adopters
+# install it.
+#
+# Cooldown is **per-tool** with a 7-day default. A tool with an
+# unusually well-watched release stream — `claude-code` is the
+# canonical example, since its release cadence is high and any
+# regression that affects the framework's permission-rule
+# semantics or sandbox flags is caught broadly within hours of
+# release — can override the default via `cooldown_days = N` in
+# its `[tools.<name>]` table. Lowering the cooldown trades
+# settle-time for currency; raise it back if a tool starts
+# shipping pre-release fix-forwards routinely.
 #
 # Adopters consume this file by:
 #   1. Reading the versions in `secure-agent-setup.md` and installing
 #      them on the host (the doc has the install commands per distro).
 #   2. Running `tools/agent-isolation/check-tool-updates.sh` weekly
 #      (or via `/schedule`) to surface upstream releases that have
-#      themselves aged past the 7-day cooldown — those are candidates
-#      for the next intentional bump.
+#      themselves aged past each tool's cooldown — those are
+#      candidates for the next intentional bump.
 #
 # To bump a tool: only when the new upstream version was released at
-# least 7 days ago, AND the framework maintainer wants to upgrade.
-# Update the `version` and `released` fields together, then bump the
-# `pinned_at` field below to today.
+# least the tool's `cooldown_days` ago, AND the framework maintainer
+# wants to upgrade. Update the `version` and `released` fields
+# together, then bump the `pinned_at` field below to today.
 
 # When this file was last touched. The check script uses this as the
 # minimum age the entries below claim to satisfy.
-pinned_at = "2026-04-29"
+pinned_at = "2026-05-01"
 
 [tools.bubblewrap]
 version = "0.11.1"
@@ -80,8 +91,18 @@ install.dnf = "dnf install socat-1.8.1.1"
 install.from_source = "http://www.dest-unreach.org/socat/download/socat-1.8.1.1.tar.gz"
 
 [tools.claude-code]
-version = "2.1.117"
-released = "2026-04-22"
+version = "2.1.123"
+released = "2026-04-29"
+# Override the framework-wide 7-day default. Claude Code releases
+# cadence is high (multiple releases per week) and any regression
+# that affects the framework's permission-rule semantics, sandbox
+# flags, or prompt-injection mitigations is caught broadly within
+# hours of release — the wider Claude Code user base spans many
+# more workloads than this framework's secure setup, and a 1-day
+# floor is a reasonable balance between currency and settle-time
+# for this specific tool. Raise back to 7 if Claude Code starts
+# shipping pre-release fix-forwards routinely.
+cooldown_days = 1
 purpose = """
 The agent runtime itself. Pinning matters because the
 permission-rule semantics, the sandbox flags, and the
@@ -97,5 +118,5 @@ upstream_releases = "https://api.github.com/repos/anthropics/claude-code/release
 # Claude Code is distributed via npm; use `--no-save` so the global
 # install doesn't drift the local lockfile of any project the user
 # installs from.
-install.npm = "npm install -g --no-save @anthropic-ai/claude-code@2.1.117"
-install.brew = "# brew tap anthropics/claude-code; brew install claude-code@2.1.117 (when available)"
+install.npm = "npm install -g --no-save @anthropic-ai/claude-code@2.1.123"
+install.brew = "# brew tap anthropics/claude-code; brew install claude-code@2.1.123 (when available)"


### PR DESCRIPTION
## Summary

- `pinned-versions.toml`: adds per-tool `cooldown_days` field. Default 7 stays the same; `claude-code` overrides to **1** because its release cadence is high enough that 7 days strands the framework many versions behind, and any regression that affects the secure setup's permission-rule semantics or sandbox flags is caught broadly within hours of release.
- `claude-code` pin bumped 2.1.117 → **2.1.123** (latest version aged past the new 1-day cooldown). Closes most of the manifest-vs-installed drift surfaced by `verify-secure-config`; the user's installed `2.1.126` becomes the next candidate once it ages past 1 day.
- `check-tool-updates.sh`: threads the per-tool cooldown through both upstream-lookup helpers (`gh_latest_aged`, `socat_latest_aged`); status line now reads each tool's actual cooldown ("aged past Nd-cooldown") instead of a fixed 7.
- `secure-agent-setup.md`: "Required tools" table gains a Cooldown column; narrative explains per-tool override and names claude-code as the canonical case. "Bumping a pinned version" updated.

## Test plan

- [ ] `prek run --files` clean on all three changed files.
- [ ] `python3 -c 'import tomllib; print(tomllib.load(open("tools/agent-isolation/pinned-versions.toml","rb")))'` parses without error and shows `cooldown_days` for `claude-code`.
- [ ] `bash -n tools/agent-isolation/check-tool-updates.sh` (syntax check) passes.
- [ ] Running `tools/agent-isolation/check-tool-updates.sh` end-to-end shows: `bubblewrap` "aged past 7d-cooldown" upgrade candidate, `claude-code` "✓ up to date" (since 2.1.123 is the latest aged-past-1-day at time of writing). socat may surface "upstream lookup failed" on macOS owing to a pre-existing `tac` GNU-ism — out of scope.