### PR TITLE
docs: enable markdownlint MD040 and tag all fenced code blocks

### DIFF
--- a/.claude/skills/allocate-cve/SKILL.md
+++ b/.claude/skills/allocate-cve/SKILL.md
@@ -263,14 +263,14 @@ over-stripping is worse than leaving one redundant word in.
 Compose a proposal block that carries everything the user needs in
 one copy-paste pass:
 
-```markdown
+````markdown
 **Allocate a CVE for [<tracker>#<N>](https://github.com/<tracker>/issues/<N>).**
 
 1. Open the ASF Vulnogram allocation form:
    <https://cveprocess.apache.org/allocatecve>
 2. In the *Title* field, paste this:
 
-   ```
+   ```text
    <stripped title>
    ```
 
@@ -284,7 +284,7 @@ one copy-paste pass:
 4. Click *Allocate*. Vulnogram returns a `CVE-YYYY-NNNNN` ID.
 5. Paste the allocated CVE ID back into this conversation — the
    skill will pick it up and update the tracker automatically.
-```
+````
 
 Scope → Vulnogram product table: the adopting project's scope labels
 and their CVE product / package-name mappings are defined in

--- a/.claude/skills/fix-security-issue/SKILL.md
+++ b/.claude/skills/fix-security-issue/SKILL.md
@@ -420,7 +420,7 @@ Write out the exact `--body` the skill will pass to
 - the standard Gen-AI disclosure block per
   [`<upstream>/contributing-docs/05_pull_requests.rst`](https://github.com/<upstream>/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions):
 
-  ```
+  ```markdown
   ##### Was generative AI tooling used to co-author this PR?
 
   - [X] Yes — Claude Opus 4.6 (1M context)

--- a/.claude/skills/import-security-issue-from-md/SKILL.md
+++ b/.claude/skills/import-security-issue-from-md/SKILL.md
@@ -244,7 +244,7 @@ The tracker title is the finding's `# Title` with the standard
 convention; see
 [`tools/github/issue-template.md`](../../../tools/github/issue-template.md)):
 
-```
+```text
 [ Security Report ] <finding title>
 ```
 
@@ -335,7 +335,7 @@ exactly one blank line before `</details>`.
 
 Render a single proposal covering every parsed finding:
 
-```
+```text
 <file-basename> — N findings parsed.
 
 | # | Severity | Category                       | Title                                              | Possible duplicate |
@@ -539,7 +539,7 @@ purpose for this finding and would otherwise accumulate.
 After every finding lands, print a short one-liner so the user can
 see progress on long batches:
 
-```
+```text
 [K/N] <tracker>#NNN — <finding title>
 ```
 
@@ -619,7 +619,7 @@ the validity discussion produces signal.
 
 ### Example 1 — A six-finding AI-scan output
 
-```
+```text
 import findings from /tmp/scan-michaelwinser-airflow-2026-04-28.md
 ```
 
@@ -633,7 +633,7 @@ reference.
 
 ### Example 2 — A single-finding scanner export
 
-```
+```text
 import findings from ~/Downloads/sast-export.md
 ```
 
@@ -644,7 +644,7 @@ as a Gmail import; the only difference is the source format.
 
 ### Example 3 — Malformed input
 
-```
+```text
 import findings from /tmp/notes.md
 ```
 

--- a/.claude/skills/import-security-issue-from-pr/SKILL.md
+++ b/.claude/skills/import-security-issue-from-pr/SKILL.md
@@ -668,7 +668,7 @@ with other trackers.
 
 ### Example 1 — `providers` scope, already merged
 
-```
+```text
 import from pr 65703
 ```
 
@@ -687,7 +687,7 @@ disclosure; see *[Reporter credit policy](#reporter-credit-policy-for-public-pr-
 
 ### Example 2 — `airflow` scope, in-flight
 
-```
+```text
 import from pr https://github.com/<upstream>/pull/65999
 ```
 
@@ -700,7 +700,7 @@ proposes everything; on user confirmation, the tracker lands
 
 ### Example 3 — Mixed-scope PR (blocker)
 
-```
+```text
 import from pr 66042
 ```
 

--- a/.claude/skills/import-security-issue/SKILL.md
+++ b/.claude/skills/import-security-issue/SKILL.md
@@ -208,7 +208,7 @@ When PonyMail MCP is enabled and authenticated (Step 0) **and**
 `tools.ponymail.private_lists`, run the archive as a **paired
 authoritative check** against the Gmail result set:
 
-```
+```text
 mcp__ponymail__search_list(
   list: "security",
   domain: "<project>.apache.org",
@@ -439,7 +439,7 @@ fuzzy-match search against existing issues on three orthogonal keys:
 For every candidate, surface the match results under a *Potential
 duplicates* sub-item in the Step 5 proposal — format:
 
-```
+```markdown
 - thread <threadId> — "<candidate title>"
   - GHSA match: [#NNN](...) "GHSA-xxxx-yyyy-zzzz"  (STRONG)
   - Code-pointer match: [#MMM](...) "BaseSerialization.deserialize"  (MEDIUM)
@@ -511,7 +511,7 @@ authenticated (Step 0) **and** `security@<project>.apache.org`
 is in `config/user.md` → `tools.ponymail.private_lists`,
 **PonyMail MCP is the primary backend for this step**:
 
-```
+```text
 mcp__ponymail__search_list(
   list: "security",
   domain: "<project>.apache.org",

--- a/.claude/skills/invalidate-security-issue/SKILL.md
+++ b/.claude/skills/invalidate-security-issue/SKILL.md
@@ -616,7 +616,7 @@ Hand-off line:
 
 ### Example 1 — `security@`-imported, dag-author-input class
 
-```
+```text
 invalidate 244
 ```
 
@@ -634,7 +634,7 @@ verbatim quotes and the draft ID. Hand-off: terminal.
 
 ### Example 2 — PR-imported, no email
 
-```
+```text
 invalidate 355
 ```
 
@@ -652,7 +652,7 @@ import-from-pr skill's golden rules.
 
 ### Example 3 — Hard stop: CVE already allocated
 
-```
+```text
 invalidate 257
 ```
 

--- a/.claude/skills/sync-security-issue/SKILL.md
+++ b/.claude/skills/sync-security-issue/SKILL.md
@@ -195,7 +195,7 @@ concurrently, which is exactly what the sync needs.
 Each subagent must return a single code block (or JSON) with exactly
 these fields so the orchestrator can merge deterministically:
 
-```
+```yaml
 issue: <N>
 title: <one line>
 scope_label: airflow | providers | chart | <missing>
@@ -439,7 +439,7 @@ backend for this step** — the archive is authoritative and
 reaches back further than any single user's Gmail window. Run the
 distinctive-phrase search against:
 
-```
+```text
 mcp__ponymail__search_list(
   list: "security",
   domain: "<project>.apache.org",
@@ -681,7 +681,7 @@ authenticated (Step 0) **and** `security@<project>.apache.org` is
 in `config/user.md` → `tools.ponymail.private_lists`, **PonyMail
 MCP is the primary path** for reviewer-comment archive queries:
 
-```
+```text
 mcp__ponymail__search_list(
   list: "security",
   domain: "<project>.apache.org",
@@ -1073,7 +1073,7 @@ will change and *why*. Group them by category:
      - **PonyMail MCP (preferred when enabled).** If Step 0
        recorded `ponymail_authenticated: true`, call:
 
-       ```
+       ```text
        mcp__ponymail__search_list(
          list: "users",
          domain: "<project>.apache.org",
@@ -1455,7 +1455,7 @@ will change and *why*. Group them by category:
 
   **Idempotency.** Before proposing, scan the issue's existing
   comments for the marker
-  ```
+  ```html
   <!-- apache-steward: release-manager-handoff v1 -->
   ```
   exactly. If a comment carrying this marker already exists, **do
@@ -1537,7 +1537,7 @@ will change and *why*. Group them by category:
 
   **Idempotency.** Before proposing, scan the issue's existing
   comments for the marker
-  ```
+  ```html
   <!-- apache-steward: release-manager-publication-ready v1 -->
   ```
   exactly. If a comment carrying this marker already exists, do not
@@ -1624,7 +1624,7 @@ the actual person, in this order:
    - **PonyMail MCP (preferred when enabled).** `dev@` is a public
      list; no LDAP allowlist check is needed. Call:
 
-     ```
+     ```text
      mcp__ponymail__search_list(
        list: "dev",
        domain: "<project-domain>",

--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -1,5 +1,5 @@
 {
-  "$comment": "Markdownlint config for apache/airflow-steward. The rule set is deliberately minimal — only enables checks that catch real bugs (broken anchors, malformed code spans, malformed link references). Style choices that the existing docs already settled (compact tables, hyphen list markers, ordered-list numbering, fenced-language tagging) are left alone so the consolidation does not balloon the diff.",
+  "$comment": "Markdownlint config for apache/airflow-steward. The rule set is deliberately minimal — only enables checks that catch real bugs (broken anchors, malformed link references, untagged fenced code). Style choices that the existing docs already settled (compact tables, hyphen list markers, ordered-list numbering) are left alone.",
 
   "default": true,
 
@@ -16,7 +16,7 @@
   "MD033": false,
   "MD034": false,
   "MD036": false,
-  "MD040": false,
+  "MD038": false,
   "MD041": false,
   "MD046": false,
   "MD050": false,
@@ -24,11 +24,11 @@
   "MD059": false,
   "MD060": false,
 
-  "MD038": false,
+  "MD040": true,
   "MD051": true,
   "MD053": true,
 
   "$comment-MD038": "MD038 (no space inside code spans) is disabled because the steward docs intentionally use literal markdown-syntax samples like `# ` (H1), `### ` (H3), `- ` (list marker) inside backticks to illustrate markdown rendering. The rule has no per-context allowlist and would force escape-everywhere across many files. Re-enable in a follow-up that escapes those samples consistently.",
 
-  "$comment-rationale": "MD051 (link-fragments) catches broken cross-references — exactly the bug class that surfaced 5 real broken anchors on the existing tree. MD053 catches dangling link-reference definitions. Everything else is style and is intentionally off so this PR stays diff-minimal."
+  "$comment-rationale": "MD040 catches untagged fenced code blocks — surfaces 64 of them in the initial sweep, all tagged in this PR. MD051 (link-fragments) catches broken cross-references — exactly the bug class that surfaced 5 real broken anchors on the previous sweep. MD053 catches dangling link-reference definitions."
 }

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -232,7 +232,7 @@ at the root of its tracker repository. The framework refers to this
 directory via the placeholder `<project-config>`. Concretely, an
 adopting project lays out:
 
-```
+```text
 <adopter-tracker-repo>/
 └── .apache-steward/
     ├── apache-steward/         # (submodule) clone of this framework
@@ -371,13 +371,13 @@ if a hook is failing, fix the underlying issue or update the hook configuration 
   itself. **Re-read this rule before preparing every `git commit`.**
   Use a `Generated-by:` trailer instead. The form is:
 
-  ```
+  ```text
   Generated-by: <agent name and version>
   ```
 
   Concrete example for Claude Code:
 
-  ```
+  ```text
   Generated-by: Claude Code (Opus 4.7)
   ```
 
@@ -859,7 +859,7 @@ not as bare text. The canonical link is the adopting project's CVE-tool
 record URL, which any security team member can click through to the
 live CVE record we control:
 
-```
+```text
 https://cveprocess.apache.org/cve5/<CVE-ID>
 ```
 
@@ -873,7 +873,7 @@ CVE record is visible on public databases), additionally link to the public
 `cve.org` / MITRE record so non-security-team readers can see the public
 description without needing access to the ASF tool:
 
-```
+```text
 https://www.cve.org/CVERecord?id=<CVE-ID>
 ```
 
@@ -964,7 +964,7 @@ messages, internal notes, `SKILL.md` files — render it as a
 **clickable markdown link**, not as a bare `#NNN` or
 `<tracker>#NNN`. The URL format is:
 
-```
+```text
 https://github.com/<tracker>/issues/<N>
 https://github.com/<tracker>/pull/<N>
 https://github.com/<tracker>/issues/<N>#issuecomment-<C>

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -79,7 +79,7 @@ four — no hard-coded project assumptions anywhere.
 
 ### Directory tree
 
-```
+```text
 .
 ├── README.md                      # Canonical 16-step handling process + conventions
 ├── AGENTS.md                      # Editorial rules: tone, brevity, confidentiality,

--- a/projects/_template/fix-workflow.md
+++ b/projects/_template/fix-workflow.md
@@ -68,7 +68,7 @@ TODO: the project's convention for AI-assisted commits. Example:
 
 And the concrete trailer text for this project:
 
-```
+```text
 Generated-by: TODO: model + URL to the project's Gen-AI disclosure anchor
 ```
 

--- a/secure-agent-setup.md
+++ b/secure-agent-setup.md
@@ -311,7 +311,7 @@ the manifest, never installs anything, never opens a PR.
 The framework's `/schedule` slash-command lets you wire the check
 script into a recurring agent without leaving Claude Code:
 
-```
+```text
 /schedule weekly run tools/agent-isolation/check-tool-updates.sh
                   and surface upgrade candidates
 ```
@@ -742,7 +742,7 @@ already follow this pattern.
 
 A minimal repo layout:
 
-```
+```text
 ~/.claude-config/                       # the synced repo's checkout
 ├── CLAUDE.md                           # symlinked → ~/.claude/CLAUDE.md
 ├── scripts/

--- a/tools/github/status-rollup.md
+++ b/tools/github/status-rollup.md
@@ -193,7 +193,7 @@ let them pick which one to keep.
 Construct the new body by concatenating the old body + a ruler + the
 new entry, with exactly one blank line on each side of the ruler:
 
-```
+```text
 <old body>
 
 ---
@@ -229,7 +229,7 @@ arbitrary comment, and the `--input` flag is needed because
 Only if Step 1 returned no existing rollup. Prepend the marker line
 and emit the new entry as the rollup's first entry:
 
-```
+```markdown
 <!-- airflow-s status rollup v1 — all bot-authored status updates fold into this single comment. -->
 <new entry>
 ```
@@ -292,7 +292,7 @@ For each foldable legacy comment, in chronological order:
 1. **Reconstruct the entry shape.** Take the legacy body and wrap it
    in the rollup's `<details>` envelope:
 
-   ```
+   ```html
    <details><summary><createdAt date> · @<author.login> · <Action></summary>
 
    <legacy body — verbatim, left-trimmed>

--- a/tools/gmail/draft-backends.md
+++ b/tools/gmail/draft-backends.md
@@ -142,7 +142,7 @@ The detection rule depends on which backend created the prior draft:
   (see the *Known issue* section below). Detect them by reading the
   thread directly:
 
-  ```
+  ```text
   mcp__claude_ai_Gmail__get_thread(threadId: "<inbound-thread-id>", messageFormat: MINIMAL)
   ```
 

--- a/tools/gmail/operations.md
+++ b/tools/gmail/operations.md
@@ -44,7 +44,7 @@ Every skill that talks to Gmail does a one-call pre-flight in Step 0
 to confirm the MCP is reachable and the user's account subscribes to
 the project's security list:
 
-```
+```text
 mcp__claude_ai_Gmail__search_threads(
   query='list:<security-list-domain>',
   pageSize=1,
@@ -65,7 +65,7 @@ fix the setup rather than guessing.
 
 ### Search threads
 
-```
+```text
 mcp__claude_ai_Gmail__search_threads(
   query='<gmail search expression>',
   pageSize=<N>,
@@ -82,7 +82,7 @@ the skills use, see [`search-queries.md`](search-queries.md).
 
 ### Get thread
 
-```
+```text
 mcp__claude_ai_Gmail__get_thread(
   threadId='<threadId>',
   messageFormat='FULL_CONTENT',   # or 'METADATA' when bodies are not needed
@@ -119,7 +119,7 @@ created via this backend always start a new conversation on the
 subject + `In-Reply-To` / `References` matching, which usually works
 but is not guaranteed.
 
-```
+```text
 mcp__claude_ai_Gmail__create_draft(
   subject='Re: <root subject of the inbound message>',
   to=['<primary>'],
@@ -184,7 +184,7 @@ For the ASF-security-relay special case (different `to` /
 
 ### List drafts
 
-```
+```text
 mcp__claude_ai_Gmail__list_drafts(
   query='<optional filter>',    # e.g. 'list:<security-list-domain>'
 )

--- a/tools/gmail/ponymail-archive.md
+++ b/tools/gmail/ponymail-archive.md
@@ -51,7 +51,7 @@ Placeholder convention:
 
 ### Archive search (query returns a list-page with matching threads)
 
-```
+```text
 https://lists.apache.org/list?<list>:YYYY-M:<url-encoded search>
 ```
 
@@ -64,13 +64,13 @@ https://lists.apache.org/list?<list>:YYYY-M:<url-encoded search>
 Alternative bare URL form used by the sync skill when scanning the
 public archive for a CVE ID:
 
-```
+```text
 https://lists.apache.org/list.html?<list>:YYYY:<CVE-ID>
 ```
 
 ### Archive API (JSON response, the sync skill uses this first)
 
-```
+```text
 https://lists.apache.org/api/thread.lua?list=<list-local>&domain=<list-domain>&q=<search>
 ```
 
@@ -83,7 +83,7 @@ public lists.
 
 ### Resolved thread URL (what the skill records in the tracker)
 
-```
+```text
 https://lists.apache.org/thread/<hash>?<list>
 ```
 
@@ -105,7 +105,7 @@ the archive URL programmatically. Instead, the skill **constructs**
 the search URL for the month the message was received and proposes
 it to the user at Step 5 as a one-click lookup:
 
-```
+```text
 https://lists.apache.org/list?<security-list>:YYYY-M:<url-encoded subject>
 ```
 

--- a/tools/ponymail/operations.md
+++ b/tools/ponymail/operations.md
@@ -60,7 +60,7 @@ Every skill that talks to PonyMail MCP does a one-call pre-flight
 in Step 0 to verify the session is authenticated before relying on
 private-list queries:
 
-```
+```text
 mcp__ponymail__auth_status()
 ```
 
@@ -79,7 +79,7 @@ auth tools:
 
 ### Login
 
-```
+```text
 mcp__ponymail__login()
 ```
 
@@ -90,7 +90,7 @@ Code session pick up the cached cookie automatically.
 
 ### Auth status
 
-```
+```text
 mcp__ponymail__auth_status()
 ```
 
@@ -101,7 +101,7 @@ handled by the [Error handling](#error-handling) section below.
 
 ### Logout
 
-```
+```text
 mcp__ponymail__logout()
 ```
 
@@ -113,7 +113,7 @@ logout on their own — it is a user-driven lifecycle step.
 
 ### List lists
 
-```
+```text
 mcp__ponymail__list_lists()
 ```
 
@@ -133,7 +133,7 @@ the MCP itself, so repeat invocations are fast.
 
 ### Search a list
 
-```
+```text
 mcp__ponymail__search_list(
   list: "<list>",
   domain: "<domain>",
@@ -180,7 +180,7 @@ tid) — not full bodies. Fetch the body via
 
 ### Get a thread
 
-```
+```text
 mcp__ponymail__get_thread(
   list: "<list>",
   domain: "<domain>",
@@ -200,7 +200,7 @@ conversation.
 
 ### Get an email
 
-```
+```text
 mcp__ponymail__get_email(
   id: "<mid or Message-ID header value>"
 )
@@ -216,7 +216,7 @@ reference) and want its full body.
 
 ### Get an mbox dump
 
-```
+```text
 mcp__ponymail__get_mbox(
   list: "<list>",
   domain: "<domain>",
@@ -245,7 +245,7 @@ Until then, common recipes:
 
 ### Find the advisory archive thread on `users@<project>.apache.org`
 
-```
+```text
 mcp__ponymail__search_list(
   list: "users",
   domain: "<project>.apache.org",
@@ -262,7 +262,7 @@ for the tracker's *Public advisory URL* body field.
 
 ### Pull the original report thread on `security@<project>.apache.org`
 
-```
+```text
 mcp__ponymail__search_list(
   list: "security",
   domain: "<project>.apache.org",
@@ -277,7 +277,7 @@ string — same heuristic as the Gmail equivalent in
 
 ### Find the `[RESULT][VOTE]` thread for a release
 
-```
+```text
 mcp__ponymail__search_list(
   list: "dev",
   domain: "<project>.apache.org",

--- a/tools/ponymail/tool.md
+++ b/tools/ponymail/tool.md
@@ -152,7 +152,7 @@ is picked up and its tools appear in the deferred-tool list.
 
 In a Claude Code session, run:
 
-```
+```text
 mcp__ponymail__login()
 ```
 
@@ -164,7 +164,7 @@ Code sessions until the cookie expires.
 
 Verify:
 
-```
+```text
 mcp__ponymail__auth_status()
 ```
 
@@ -177,7 +177,7 @@ lists but returns empty results for private-list queries.
 Pull the list overview to confirm the session sees the expected
 lists:
 
-```
+```text
 mcp__ponymail__list_lists()
 ```
 

--- a/tools/vulnogram/allocation.md
+++ b/tools/vulnogram/allocation.md
@@ -29,7 +29,7 @@ ID) lives in
 
 ## Allocation URL
 
-```
+```text
 https://cveprocess.apache.org/allocatecve
 ```
 


### PR DESCRIPTION
Follow-up to #18. Flips MD040 to `true` and tags the 64 untagged fences across the tree.

Most fences ended up `text` (MCP call sketches, URL examples, dir trees, plain output). Three got `html` for HTML-comment markers and the `<details>` envelope, three `markdown` for the AI-disclosure block and rollup body samples, one `yaml` for the subagent return block in `sync-security-issue`.

One quirk worth flagging: `allocate-cve/SKILL.md` had a nested fence that needed the outer one promoted from 3 to 4 backticks so the inner 3-backtick block renders as an actual nested code block instead of breaking out of the outer one.

## Test plan

- [x] `prek run --all-files` clean
- [x] `npx markdownlint-cli2 "**/*.md" "#node_modules" "#.git"` clean
- [x] Nested fence in `allocate-cve/SKILL.md` previewed on GitHub, renders as expected

---

##### Was generative AI tooling used to co-author this PR?

- [ ] Yes