### PR TITLE
refactor(skills): rename skills with category prefixes (setup-/security-)

### DIFF
--- a/.claude/skills/security-allocate-cve/SKILL.md
+++ b/.claude/skills/security-allocate-cve/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: allocate-cve
+name: security-allocate-cve
 description: |
   Walk a security team member through allocating a CVE for an
   <tracker> tracking issue. Prints the ASF Vulnogram
@@ -11,7 +11,7 @@ description: |
   *CVE tool link* field, adds the `cve allocated` label, posts a
   collapsed status-change comment, and runs `generate-cve-json
   --attach` to embed the paste-ready JSON in the body. Finishes by
-  handing off to the `sync-security-issue` skill to reconcile the
+  handing off to the `security-sync-issues` skill to reconcile the
   rest of the tracker (milestone, assignee, reporter drafts, fix-PR
   state) now that the CVE landing is complete.
 when_to_use: |
@@ -32,7 +32,7 @@ when_to_use: |
      Before running any bash command below, substitute these with the
      concrete values from the adopting project's <project-config>/project.md. -->
 
-# allocate-cve
+# security-allocate-cve
 
 Walks a security team member through the CVE-allocation step of the
 [handling process](../../../README.md) for a given
@@ -81,7 +81,7 @@ of the allocated ID does not need to be done by the PMC member.
 
 **Golden rule — every `<tracker>` reference is a clickable
 link**, per Golden rule 2 in
-[`sync-security-issue`](../sync-security-issue/SKILL.md). The
+[`security-sync-issues`](../security-sync-issues/SKILL.md). The
 allocation recipe, the post-allocation proposal, and the status-
 change comment must all follow the link-form convention from
 [`AGENTS.md`](../../../AGENTS.md).
@@ -345,7 +345,7 @@ user to confirm. Numbered items:
 1. **Set the *CVE tool link* body field** to
    `https://cveprocess.apache.org/cve5/CVE-YYYY-NNNNN`. Patch only
    this one field; do not touch the rest of the body. Use the
-   `sync-security-issue` skill's body-field-surgery recipe — read
+   `security-sync-issues` skill's body-field-surgery recipe — read
    the full body, replace the *CVE tool link* field's value between
    its `### CVE tool link\n\n` header and the next `### ` or
    end-of-body, write back via `gh issue edit --body-file`.
@@ -363,8 +363,8 @@ user to confirm. Numbered items:
    creates one; on the way, the skill must also fold any
    pre-existing legacy bot comments into the new rollup per the
    fold-legacy sub-step described in
-   [`sync-security-issue`](../sync-security-issue/SKILL.md) —
-   allocate-cve is a common first write after a long pause, so
+   [`security-sync-issues`](../security-sync-issues/SKILL.md) —
+   security-allocate-cve is a common first write after a long pause, so
    the legacy comments are often there.
 4. **Regenerate the CVE JSON attachment** in the tracker body by
    running
@@ -374,12 +374,12 @@ user to confirm. Numbered items:
    This is how the CVE record first gets seeded with the allocated
    ID. The remediation-developer credit (if any) comes from the
    tracker's *Remediation developer* body field — populated by the
-   `sync-security-issue` skill from the linked PR's author the
+   `security-sync-issues` skill from the linked PR's author the
    first time *PR with the fix* is set, and editable by hand
    thereafter. No CLI flag needed.
 5. **Draft a reporter status update** — only when the real
    reporter's Gmail thread is known and the ball is in our court
-   (see `sync-security-issue` Step 1c). Keep the draft short, per
+   (see `security-sync-issues` Step 1c). Keep the draft short, per
    the "Brevity: emails state facts, not context" section of
    [`AGENTS.md`](../../../AGENTS.md): one sentence that the CVE has
    been allocated, one sentence that the advisory will be sent
@@ -434,7 +434,7 @@ spaces inside the block, one blank line after
 - Label `cve allocated` added.
 - CVE JSON attachment embedded in the issue body — paste into [Vulnogram `#source`](https://cveprocess.apache.org/cve5/<CVE-YYYY-NNNNN>#source) to seed the record.
 
-**Next:** <one-sentence next step — e.g. "design the fix (`fix-security-issue` skill)", or "release manager completes [process step 12](../../../README.md) once the fix ships">.
+**Next:** <one-sentence next step — e.g. "design the fix (`security-fix-issue` skill)", or "release manager completes [process step 12](../../../README.md) once the fix ships">.
 
 <Reporter-notification line — one of the four options below.>
 
@@ -496,16 +496,16 @@ partial failures stay legible:
 
 If any step fails, stop and ask the user how to proceed — do not
 guess. The body edit (step 1) is the only *load-bearing* step; if
-steps 2–5 fail, a subsequent `sync-security-issue` run will pick up
+steps 2–5 fail, a subsequent `security-sync-issues` run will pick up
 the slack because it reads the CVE ID from the body.
 
 ---
 
-## Step 6 — Hand off to `sync-security-issue`
+## Step 6 — Hand off to `security-sync-issues`
 
 Right after the apply loop finishes (and before the recap in Step
 7), invoke the
-[`sync-security-issue`](../sync-security-issue/SKILL.md) skill on
+[`security-sync-issues`](../security-sync-issues/SKILL.md) skill on
 the same tracker. The CVE allocation touches every axis the sync
 skill reconciles — labels, body fields, assignees, milestone,
 reporter-notification drafts, cross-referenced fix PRs — and
@@ -526,7 +526,7 @@ that the next triage sweep has to clean up from scratch. Always
 run it.
 
 **How to invoke.** The sync skill is prompt-driven, so this is a
-meta-step: tell the user *"running `sync-security-issue` on
+meta-step: tell the user *"running `security-sync-issues` on
 [<tracker>#<N>](...) to reconcile the rest of the
 tracker"* and then run the sync skill's Step 1 (Gather state) on
 the same issue. Sync produces its own numbered proposal with its
@@ -542,7 +542,7 @@ bump.
 **When the handoff is not appropriate.** Skip the sync handoff
 **only** if the user explicitly says they are about to close the
 tracker (e.g. allocated-then-decided-to-reject — a rare case, but
-possible), or if sync was already running when `allocate-cve` was
+possible), or if sync was already running when `security-allocate-cve` was
 invoked (nested invocation — sync's own Step 1 will detect the
 fresh CVE on its next pass anyway). In every other case, run it.
 
@@ -607,7 +607,7 @@ presenting.
   particular step 6 (CVE allocation).
 - [`AGENTS.md`](../../../AGENTS.md) — confidentiality, linking
   conventions, reporter-supplied CVSS rule.
-- [`sync-security-issue`](../sync-security-issue/SKILL.md) —
+- [`security-sync-issues`](../security-sync-issues/SKILL.md) —
   **mandatory follow-up** to this skill (Step 6). Reconciles the
   tracker, the mail thread, and any fix PR after the CVE landing
   touches labels, body fields, and comments. Always runs; only
@@ -615,11 +615,11 @@ presenting.
 - [`generate-cve-json`](../../../tools/vulnogram/generate-cve-json/SKILL.md) — Step 4
   regenerates the CVE JSON attachment in the body so Vulnogram can
   be seeded via the `#source` tab paste.
-- [`import-security-issue`](../import-security-issue/SKILL.md) /
-  [`deduplicate-security-issue`](../deduplicate-security-issue/SKILL.md)
+- [`security-import-issues`](../security-import-issues/SKILL.md) /
+  [`security-deduplicate-issues`](../security-deduplicate-issues/SKILL.md)
   — the two on-ramps that feed trackers into this skill; running
   dedupe before allocation is how we avoid burning two CVE IDs on
   the same root-cause bug.
-- [`fix-security-issue`](../fix-security-issue/SKILL.md) — the
+- [`security-fix-issue`](../security-fix-issue/SKILL.md) — the
   follow-up after allocation: open the public fix PR with the CVE
   context kept internal.

--- a/.claude/skills/security-deduplicate-issues/SKILL.md
+++ b/.claude/skills/security-deduplicate-issues/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: deduplicate-security-issue
+name: security-deduplicate-issues
 description: |
   Merge two <tracker> tracking issues that describe the same
   root-cause vulnerability (typically discovered independently by two
@@ -12,7 +12,7 @@ description: |
 when_to_use: |
   Invoke when a security team member says "dedupe #NNN and #MMM",
   "merge #MMM into #NNN", "#MMM is a duplicate of #NNN", or when the
-  import-security-issue skill's Step 2a surfaces a STRONG match (GHSA
+  security-import-issues skill's Step 2a surfaces a STRONG match (GHSA
   ID collision) between a new report and an existing tracker. Also
   appropriate as a periodic cleanup action when a triager spots two
   open trackers describing the same bug from different angles.
@@ -27,7 +27,7 @@ when_to_use: |
      Before running any bash command below, substitute these with the
      concrete values from the adopting project's <project-config>/project.md. -->
 
-# deduplicate-security-issue
+# security-deduplicate-issues
 
 Merges two `<tracker>` tracking issues that describe the
 same underlying vulnerability. The output is a single tracker
@@ -55,7 +55,7 @@ different **scope labels** (`airflow` vs. `providers`, `airflow`
 vs. `chart`, etc.) must not be merged. If an external reporter
 rediscovers the same bug in two different products' surfaces, that
 is a multi-scope report and the resolution is a
-**scope split** handled by the `sync-security-issue` skill, not a
+**scope split** handled by the `security-sync-issues` skill, not a
 dedupe. This skill refuses to operate when the two candidate
 trackers have different scope labels, and the proposal says so
 explicitly.
@@ -129,7 +129,7 @@ Verify:
 - Both have the **same scope label** — `airflow` vs. `airflow`,
   or `providers` vs. `providers`, or `chart` vs. `chart`. If the
   scope labels differ, refuse the merge and tell the user this is
-  a multi-scope report to be handled by `sync-security-issue`'s
+  a multi-scope report to be handled by `security-sync-issues`'s
   scope-split flow instead.
 - Neither tracker is already labelled `duplicate` (that would
   indicate a partial-merge already happened and someone left it
@@ -286,7 +286,7 @@ merges.
 
 Two rollup-comment entries, one per tracker — **not** two new
 top-level comments. The entries are appended to each tracker's
-existing status-rollup comment (created by `import-security-issue`)
+existing status-rollup comment (created by `security-import-issues`)
 via the upsert recipe in
 [`tools/github/status-rollup.md`](../../../tools/github/status-rollup.md#upsert-recipe--append-to-an-existing-rollup-or-create-one).
 When either tracker does not yet carry a rollup (legacy tracker
@@ -387,7 +387,7 @@ After confirmation, apply **sequentially** (never in parallel):
    the rollup if none exists yet. The same step folds any legacy
    bot comments on the kept tracker into the rollup first, per
    the fold-legacy sub-step in
-   [`sync-security-issue`](../sync-security-issue/SKILL.md).
+   [`security-sync-issues`](../security-sync-issues/SKILL.md).
 3. Rollup-comment upsert on the dropped tracker — append the
    `Merge (dropped)` entry (same recipe; fold legacy comments
    first when needed).
@@ -399,7 +399,7 @@ After confirmation, apply **sequentially** (never in parallel):
 6. `uv run --project <framework>/tools/vulnogram/generate-cve-json generate-cve-json <keep> --attach`
    — the *Remediation developer* body field is the source of truth
    for remediation-developer credits (populated by the
-   `sync-security-issue` skill from the linked PR's author); no CLI
+   `security-sync-issues` skill from the linked PR's author); no CLI
    flag needed
 7. For each legacy bot comment folded in steps 2 / 3, delete the
    original with `gh api -X DELETE
@@ -434,7 +434,7 @@ recap before presenting.
 ## Hard rules
 
 - **Never merge across scopes.** Different scope labels → scope
-  split (via `sync-security-issue`), not dedupe.
+  split (via `security-sync-issues`), not dedupe.
 - **Never re-synthesize credits.** Copy each reporter's credit line
   verbatim from their tracker.
 - **Never propagate a reporter-supplied CVSS** from the dropped
@@ -457,7 +457,7 @@ recap before presenting.
 ## When dedupe is **not** appropriate
 
 - The two trackers are in **different scopes** → use the scope-split
-  flow in `sync-security-issue` instead.
+  flow in `security-sync-issues` instead.
 - The two trackers describe the same code surface but **different
   bugs** with **different fixes** (for example, two separate
   allowlist gaps in the same file, each requiring its own
@@ -476,11 +476,11 @@ recap before presenting.
 - [`README.md`](../../../README.md) — the handling process;
   duplicates are resolved here at various steps rather than at a
   single numbered step.
-- [`import-security-issue`](../import-security-issue/SKILL.md) —
+- [`security-import-issues`](../security-import-issues/SKILL.md) —
   Step 2a surfaces potential duplicates before a new tracker is
   even created, so in the ideal case this skill is never needed
   on a fresh import.
-- [`sync-security-issue`](../sync-security-issue/SKILL.md) — runs
+- [`security-sync-issues`](../security-sync-issues/SKILL.md) — runs
   on the kept tracker after the merge to reconcile labels /
   milestone / credit-preference drafts for both reporters.
 - [`generate-cve-json`](../../../tools/vulnogram/generate-cve-json/SKILL.md) —

--- a/.claude/skills/security-fix-issue/SKILL.md
+++ b/.claude/skills/security-fix-issue/SKILL.md
@@ -1,9 +1,9 @@
 ---
-name: fix-security-issue
+name: security-fix-issue
 description: |
   Attempt to fix a security issue tracked in <tracker> by
   implementing the change in a public <upstream> PR. Runs the
-  sync-security-issue skill first to reconcile the issue's state, then
+  security-sync-issues skill first to reconcile the issue's state, then
   analyses the discussion to decide whether the issue is easily fixable
   (clear consensus, small scope, known location). If it is, proposes an
   implementation plan, waits for explicit user confirmation, writes the
@@ -33,11 +33,11 @@ when_to_use: |
      Before running any bash command below, substitute these with the
      concrete values from the adopting project's <project-config>/project.md. -->
 
-# fix-security-issue
+# security-fix-issue
 
 This skill automates the "attempt a fix" step of the security handling
 process for issues in [`<tracker>`](https://github.com/<tracker>).
-It composes with the [`sync-security-issue`](../sync-security-issue/SKILL.md)
+It composes with the [`security-sync-issues`](../security-sync-issues/SKILL.md)
 skill — it always runs the sync first so that the issue's state is
 reconciled with the mail thread and any existing PRs before attempting
 any new work.
@@ -167,7 +167,7 @@ Only after **every** check is green, proceed to Step 1.
 
 ## Step 1 — Sync the issue first
 
-Run the [`sync-security-issue`](../sync-security-issue/SKILL.md) skill
+Run the [`security-sync-issues`](../security-sync-issues/SKILL.md) skill
 on the same issue number and apply any state corrections the user
 confirms there. **Do not attempt a fix before the sync has completed**,
 because:
@@ -552,7 +552,7 @@ Now that a public PR exists, update the private tracking issue:
    convention), run the upsert recipe's Step 2b to create it and
    fold any pre-existing bot comments into the new rollup first —
    see the fold-legacy sub-step in
-   [`sync-security-issue`](../sync-security-issue/SKILL.md).
+   [`security-sync-issues`](../security-sync-issues/SKILL.md).
 
    Before writing the entry, **scrub the body for bare-name
    mentions** of project maintainers, release managers, and
@@ -570,14 +570,14 @@ Now that a public PR exists, update the private tracking issue:
 2. **Update the issue body "PR with the fix" field** if it is empty
    or points to a stale PR. Use `gh issue view --json body`, patch
    only that field, and apply via `gh issue edit --body-file`, as
-   in the [`sync-security-issue`](../sync-security-issue/SKILL.md)
+   in the [`security-sync-issues`](../security-sync-issues/SKILL.md)
    skill.
 
 3. **Maintain milestones and labels** — see the next section.
 
 4. **Status update to the reporter** — if the <tracker> issue has an
    identified external reporter and the reporter has not yet been
-   told about the fix PR, delegate to the `sync-security-issue`
+   told about the fix PR, delegate to the `security-sync-issues`
    skill's "Status update to the reporter" category by re-running
    that skill with a pointer to the new PR. Do **not** draft the
    reporter email directly in this skill — it is the sync skill's
@@ -661,7 +661,7 @@ For a post-triage, pre-merge fix, the target label set is:
 - `needs triage` **removed** (if still present after triage);
 - `pr created` once the public PR is open;
 - **not** `pr merged` or `fix released` (those belong to post-merge
-  / post-release states, applied by the `sync-security-issue` skill
+  / post-release states, applied by the `security-sync-issues` skill
   on later runs);
 - **not** `announced - emails sent` or `announced` (those
   belong to post-advisory states, also applied by the sync skill).
@@ -723,7 +723,7 @@ Print a short recap:
 - the comment posted on the `<tracker>` issue,
 - the backport label that was applied (or a note that none was needed),
 - the next step — typically *"wait for review; re-run
-  sync-security-issue after the PR merges to transition the issue
+  security-sync-issues after the PR merges to transition the issue
   from `pr created` to `pr merged` and update the milestone"*.
 
 ---
@@ -766,7 +766,7 @@ Print a short recap:
 
 ## References
 
-- [`sync-security-issue` skill](../sync-security-issue/SKILL.md) — run this first.
+- [`security-sync-issues` skill](../security-sync-issues/SKILL.md) — run this first.
 - [`README.md`](../../../README.md) — canonical process description, especially steps 7–9 (implementing the fix).
 - [`AGENTS.md`](../../../AGENTS.md) — repo-wide rules (confidentiality, commit trailers, tone, CVE linking).
 - [`<upstream>/AGENTS.md`](https://github.com/<upstream>/blob/main/AGENTS.md) — parent conventions this skill defers to.

--- a/.claude/skills/security-import-issue-from-pr/SKILL.md
+++ b/.claude/skills/security-import-issue-from-pr/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: import-security-issue-from-pr
+name: security-import-issue-from-pr
 description: |
   Open a tracking issue in <tracker> for a security-relevant fix that
   has already been opened (or merged) as a public PR in <upstream>,
@@ -9,7 +9,7 @@ description: |
   happened) with the scope label applied, `pr created` / `pr merged`
   reflecting the PR's state, and `Remediation developer` / `PR with
   the fix` body fields populated from the PR — ready for
-  `allocate-cve` to take over.
+  `security-allocate-cve` to take over.
 when_to_use: |
   Invoke when a security team member says "import a tracker from
   PR <N>", "open a tracker for <upstream>#NNN", "we need a CVE
@@ -18,7 +18,7 @@ when_to_use: |
   that never went through `security@`. Use only when the PR's
   security relevance has already been agreed informally; this skill
   does not host a validity discussion. For reports that arrive on
-  `<security-list>`, use `import-security-issue`.
+  `<security-list>`, use `security-import-issues`.
 ---
 
 <!-- Placeholder convention (see AGENTS.md#placeholder-convention-used-in-skill-files):
@@ -30,7 +30,7 @@ when_to_use: |
      Before running any bash command below, substitute these with the
      concrete values from the adopting project's <project-config>/project.md. -->
 
-# import-security-issue-from-pr
+# security-import-issue-from-pr
 
 This skill is an alternative on-ramp of the security-issue handling
 process for the case where the report **never arrived on
@@ -39,12 +39,12 @@ in `<upstream>`; somebody on the security team noticed it is
 security-relevant; the team decided informally that the fix
 warrants a CVE. This skill turns that public PR into an
 `<tracker>` tracking issue so the rest of the workflow
-(`allocate-cve` → `sync-security-issue` → `fix-security-issue` →
+(`security-allocate-cve` → `security-sync-issues` → `security-fix-issue` →
 public advisory) can run.
 
-It is the smaller sibling of [`import-security-issue`](../import-security-issue/SKILL.md):
+It is the smaller sibling of [`security-import-issues`](../security-import-issues/SKILL.md):
 
-| | `import-security-issue` | `import-security-issue-from-pr` |
+| | `security-import-issues` | `security-import-issue-from-pr` |
 |---|---|---|
 | Source | `<security-list>` Gmail / PonyMail thread | `<upstream>` PR URL or number |
 | Reporter present | Yes (external researcher) | No (PR author = remediation developer = de-facto finder) |
@@ -76,7 +76,7 @@ tracker URL itself is a public-safe identifier per the
 rule and may appear in the public PR description as a
 cross-reference, **so long as the surrounding text does not frame
 the change as a security fix**. The
-[`fix-security-issue`](../fix-security-issue/SKILL.md) public-PR
+[`security-fix-issue`](../security-fix-issue/SKILL.md) public-PR
 guardrails apply in full from the moment the tracker exists:
 neutral bug-fix language, no `CVE-`, no *"vulnerability"* or
 *"security fix"* phrasing.
@@ -234,7 +234,7 @@ is a manual project-board action, not part of this skill.
 Before proposing a new tracker, check that one does not already
 exist for this PR. The PR URL and number are both reliable
 discriminators because the *PR with the fix* body field on
-existing trackers contains the URL once `sync-security-issue`
+existing trackers contains the URL once `security-sync-issues`
 has run on them.
 
 ```bash
@@ -255,7 +255,7 @@ If either search returns a hit:
 - Surface the existing tracker(s) to the user with a clickable
   `<tracker>#NNN` reference.
 - **Stop** — do not create a duplicate tracker. The user either
-  re-invokes `sync-security-issue NNN` to refresh the existing
+  re-invokes `security-sync-issues NNN` to refresh the existing
   tracker's PR-state labels, or (if the existing tracker is
   closed and the fix needs re-tracking) invokes the skill again
   with an explicit `force` argument.
@@ -279,7 +279,7 @@ Start from `pr.title`. Strip:
 
 Do **not** add `<vendor>: <product>:` (e.g. `Apache Airflow:`) prefix — that lives in the CVE
 title, not the tracker title (the
-[`allocate-cve`](../allocate-cve/SKILL.md) skill normalises for
+[`security-allocate-cve`](../security-allocate-cve/SKILL.md) skill normalises for
 the CVE record). Tracker titles in `<tracker>` are
 plain-language summaries.
 
@@ -299,14 +299,14 @@ has nine fields. Fill them as follows:
 | **The issue description** | Two paragraphs: (1) a one-line note `> **Imported from public PR <upstream>#<N>** — there is no inbound \`security@\` report; the PR description below is the public statement of the vulnerability.` (2) the PR body verbatim, fenced if it is heavily templated. |
 | **Short public summary for publish** | `_No response_` (the team writes this when drafting the advisory; not derivable from the PR). |
 | **Affected versions** | Per the scope's *Affected versions* convention from [`scope-labels.md`](../../../<project-config>/scope-labels.md). For `providers`: one line per affected package, `<package-name> < NEXT VERSION`. For `airflow` / `chart`: `< X.Y.Z` from the milestone. |
-| **Security mailing list thread** | Sentinel: `N/A — opened from public PR <upstream>#<N>; no security@ thread`. The field is `required: true` in the form — the skill creates the issue via `gh api` (Step 7), which bypasses form-required-field enforcement, but the sentinel is still set so future `sync-security-issue` runs do not flag the field as missing. |
+| **Security mailing list thread** | Sentinel: `N/A — opened from public PR <upstream>#<N>; no security@ thread`. The field is `required: true` in the form — the skill creates the issue via `gh api` (Step 7), which bypasses form-required-field enforcement, but the sentinel is still set so future `security-sync-issues` runs do not flag the field as missing. |
 | **Public advisory URL** | `_No response_`. |
 | **Reporter credited as** | `_No response_`. **The PR author is *not* credited as the CVE reporter for this kind of import.** A public PR is not a responsible disclosure — the contributor went straight to the public fix without giving the security team a chance to coordinate the announcement, so the security team neither owes a finder credit nor wants to incentivise the practice. The user can populate the field manually if there is a project-specific reason to credit a different individual (e.g. an internal reviewer who privately flagged the issue on the PR before it landed). See *[Reporter credit policy for public-PR imports](#reporter-credit-policy-for-public-pr-imports)* below. |
 | **PR with the fix** | `pr.url` (e.g. `https://github.com/<upstream>/pull/65703`). |
 | **Remediation developer** | `pr.author.name` (fall back to `pr.author.login`). One name per line. |
 | **CWE** | `_No response_` (the team assesses; not derivable). |
 | **Severity** | `Unknown`. |
-| **CVE tool link** | `_No response_` (filled by [`allocate-cve`](../allocate-cve/SKILL.md)). |
+| **CVE tool link** | `_No response_` (filled by [`security-allocate-cve`](../security-allocate-cve/SKILL.md)). |
 
 The body is written to a temp file in Step 7; in the proposal,
 show it inline so the user can scan-and-redirect before any
@@ -386,12 +386,12 @@ The first entry on the tracker's status rollup. Shape per
 
 This tracker was deliberately opened by the security team for a public fix that did **not** arrive on `<security-list>`. The validity assessment was made informally before invocation; the tracker landed in the `Assessed` column accordingly.
 
-**Next:** Step 6 — allocate the CVE via the [`allocate-cve`](https://github.com/<tracker>/blob/<default-branch>/.claude/skills/allocate-cve/SKILL.md) skill.
+**Next:** Step 6 — allocate the CVE via the [`security-allocate-cve`](https://github.com/<tracker>/blob/<default-branch>/.claude/skills/security-allocate-cve/SKILL.md) skill.
 
 Provenance: public PR <pr.url>, author `@<pr.author.login>`.
 Extracted fields: scope=`<scope>`, *PR with the fix*=<pr.url>, *Remediation developer*=<pr.author.name>, *Affected versions*=`<per-scope shape>`, Severity=`Unknown`.
 
-*Reporter credited as* intentionally left blank — public-PR imports do not credit the PR author as the CVE reporter (no responsible disclosure). See the [Reporter credit policy](https://github.com/<tracker>/blob/<tracker-default-branch>/.claude/skills/import-security-issue-from-pr/SKILL.md#reporter-credit-policy-for-public-pr-imports) section of the skill for the rationale.
+*Reporter credited as* intentionally left blank — public-PR imports do not credit the PR author as the CVE reporter (no responsible disclosure). See the [Reporter credit policy](https://github.com/<tracker>/blob/<tracker-default-branch>/.claude/skills/security-import-issue-from-pr/SKILL.md#reporter-credit-policy-for-public-pr-imports) section of the skill for the rationale.
 ```
 
 Zero-whitespace rules from
@@ -430,7 +430,7 @@ Confirmation forms:
   `reporter: Anonymous, severity: Important`.
 - `cancel` / `none` / `hold off` — bail; no tracker created.
 
-Do **not** auto-default to import the way `import-security-issue`
+Do **not** auto-default to import the way `security-import-issues`
 does. This skill is invoked deliberately on a single PR;
 spending one round-trip on explicit confirmation is the right
 trade. The proposal-to-confirmation pause also lets the user
@@ -447,7 +447,7 @@ Sequenced. Each step depends on the previous one's output.
 
 Bypasses the form so the `Security mailing list thread`
 required-field check does not fire. Equivalent to
-[`import-security-issue`'s](../import-security-issue/SKILL.md) Step 7.
+[`security-import-issues`'s](../security-import-issues/SKILL.md) Step 7.
 
 Write the body to a temp file:
 
@@ -612,9 +612,9 @@ Print a one-screen recap:
 Then a one-line hand-off:
 
 > Next: allocate the CVE for this tracker. Run
-> [`allocate-cve`](../allocate-cve/SKILL.md) on `<tracker>#NNN`.
+> [`security-allocate-cve`](../security-allocate-cve/SKILL.md) on `<tracker>#NNN`.
 
-Do **not** auto-invoke `allocate-cve` — CVE allocation is
+Do **not** auto-invoke `security-allocate-cve` — CVE allocation is
 PMC-gated (a non-PMC triager must relay the allocation request
 to a PMC member), and the user may want to batch the allocation
 with other trackers.
@@ -642,7 +642,7 @@ with other trackers.
   verbatim quote from the tracker discussion. See the
   [Confidentiality of `<tracker>`](../../../AGENTS.md#confidentiality-of-the-tracker-repository)
   rule.
-- **Does not run `sync-security-issue` on the new tracker.** The
+- **Does not run `security-sync-issues` on the new tracker.** The
   initial body is already coherent; sync's job (reconciling PR
   state, milestone, assignee against current reality) is not
   needed on a tracker that is being created from those exact
@@ -696,7 +696,7 @@ PR state `OPEN`, milestone `Airflow 3.2.3`. Files all under
 Milestone: `Airflow 3.2.3`. Labels: `airflow`, `pr created`,
 `security issue`. *Affected versions*: `< 3.2.3`. The skill
 proposes everything; on user confirmation, the tracker lands
-`Assessed`, ready for `allocate-cve`.
+`Assessed`, ready for `security-allocate-cve`.
 
 ### Example 3 — Mixed-scope PR (blocker)
 

--- a/.claude/skills/security-import-issues-from-md/SKILL.md
+++ b/.claude/skills/security-import-issues-from-md/SKILL.md
@@ -1,13 +1,13 @@
 ---
-name: import-security-issue-from-md
+name: security-import-issues-from-md
 description: |
   Open one or more `<tracker>` tracking issues from a markdown file
   containing a batch of security findings (typically the output of an
   AI security review or a third-party scanner). Each finding in the
   file becomes one tracker, landing in the `Needs triage` board
   column with the standard issue-template body fields populated from
-  the markdown sections. Unlike `import-security-issue` (Gmail) and
-  `import-security-issue-from-pr` (public PR), there is no inbound
+  the markdown sections. Unlike `security-import-issues` (Gmail) and
+  `security-import-issue-from-pr` (public PR), there is no inbound
   reporter to reply to and no PR to inspect — the file itself is the
   full report.
 when_to_use: |
@@ -19,8 +19,8 @@ when_to_use: |
   third-party SAST report exported as markdown, or a security
   consultant's findings document. Not appropriate when a single
   inbound report is best handled through the Gmail path
-  (`import-security-issue`) or when there is a public PR to anchor
-  the import on (`import-security-issue-from-pr`).
+  (`security-import-issues`) or when there is a public PR to anchor
+  the import on (`security-import-issue-from-pr`).
 ---
 
 <!-- Placeholder convention (see AGENTS.md#placeholder-convention-used-in-skill-files):
@@ -32,7 +32,7 @@ when_to_use: |
      Before running any bash command below, substitute these with the
      concrete values from the adopting project's <project-config>/project.md. -->
 
-# import-security-issue-from-md
+# security-import-issues-from-md
 
 This skill is the **batch on-ramp** of the security-issue handling
 process for the case where the security team has a markdown file
@@ -47,7 +47,7 @@ can run.
 It is the third on-ramp variant alongside the two existing import
 skills:
 
-| | `import-security-issue` | `import-security-issue-from-pr` | `import-security-issue-from-md` |
+| | `security-import-issues` | `security-import-issue-from-pr` | `security-import-issues-from-md` |
 |---|---|---|---|
 | Source | `<security-list>` Gmail / PonyMail thread | `<upstream>` PR URL or number | Markdown file with one or more findings |
 | Reporter | External researcher | None (PR author = remediation developer) | None (the file is the report; usually AI- or scanner-generated) |
@@ -79,7 +79,7 @@ surface the URL points at.
 **Golden rule — propose every finding individually before applying.**
 Even when the input is a 50-finding file, the skill surfaces a
 proposal table listing every finding and waits for explicit
-confirmation. The default disposition mirrors `import-security-issue`:
+confirmation. The default disposition mirrors `security-import-issues`:
 *import all unless rejected upfront* (`skip N` to drop a specific
 candidate). A bare `go` / `proceed` / `yes, all` imports every
 non-rejected candidate. The skill must still render each candidate
@@ -249,7 +249,7 @@ convention; see
 ```
 
 The title is left otherwise untouched — this skill does not run the
-title-normalisation cascade (that lives in `allocate-cve`, by which
+title-normalisation cascade (that lives in `security-allocate-cve`, by which
 point the validity of the report is established).
 
 ### 3b — Issue body
@@ -384,7 +384,7 @@ GitHub rate limits cleanly when serialised.
 
 Bypasses the form so the `Security mailing list thread`
 required-field check does not fire. Same pattern as
-[`import-security-issue-from-pr`'s](../import-security-issue-from-pr/SKILL.md#7a--create-the-tracker-via-gh-api) Step 7a.
+[`security-import-issue-from-pr`'s](../security-import-issue-from-pr/SKILL.md#7a--create-the-tracker-via-gh-api) Step 7a.
 
 Write the body to a temp file (per finding):
 
@@ -565,10 +565,10 @@ Print a one-screen recap:
 Then a one-line hand-off:
 
 > Next: triage each new tracker per Step 3 of the handling
-> process. Run [`sync-security-issue`](../sync-security-issue/SKILL.md)
+> process. Run [`security-sync-issues`](../security-sync-issues/SKILL.md)
 > on `<tracker>#NNN` once the validity discussion progresses.
 
-Do **not** auto-invoke `sync-security-issue` — these trackers are
+Do **not** auto-invoke `security-sync-issues` — these trackers are
 freshly created in `Needs triage` and have nothing to sync until
 the validity discussion produces signal.
 
@@ -586,7 +586,7 @@ the validity discussion produces signal.
 - **Does not allocate CVEs.** A finding tagged `**Severity:** HIGH`
   in the source markdown is *still* unassessed from the security
   team's perspective; the CVE-allocation gate (per
-  [`allocate-cve`](../allocate-cve/SKILL.md)) requires the team's
+  [`security-allocate-cve`](../security-allocate-cve/SKILL.md)) requires the team's
   own validity decision first.
 - **Does not parse markdown formats other than the one documented
   in Step 1.** If the input file uses a different shape (e.g.

--- a/.claude/skills/security-import-issues/SKILL.md
+++ b/.claude/skills/security-import-issues/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: import-security-issue
+name: security-import-issues
 description: |
   Scan <security-list> for reports that have not yet been
   copied into <tracker> as tracking issues, present the proposed
@@ -8,8 +8,8 @@ description: |
   `Needs triage` project-board status and draft a receipt-of-
   confirmation reply to each reporter. This is the first step of the
   handling process: the entry point that converts an inbound email
-  thread into a tracker the rest of the skills (sync-security-issue,
-  fix-security-issue, generate-cve-json) operate on.
+  thread into a tracker the rest of the skills (security-sync-issues,
+  security-fix-issue, generate-cve-json) operate on.
 when_to_use: |
   Invoke when a security team member says "import new reports", "check
   for unimported security@ messages", "import #<threadId>", or when
@@ -30,7 +30,7 @@ when_to_use: |
      Before running any bash command below, substitute these with the
      concrete values from the adopting project's <project-config>/project.md. -->
 
-# import-security-issue
+# security-import-issues
 
 This skill is the **on-ramp** of the security-issue handling process.
 It converts an inbound `<security-list>` email thread into
@@ -189,7 +189,7 @@ tooling / GitHub-notification / mailing-list chatter that isn't a
 report:
 
 Use the canonical candidate-listing query template from
-[`tools/gmail/search-queries.md`](../../../tools/gmail/search-queries.md#import-security-issue--candidate-listing-query);
+[`tools/gmail/search-queries.md`](../../../tools/gmail/search-queries.md#security-import-issues--candidate-listing-query);
 substitute the adopting project's `<security-list-domain>` (Airflow:
 `<security-list-domain>`) and the project's GitHub-notification
 exclusions — both declared in
@@ -448,7 +448,7 @@ duplicates* sub-item in the Step 5 proposal — format:
 
 When at least one **STRONG** match is found (GHSA ID collision), do
 **not** propose creating a new tracker. Instead, propose invoking
-the [`deduplicate-security-issue`](../deduplicate-security-issue/SKILL.md)
+the [`security-deduplicate-issues`](../security-deduplicate-issues/SKILL.md)
 skill to merge the new report's body, reporter credit, and
 mailing-list-thread entries into the existing tracker, and to close
 the new thread's would-be tracker with a `duplicate` label.
@@ -503,7 +503,7 @@ image-scan dump). Skip Step 2b on candidates Step 2a flagged STRONG
 
 **Search recipe — two Gmail calls per candidate, maximum.** The
 query templates and the substitution-values guide live in
-[`tools/gmail/search-queries.md`](../../../tools/gmail/search-queries.md#import-security-issue--prior-rejection-search);
+[`tools/gmail/search-queries.md`](../../../tools/gmail/search-queries.md#security-import-issues--prior-rejection-search);
 in short:
 
 **Backend selection.** When PonyMail MCP is enabled and
@@ -628,7 +628,7 @@ Decide the candidate's class from the root message:
 |---|---|---|
 | **Report**: a reporter describes a vulnerability | The body has a description, a PoC / reproduction steps, an impact claim. Sender is an external address (not `@apache.org`, not on the security-team roster in [`AGENTS.md`](../../../AGENTS.md)). | Proceed to Step 4. |
 | **ASF-security relay**: `security@apache.org` forwarded a report from a reporter via the Foundation channel | Sender is `security@apache.org`. The body almost always starts with the ASF forwarding preamble — *"Dear PMC, The security vulnerability report has been received by the Apache Security Team and is being passed to you for action …"* — and contains the original report underneath (often after a `====GHSA-…` separator when the report came in via GitHub Security Advisory). The preamble is the load-bearing signal: if you see it, treat as a report regardless of what follows. | Proceed to Step 4. **Credit extraction**: the forwarded body usually ends with a `Credit` line naming the discoverer (e.g. *"This vulnerability was discovered and reported by bugbunny.ai"*) — use that verbatim for the Reporter-credited-as placeholder, not the `From:` header (which is always `security@apache.org`). If the report has no credit line, fall back to the GHSA number or to the phrase *"ASF-relayed"* so the credit-preference question can be routed through `@raboof` / Arnout. |
-| **CVE-tool bookkeeping**: an automated or human status-change notification on the ASF CVE tool | Sender is `security@apache.org` (or one of the security-team members acting on behalf of the CVE tool). Subject matches one of: `"CVE-YYYY-NNNNN reserved for airflow"`, `"Comment added on CVE-YYYY-NNNNN"`, `"CVE-YYYY-NNNNN is now READY"`, `"CVE-YYYY-NNNNN is now PUBLIC"`, `"CVE-YYYY-NNNNN is now PUBLISHED"`, `"CVE-YYYY-NNNNN REJECTED"`, or a verbatim `"<state-change>"` line in the body pointing at `cveprocess.apache.org/cve5/CVE-YYYY-NNNNN`. | Do **not** import and do **not** draft a reply — the CVE-tool notifications are consumed by the `sync-security-issue` skill's Step 1e review-comment check. Classify as `cve-tool-bookkeeping` and drop. |
+| **CVE-tool bookkeeping**: an automated or human status-change notification on the ASF CVE tool | Sender is `security@apache.org` (or one of the security-team members acting on behalf of the CVE tool). Subject matches one of: `"CVE-YYYY-NNNNN reserved for airflow"`, `"Comment added on CVE-YYYY-NNNNN"`, `"CVE-YYYY-NNNNN is now READY"`, `"CVE-YYYY-NNNNN is now PUBLIC"`, `"CVE-YYYY-NNNNN is now PUBLISHED"`, `"CVE-YYYY-NNNNN REJECTED"`, or a verbatim `"<state-change>"` line in the body pointing at `cveprocess.apache.org/cve5/CVE-YYYY-NNNNN`. | Do **not** import and do **not** draft a reply — the CVE-tool notifications are consumed by the `security-sync-issues` skill's Step 1e review-comment check. Classify as `cve-tool-bookkeeping` and drop. |
 | **Automated scanner dump**: SAST/DAST tool output, CodeQL/Dependabot alert paste, a string of "issues" with no human PoC | Body is machine-generated, contains multiple unrelated findings, no explanation of Security Model violation | Surface as a candidate with class `automated-scanner` and **do not** propose auto-import. In Step 5 the skill proposes a Gmail draft from the *"Automated scanning results"* canned response in [`canned-responses.md`](../../../<project-config>/canned-responses.md) instead. |
 | **Consolidated multi-issue report**: one email bundles ≥3 unrelated vulnerabilities | The root message has headings like *"Issue 1"*, *"Issue 2"*, each of which would be its own tracker | Surface class `consolidated-multi-issue`; do not auto-import. Propose the "Sending multiple issues in consolidated report" canned reply. |
 | **Media / research-disclosure request**: reporter wants to publish a blog or talk about a finding we already know about | Body asks about disclosure timing, mentions a talk / blog / CVE on another vendor | Surface class `media-request`; do not auto-import. Propose the "When someone submits a media report" canned reply. |
@@ -648,7 +648,7 @@ is missing a vulnerability.
 For each `Report` / `ASF-security relay` candidate, extract the fields
 the [issue template](../../../.github/ISSUE_TEMPLATE/issue_report.yml)
 expects. Most fields the reporter did not explicitly supply stay as
-`_No response_`; the subsequent `sync-security-issue` run will prompt
+`_No response_`; the subsequent `security-sync-issues` run will prompt
 the triager to fill them as the discussion progresses.
 
 The generic body-field schema (role → field-name contract, empty-field
@@ -665,11 +665,11 @@ here.
 | **The issue description** | The root email body, **verbatim** (preserve paragraphs, PoC code blocks, and any quoted sections). The body is private — the triager will copy it into a public CVE description only after Step 13. |
 | **Short public summary for publish** | Leave `_No response_`. Filled by the release manager at Step 13 in sanitised form. |
 | **Affected versions** | Extract `Airflow <version>` / `>= X, < Y` / `<Y` phrases from the body. If the reporter gave only a single version they tested on (e.g. `3.1.5`), record that verbatim; the triager can widen the range later. Leave `_No response_` if no version is mentioned. |
-| **Security mailing list thread** | **Keep the private thread handle, and — if possible — also link the PonyMail archive entry.** The full URL-construction recipe (search URL template, month-token format, user-pastes-back flow, Gmail-threadId fallback) lives in [`tools/gmail/ponymail-archive.md`](../../../tools/gmail/ponymail-archive.md#use-case--import-security-issue); the adopting project's private-search URL template is declared in [`<project-config>/project.md`](../../../<project-config>/project.md#gmail-and-ponymail). Propose the constructed search URL to the user at Step 5, wait for them to paste back the resolved `lists.apache.org/thread/<hash>?<security-list>` URL, and record both the PonyMail URL and the Gmail `threadId` in this field. The URL is **internal-only** — the `generate-cve-json` script will not export it to `references[]` — see the "CVE references must never point at non-public mailing-list threads" section of [`AGENTS.md`](../../../AGENTS.md). |
-| **Public advisory URL** | `_No response_`. Populated at Step 14 by `sync-security-issue` once the advisory is archived. |
+| **Security mailing list thread** | **Keep the private thread handle, and — if possible — also link the PonyMail archive entry.** The full URL-construction recipe (search URL template, month-token format, user-pastes-back flow, Gmail-threadId fallback) lives in [`tools/gmail/ponymail-archive.md`](../../../tools/gmail/ponymail-archive.md#use-case--security-import-issues); the adopting project's private-search URL template is declared in [`<project-config>/project.md`](../../../<project-config>/project.md#gmail-and-ponymail). Propose the constructed search URL to the user at Step 5, wait for them to paste back the resolved `lists.apache.org/thread/<hash>?<security-list>` URL, and record both the PonyMail URL and the Gmail `threadId` in this field. The URL is **internal-only** — the `generate-cve-json` script will not export it to `references[]` — see the "CVE references must never point at non-public mailing-list threads" section of [`AGENTS.md`](../../../AGENTS.md). |
+| **Public advisory URL** | `_No response_`. Populated at Step 14 by `security-sync-issues` once the advisory is archived. |
 | **Reporter credited as** | The reporter's full display name from the email `From:` header (e.g. `Alice Example` from `"Alice Example" <alice@example.com>`). This is a **placeholder** — the receipt-of-confirmation reply in Step 7 asks the reporter to confirm their preferred credit form. |
 | **PR with the fix** | `_No response_`. |
-| **Remediation developer** | `_No response_`. Auto-populated by the `sync-security-issue` skill from the linked PR's author the first time *PR with the fix* is set; manual edits are preserved on subsequent syncs. |
+| **Remediation developer** | `_No response_`. Auto-populated by the `security-sync-issues` skill from the linked PR's author the first time *PR with the fix* is set; manual edits are preserved on subsequent syncs. |
 | **CWE** | `_No response_`. The security team scores CWE independently; a reporter-supplied CWE is informational only (per the *"Reporter-supplied CVSS scores are informational only"* rule in [`AGENTS.md`](../../../AGENTS.md)). Do **not** copy a CWE from the reporter's body into this field. |
 | **Severity** | `Unknown`. Same reason as CWE — the team scores independently. Surface a reporter-supplied CVSS / severity label in the proposal's observed-state for context, but do not use it as the field value. |
 | **CVE tool link** | `_No response_`. Filled at Step 6 once the CVE is allocated. |
@@ -704,7 +704,7 @@ Present all candidates as a single numbered proposal grouped by class:
   canned-response discipline below.
 - **Dropped silently** (class `cve-tool-bookkeeping`): do not even
   surface these to the user — they are consumed by
-  `sync-security-issue` Step 1e. The skill should just report the
+  `security-sync-issues` Step 1e. The skill should just report the
   count in the recap (*"N CVE-tool-bookkeeping emails dropped"*) so
   the user knows the filter is working but is not forced to scroll
   past them.
@@ -1143,5 +1143,5 @@ before presenting.
 - [`canned-responses.md`](../../../<project-config>/canned-responses.md) — the canned
   email bodies the skill uses for receipt-of-confirmation, invalid
   reports, automated scans, etc.
-- [`sync-security-issue`](../sync-security-issue/SKILL.md) — the
+- [`security-sync-issues`](../security-sync-issues/SKILL.md) — the
   follow-up skill that runs on the tracker this one creates.

--- a/.claude/skills/security-invalidate-issue/SKILL.md
+++ b/.claude/skills/security-invalidate-issue/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: invalidate-security-issue
+name: security-invalidate-issue
 description: |
   Close an `<tracker>` tracking issue as invalid: apply the
   `invalid` label, remove the scope label, post a short closing
@@ -8,7 +8,7 @@ description: |
   polite-but-firm reply to the reporter on the original Gmail
   thread explaining the team's reasoning (extracted from the
   tracker's discussion). For trackers opened via
-  `import-security-issue-from-pr`, the email-draft step is skipped
+  `security-import-issue-from-pr`, the email-draft step is skipped
   per the *no outreach to the PR author* rule of that skill.
 when_to_use: |
   Invoke when a security team member says "close NN as invalid",
@@ -31,7 +31,7 @@ when_to_use: |
      Before running any bash command below, substitute these with the
      concrete values from the adopting project's <project-config>/project.md. -->
 
-# invalidate-security-issue
+# security-invalidate-issue
 
 This skill is the **terminal-disposition apply step** for the
 `invalid` close on an `<tracker>` tracker. It does not host the
@@ -45,7 +45,7 @@ closes the tracker, archives the project-board item, and (for
 explaining why.
 
 It is the symmetric counterpart of
-[`allocate-cve`](../allocate-cve/SKILL.md) (apply step for the
+[`security-allocate-cve`](../security-allocate-cve/SKILL.md) (apply step for the
 *valid → CVE* path). Both skills assume the validity decision has
 already been reached; they wire that decision into the tracker
 state in one pass.
@@ -66,7 +66,7 @@ material.
 
 **Golden rule — no outreach to PR-imported tracker authors.** When
 the tracker came in via
-[`import-security-issue-from-pr`](../import-security-issue-from-pr/SKILL.md)
+[`security-import-issue-from-pr`](../security-import-issue-from-pr/SKILL.md)
 (detected by the `N/A — opened from public PR …` sentinel in the
 *Security mailing list thread* body field), there is no reporter
 to notify — the PR author is not the CVE reporter and the public
@@ -167,8 +167,8 @@ the close. Read the *Security mailing list thread* body field:
 | Body field shape | Import path | Email-draft step |
 |---|---|---|
 | Real `lists.apache.org` URL or any URL | `security@`-imported (public-archive case) | Draft on the original Gmail thread; locate via the rollup-comment `threadId` reference. |
-| `No public archive URL — tracked privately on Gmail thread <threadId>` (sentinel from [`import-security-issue`](../import-security-issue/SKILL.md) Step 7) | `security@`-imported (Gmail-only case) | Draft on the named `<threadId>`. |
-| `N/A — opened from public PR <upstream>#<N>; no security@ thread` (sentinel from [`import-security-issue-from-pr`](../import-security-issue-from-pr/SKILL.md)) | PR-imported | **Skip** the email-draft step. No reporter exists to notify. |
+| `No public archive URL — tracked privately on Gmail thread <threadId>` (sentinel from [`security-import-issues`](../security-import-issues/SKILL.md) Step 7) | `security@`-imported (Gmail-only case) | Draft on the named `<threadId>`. |
+| `N/A — opened from public PR <upstream>#<N>; no security@ thread` (sentinel from [`security-import-issue-from-pr`](../security-import-issue-from-pr/SKILL.md)) | PR-imported | **Skip** the email-draft step. No reporter exists to notify. |
 | Empty / `_No response_` / unrecognised | Indeterminate | Surface to the user; ask whether the tracker has a Gmail thread the skill should reply on, or whether the close is silent (no email). |
 
 For `security@`-imported trackers, locate the Gmail `threadId`:
@@ -234,7 +234,7 @@ on the tracker), surface this gap to the user with:
 
 The email draft is built canned-response-spine + augmentation,
 same pattern as
-[`import-security-issue` Step 5](../import-security-issue/SKILL.md).
+[`security-import-issues` Step 5](../security-import-issues/SKILL.md).
 Read [`<project-config>/canned-responses.md`](../../../<project-config>/canned-responses.md)
 and pick the section that best matches the invalidity reasoning
 mined in Step 3:
@@ -292,7 +292,7 @@ Reasoning summary in the [status rollup](#issuecomment-<rollup-id>); a draft rep
 For PR-imported trackers, replace *"a draft reply to the reporter
 is in Gmail awaiting review"* with *"no reporter notification
 (PR-imported tracker — see the import-from-pr skill's
-[Reporter credit policy](https://github.com/<tracker>/blob/<tracker-default-branch>/.claude/skills/import-security-issue-from-pr/SKILL.md#reporter-credit-policy-for-public-pr-imports))"*.
+[Reporter credit policy](https://github.com/<tracker>/blob/<tracker-default-branch>/.claude/skills/security-import-issue-from-pr/SKILL.md#reporter-credit-policy-for-public-pr-imports))"*.
 
 The comment links must resolve once the rollup entry from Step 5e
 has been posted (capture its URL and substitute before posting
@@ -357,7 +357,7 @@ For `security@`-imported trackers:
      ASF-security relay path (the `From:` is a `@apache.org`
      forwarder, not the external reporter), reply to the
      forwarder per the *ASF-security relay* convention in
-     [`import-security-issue` Step 7](../import-security-issue/SKILL.md).
+     [`security-import-issues` Step 7](../security-import-issues/SKILL.md).
    - `ccRecipients`: always includes `<security-list>`
      (`<security-list>` for the adopting project) —
      value comes from
@@ -373,7 +373,7 @@ For `security@`-imported trackers:
      equivalent) with the case-specific reasoning gathered in
      Step 3. Use the same `> **[Inline addition for this
      report]**` block convention as
-     [`import-security-issue` Step 5](../import-security-issue/SKILL.md)
+     [`security-import-issues` Step 5](../security-import-issues/SKILL.md)
      — the user must be able to delete the augmentation
      cleanly without leaving a grammatical orphan.
    - **No mention of `<tracker>`.** The tracker repo is
@@ -420,7 +420,7 @@ upsert recipe). Shape:
 
 **Reporter notification:** <one of:>
 - **`security@`-imported:** Gmail draft `<draftId>` created on thread `<threadId>` — awaiting user review.
-- **PR-imported:** none (no reporter; per [Reporter credit policy](https://github.com/<tracker>/blob/<tracker-default-branch>/.claude/skills/import-security-issue-from-pr/SKILL.md#reporter-credit-policy-for-public-pr-imports)).
+- **PR-imported:** none (no reporter; per [Reporter credit policy](https://github.com/<tracker>/blob/<tracker-default-branch>/.claude/skills/security-import-issue-from-pr/SKILL.md#reporter-credit-policy-for-public-pr-imports)).
 - **Indeterminate import path:** none (flag from Step 2 surfaced; user explicitly chose silent close).
 
 **Project board:** archived (item `<item-id>`).
@@ -453,7 +453,7 @@ entry — and ask:
   reporter is unreachable, GHSA closed, etc.).
 - `cancel` / `none` — bail; nothing applied.
 
-The user must confirm explicitly. Unlike `import-security-issue`,
+The user must confirm explicitly. Unlike `security-import-issues`,
 this skill does **not** default to apply — the close is a
 terminal disposition and the email draft is a public message
 attributed to the security team. One round of confirmation is
@@ -639,7 +639,7 @@ invalidate 355
 ```
 
 Tracker `#355` (the public-PR-imported tracker from the test of
-`import-security-issue-from-pr` against PR 65703). Suppose the
+`security-import-issue-from-pr` against PR 65703). Suppose the
 team later decides the report is not CVE-worthy on its own
 merits. Step 2 detects the `N/A — opened from public PR` sentinel;
 the email-draft step is skipped. Closing comment notes *"no

--- a/.claude/skills/security-sync-issues/SKILL.md
+++ b/.claude/skills/security-sync-issues/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: sync-security-issue
+name: security-sync-issues
 description: |
   Synchronize a security issue in <tracker> with the state of its
   GitHub discussion, the <security-list> mailing thread, and any
@@ -25,7 +25,7 @@ when_to_use: |
      Before running any bash command below, substitute these with the
      concrete values from the adopting project's <project-config>/project.md. -->
 
-# sync-security-issue
+# security-sync-issues
 
 This skill reconciles a single security issue in
 [`<tracker>`](https://github.com/<tracker>) with:
@@ -484,7 +484,7 @@ Process for finding the real reporter and the original thread:
    phrase* from the issue body (a function name, an endpoint, an error
    message) and search Gmail with it, **excluding GitHub notifications**.
    The canonical query template for this search lives in
-   [`tools/gmail/search-queries.md`](../../../tools/gmail/search-queries.md#sync-security-issue--reporter-thread-lookup-by-distinctive-phrase)
+   [`tools/gmail/search-queries.md`](../../../tools/gmail/search-queries.md#security-sync-issues--reporter-thread-lookup-by-distinctive-phrase)
    (the GitHub-notification exclusions used for this project are
    declared in
    [`<project-config>/project.md`](../../../<project-config>/project.md#gmail-and-ponymail)).
@@ -630,7 +630,7 @@ update, label change, or next-step recommendation in Step 2:
 | A tracker is transitioning to `fix released` (per the row below) and *"Affected versions"* still carries the project's pre-release sentinel | Propose replacing the sentinel with the concrete released version per the project's convention; see [`<project-config>/scope-labels.md` — *Affected versions convention by scope*](../../../<project-config>/scope-labels.md#affected-versions-convention-by-scope) for the recipe. After the body update, regenerate the CVE JSON attachment so `versions[]` picks up the bounded `lessThan` shape and the record becomes review-ready. |
 | A release carrying the fix has shipped. Detection is **scope-dependent** — different scope labels on a project can ride different release trains, each with its own *"is it released?"* signal (which artifact registry to consult, what to query, how to map a tracker's milestone to that registry, partial-release edge cases). The per-scope detection recipe lives in [`<project-config>/scope-labels.md` — *Detecting that a fix release has shipped*](../../../<project-config>/scope-labels.md#detecting-that-a-fix-release-has-shipped). The "or an explicit *fix shipped in X.Y.Z* comment" fallback applies across all scopes regardless of the project-specific signal. | Propose swapping `pr merged` → `fix released` (Step 12). This is the release manager's cue to own Steps 13–15 (advisory send → URL capture → Vulnogram PUBLIC → close). **Also propose swapping the assignee from the remediation developer to the release manager** (looked up via the three-source cascade in Step 2c — [`<project-config>/release-trains.md`](../../../<project-config>/release-trains.md) "Release managers for releases currently relevant to the security tracker" → Release Plan wiki → `[RESULT][VOTE]` thread on `dev@`), so the issue list reflects ownership hand-off. See the *Assignee hand-off at the `fix released` transition* paragraph under **Assignees** in Step 2b for the full rule. |
 | GHSA state transition (opened, accepted, published, rejected) in a GHSA-forwarded email | If the GHSA is closed as "not accepted" but the security team accepted the report on `security@`, flag the divergence in the status comment so it is not lost. |
-| Team member saying *"let's also backport to v3-2-test"* / *"please mark X for backport"* | Note the requested backport label on the public PR as an item for Step 9 of the `fix-security-issue` workflow. |
+| Team member saying *"let's also backport to v3-2-test"* / *"please mark X for backport"* | Note the requested backport label on the public PR as an item for Step 9 of the `security-fix-issue` workflow. |
 | Reporter flagging a second distinct vulnerability on the same thread | Surface as an explicit question to the user — it may warrant a separate tracking issue. |
 | Team member classifying severity or CWE independently (not copying the reporter) | Propose setting the `Severity` / `CWE` fields accordingly, with a pointer to the comment that established the assessment. |
 | Stale "pending" text from an earlier status update (e.g. the tracker still says *"CVE allocation pending"* but the issue body now has a CVE) | Propose removing the stale reference from the status-change comment trail. |
@@ -699,7 +699,7 @@ fallback when (a) PonyMail is not enabled / not authenticated,
 before the archive indexes it.
 
 **Search recipe.** Use the CVE-review-comment query templates in
-[`tools/gmail/search-queries.md`](../../../tools/gmail/search-queries.md#sync-security-issue--cve-review-comment-search);
+[`tools/gmail/search-queries.md`](../../../tools/gmail/search-queries.md#security-sync-issues--cve-review-comment-search);
 substitute the adopting project's `<security-list-domain>` (Airflow:
 `<security-list-domain>`, declared in
 [`<project-config>/project.md`](../../../<project-config>/project.md#gmail-and-ponymail))
@@ -866,7 +866,7 @@ the recipe lives in
 Concretely, for each closed-`announced` tracker in this run:
 
 1. Extract the `CVE-YYYY-NNNNN` ID from the tracker's *CVE tool
-   link* body field (same field the allocate-cve and sync skills
+   link* body field (same field the security-allocate-cve and sync skills
    already read).
 2. Call the API:
    ```bash
@@ -1093,7 +1093,7 @@ will change and *why*. Group them by category:
      - **PonyMail HTTP API (fallback).** When PonyMail MCP is
        disabled, unauthenticated, or returns an error, fall back
        to the HTTP API + `list.html` pattern documented in
-       [`tools/gmail/ponymail-archive.md`](../../../tools/gmail/ponymail-archive.md#use-case--sync-security-issue).
+       [`tools/gmail/ponymail-archive.md`](../../../tools/gmail/ponymail-archive.md#use-case--security-sync-issues).
        The adopting project's URL templates are declared in
        [`<project-config>/project.md`](../../../<project-config>/project.md#gmail-and-ponymail)
        (`ponymail_api_url_template`,
@@ -1286,9 +1286,9 @@ will change and *why*. Group them by category:
   **The status record lives in a single rollup comment, not a new
   comment per sync.** The first bot-authored comment on a tracker
   is the **rollup comment** (created by the
-  [`import-security-issue`](../import-security-issue/SKILL.md)
-  skill); every subsequent pass — this sync skill, allocate-cve,
-  deduplicate-security-issue, fix-security-issue — appends a new
+  [`security-import-issues`](../security-import-issues/SKILL.md)
+  skill); every subsequent pass — this sync skill, security-allocate-cve,
+  security-deduplicate-issues, security-fix-issue — appends a new
   *entry* to that comment instead of posting a fresh one. Readers
   scroll one comment instead of fifteen. The full shape, summary
   conventions, upsert recipe, and legacy-comment-folding rules
@@ -1394,7 +1394,7 @@ will change and *why*. Group them by category:
   `**Closing as duplicate`, `**Split for scope clarity`, `**Imported
   on `, `**Process-step escalation`, `**Allocated CVE`, or the
   bare-text `Sync status (` / `Sync YYYY-MM-DD` / `Status update`
-  legacy prefixes, or a content tell like `sync-security-issue
+  legacy prefixes, or a content tell like `security-sync-issues
   skill`). For each hit, the Step 2 proposal carries a numbered
   item: *"fold legacy comment `<url>` (`<YYYY-MM-DD>`, first line
   <first-line>) into the rollup as a `<Action>` entry, then
@@ -1591,7 +1591,7 @@ updates land, based on the process step. Examples:
 
 - *"Step 3: start the CVE-worthiness discussion in a comment on the issue, tagging at least one other security team member."*
 - *"Step 4: escalate to a wider audience — the discussion has been stalled for 34 days. Run the two-phase escalation per [`README.md` — Step 4](../../../README.md#step-4--escalate-stalled-discussions): phase 1 is a short call for ideas to `<private-list>` (no AI analysis), phase 2 — only if phase 1 stays silent for ~7 more days — is an AI-generated design-space analysis that the triager reviews before posting. The agent drafts both phases as proposals; the triager confirms the exact wording + the list of people to `@`-mention before anything is sent."*
-- *"Step 6: allocate a CVE. Run the [`allocate-cve`](../allocate-cve/SKILL.md) skill (it prints the ASF Vulnogram form URL plus a CVE-ready title and wires the allocated ID back into the tracker)."*
+- *"Step 6: allocate a CVE. Run the [`security-allocate-cve`](../security-allocate-cve/SKILL.md) skill (it prints the ASF Vulnogram form URL plus a CVE-ready title and wires the allocated ID back into the tracker)."*
 - *"Step 10: close the private PR at <tracker>#NNN now that <upstream>#NNNN has merged."*
 - *"Step 11: `pr merged` — tracker parked until the release train ships. No action needed from the security team; the next sync run will detect the PyPI / Helm release and propose the `fix released` swap (Step 12)."*
 - *"Step 12: `fix released` — the release carrying the fix is now on PyPI / the Helm registry. Ownership of the issue has transferred to the release manager; the label swap was the hand-off."*
@@ -1658,10 +1658,10 @@ wrong name in a status update leads to the advisory sitting on nobody's
 desk.
 
 **If a CVE needs to be allocated**, always point the user at the
-[`allocate-cve`](../allocate-cve/SKILL.md) skill explicitly on its own
+[`security-allocate-cve`](../security-allocate-cve/SKILL.md) skill explicitly on its own
 line so the handoff is unambiguous:
 
-> Allocate a CVE via the [`allocate-cve`](../allocate-cve/SKILL.md)
+> Allocate a CVE via the [`security-allocate-cve`](../security-allocate-cve/SKILL.md)
 > skill. It opens the ASF Vulnogram form at
 > <https://cveprocess.apache.org/allocatecve>, pre-computes a CVE-ready
 > title (stripped of `<vendor>: <product>:` (e.g. `Apache Airflow:`) / `[ Security Report ]` / version

--- a/.claude/skills/setup-secure-config/SKILL.md
+++ b/.claude/skills/setup-secure-config/SKILL.md
@@ -21,8 +21,8 @@ when_to_use: |
   secure-config wiring yet. Also appropriate after a fresh OS
   install / new dev machine where `~/.claude/scripts/` is empty.
   Do **not** invoke when the secure setup is already in place — use
-  `verify-secure-config` (to confirm completeness) or
-  `update-secure-config` (to refresh against the framework's
+  `setup-verify-secure-config` (to confirm completeness) or
+  `setup-update-secure-config` (to refresh against the framework's
   latest) instead.
 ---
 
@@ -102,23 +102,23 @@ sub-step with the user. The doc names are the source of truth; the
 skill is the runner.
 
 For the verification step at the end, hand off to the
-`verify-secure-config` skill rather than re-walking the checklist
+`setup-verify-secure-config` skill rather than re-walking the checklist
 inline.
 
 ## After the install lands
 
 Suggest two follow-up routines the user can wire later:
 
-- `verify-secure-config` — re-run after every Claude Code upgrade
+- `setup-verify-secure-config` — re-run after every Claude Code upgrade
   or settings-file edit, to confirm denials still fire as
   expected. The "did a denial silently turn into an allow?"
   signal is exactly what this skill exists for.
-- `update-secure-config` — periodic check for framework
+- `setup-update-secure-config` — periodic check for framework
   updates, pinned-tool upgrade candidates, and drift between the
   installed user-scope copies and the framework's
   source-of-truth. Recommend a per-Claude-Code-upgrade or
   monthly cadence, whichever comes first.
 
 If the user has the `~/.claude-config` sync repo in place, also
-mention `sync-shared-config` for committing + pushing local
+mention `setup-sync-shared-config` for committing + pushing local
 modifications to the shared scripts.

--- a/.claude/skills/setup-sync-shared-config/SKILL.md
+++ b/.claude/skills/setup-sync-shared-config/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: sync-shared-config
+name: setup-sync-shared-config
 description: |
   Commit + push the user's shared Claude config to the
   `~/.claude-config` private dotfile-style sync repo (per
@@ -18,7 +18,7 @@ when_to_use: |
   `~/.claude-config/scripts/*.sh`,
   `~/.claude-config/CLAUDE.md`,
   `~/.claude-config/commands/*`, the `sync.sh` itself, etc. Also
-  appropriate after the `update-secure-config` skill surfaces
+  appropriate after the `setup-update-secure-config` skill surfaces
   drift on a script that the user keeps in `~/.claude-config/` and
   the user wants the framework's update propagated to every
   machine the sync repo is checked out on.
@@ -27,7 +27,7 @@ when_to_use: |
 <!-- Placeholder convention (see AGENTS.md#placeholder-convention-used-in-skill-files):
      <project-config> → adopting project's `.apache-steward/` directory -->
 
-# sync-shared-config
+# setup-sync-shared-config
 
 This skill propagates local edits in `~/.claude-config/` to the
 sync repo's remote, so other machines can pull them. It is the

--- a/.claude/skills/setup-update-secure-config/SKILL.md
+++ b/.claude/skills/setup-update-secure-config/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: update-secure-config
+name: setup-update-secure-config
 description: |
   Surface drift between the user's installed secure agent setup and
   the framework's latest. Reports framework-checkout updates
@@ -24,7 +24,7 @@ when_to_use: |
 <!-- Placeholder convention (see AGENTS.md#placeholder-convention-used-in-skill-files):
      <project-config> → adopting project's `.apache-steward/` directory -->
 
-# update-secure-config
+# setup-update-secure-config
 
 This skill is the **drift report** for an already-installed secure
 setup. It walks the canonical update-check at
@@ -55,7 +55,7 @@ any change.
   changes into `~/.claude-config/scripts/`). Report each
   separately.
 - **Re-verify after surfacing the drift.** Run the same denial
-  checks `verify-secure-config` runs (one Bash invocation per
+  checks `setup-verify-secure-config` runs (one Bash invocation per
   command, not chained), so a regression that turned a deny into
   an allow shows up as part of the update report. A *passing*
   verification at the end of an update report is the signal that
@@ -100,7 +100,7 @@ Walk each:
    the user does not have; do not auto-merge.
 5. **Re-verify.** Run the three denial commands as standalone
    Bash invocations (not chained — see
-   [verify-secure-config](../verify-secure-config/SKILL.md) for
+   [setup-verify-secure-config](../setup-verify-secure-config/SKILL.md) for
    why). Report any newly-allowed call as a regression that
    warrants attention.
 
@@ -113,7 +113,7 @@ If something is out-of-date or has drifted, name the concrete
 follow-up:
 
 - Framework checkout behind → run
-  [`upgrade-apache-steward`](../upgrade-apache-steward/SKILL.md),
+  [`setup-upgrade-steward`](../setup-upgrade-steward/SKILL.md),
   which performs the `git pull --ff-only` after the same
   pre-flight checks this skill recommends, surfaces what
   arrived, and reminds the user to handle the parent-tracker
@@ -123,7 +123,7 @@ follow-up:
 - User-scope script drift → re-`cp` from the framework checkout,
   or — if the script lives in `~/.claude-config/` and the user
   wants the change propagated to other machines — invoke
-  `sync-shared-config` to commit + push.
+  `setup-sync-shared-config` to commit + push.
 - Settings.json shape drift → the user merges the new
   framework block into their tracker's `.claude/settings.json`
   by hand (the section to copy from is documented in

--- a/.claude/skills/setup-upgrade-steward/SKILL.md
+++ b/.claude/skills/setup-upgrade-steward/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: upgrade-apache-steward
+name: setup-upgrade-steward
 description: |
   Pull the user's local `airflow-steward` framework checkout to the
   latest `origin/main` and surface what changed — the commits
@@ -8,7 +8,7 @@ description: |
   `secure-agent-setup.md`, `secure-agent-internals.md`,
   `pinned-versions.toml`), and the next-step recommendation. Never
   applies user-side propagation itself — that is the job of
-  `update-secure-config` (drift report) and the framework
+  `setup-update-secure-config` (drift report) and the framework
   maintainer's manual re-`cp` of any user-scope script copies that
   drifted. Refuses to act if the working tree is dirty or the
   branch has unpushed commits, since both states are signs the
@@ -21,8 +21,8 @@ when_to_use: |
   to a periodic update routine — recommended cadence per
   secure-agent-setup.md is once per Claude Code upgrade or once
   a month, whichever comes first; this skill is the *first* step
-  of that routine, with `update-secure-config` (read-only drift
-  report) and any subsequent re-`cp` / `/sync-shared-config` runs
+  of that routine, with `setup-update-secure-config` (read-only drift
+  report) and any subsequent re-`cp` / `/setup-sync-shared-config` runs
   following on. Do **not** invoke when the user has uncommitted
   changes in the framework checkout or when they have local
   commits ahead of origin — the skill will refuse and surface
@@ -32,7 +32,7 @@ when_to_use: |
 <!-- Placeholder convention (see AGENTS.md#placeholder-convention-used-in-skill-files):
      <project-config> → adopting project's `.apache-steward/` directory -->
 
-# upgrade-apache-steward
+# setup-upgrade-steward
 
 This skill is the **upstream** half of the framework's update flow.
 It moves the user's local `airflow-steward` checkout forward to
@@ -40,7 +40,7 @@ It moves the user's local `airflow-steward` checkout forward to
 this upgrade means for the user's *installed* secure setup
 (user-scope script copies, project `.claude/settings.json`, pinned
 tool versions on the host) — is the
-[`update-secure-config`](../update-secure-config/SKILL.md) skill,
+[`setup-update-secure-config`](../setup-update-secure-config/SKILL.md) skill,
 which is read-only and runs naturally as the next step.
 
 ## Golden rules
@@ -78,7 +78,7 @@ which is read-only and runs naturally as the next step.
   `~/.claude/`. It does not edit any project's
   `.claude/settings.json`. It does not bump installed tool
   versions on the host. All of those are surfaced by the
-  follow-on `update-secure-config` skill, which is read-only by
+  follow-on `setup-update-secure-config` skill, which is read-only by
   design — the user decides what to apply.
 
 ## Walk-through
@@ -145,13 +145,13 @@ which is read-only and runs naturally as the next step.
      the new framework. Mention the post-merge hook documented in
      `README.md → Adopting the framework` for users who want this
      automatic. Suggest
-     [`verify-apache-steward`](../verify-apache-steward/SKILL.md)
+     [`setup-verify-steward`](../setup-verify-steward/SKILL.md)
      to confirm the parent tracker's submodule integration is
      still aligned (the skill catches the `+` "submodule HEAD
      ahead of parent index" state directly).
 
    - **Always after a successful pull**, recommend
-     [`update-secure-config`](../update-secure-config/SKILL.md)
+     [`setup-update-secure-config`](../setup-update-secure-config/SKILL.md)
      to surface user-side drift the upgrade may have introduced
      (new `permissions.deny` patterns the user's tracker repo
      hasn't picked up, drift between user-scope `~/.claude/`
@@ -165,7 +165,7 @@ which is read-only and runs naturally as the next step.
      re-`cp`'ing the updated framework scripts over the
      `~/.claude-config/scripts/` (or
      `~/.claude/agent-isolation/`) copies and then running
-     [`sync-shared-config`](../sync-shared-config/SKILL.md) to
+     [`setup-sync-shared-config`](../setup-sync-shared-config/SKILL.md) to
      push the propagated changes to the sync remote so other
      machines pick them up.
 
@@ -195,7 +195,7 @@ which is read-only and runs naturally as the next step.
   [Bumping a pinned version](../../../secure-agent-setup.md#bumping-a-pinned-version)
   flow.
 - Not for syncing user-scope edits to `~/.claude-config`. That
-  is `sync-shared-config`'s job.
+  is `setup-sync-shared-config`'s job.
 
 ## Failure modes
 

--- a/.claude/skills/setup-verify-secure-config/SKILL.md
+++ b/.claude/skills/setup-verify-secure-config/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: verify-secure-config
+name: setup-verify-secure-config
 description: |
   Walk the verification checklist documented in
   `secure-agent-setup.md` and report ✓ done / ✗ missing / ⚠ partial
@@ -24,7 +24,7 @@ when_to_use: |
 <!-- Placeholder convention (see AGENTS.md#placeholder-convention-used-in-skill-files):
      <project-config> → adopting project's `.apache-steward/` directory -->
 
-# verify-secure-config
+# setup-verify-secure-config
 
 This skill is the **assertion** layer over the secure setup. It
 runs the checklist documented in
@@ -38,7 +38,7 @@ and reports each check's status to the user with concrete evidence
   script, install any package, or modify any settings. If a check
   surfaces a missing or misconfigured piece, surface the gap and
   point at the install path (`setup-secure-config` for a missing
-  install, `update-secure-config` for drift); do not auto-fix.
+  install, `setup-update-secure-config` for drift); do not auto-fix.
 - **Report every check, even on early failure.** Do not stop at
   the first ✗ — the value of the report is in the full picture.
   If check 3 fails, continue to checks 4 / 5 / 6 / 7 anyway and
@@ -115,7 +115,7 @@ without invoking it:
   install pieces).
 - ⚠ on check 5 (pinned-version drift) or any user-scope script
   copy that is older than the framework's source-of-truth →
-  `update-secure-config`.
+  `setup-update-secure-config`.
 - The user-scope script copies live under `~/.claude-config/`
   for users who maintain that sync repo; uncommitted local edits
-  there → `sync-shared-config`.
+  there → `setup-sync-shared-config`.

--- a/.claude/skills/setup-verify-steward/SKILL.md
+++ b/.claude/skills/setup-verify-steward/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: verify-apache-steward
+name: setup-verify-steward
 description: |
   Verify that the `apache-steward` framework is correctly integrated
   into the user's adopter tracker repository — `.apache-steward/`
@@ -31,7 +31,7 @@ when_to_use: |
 <!-- Placeholder convention (see AGENTS.md#placeholder-convention-used-in-skill-files):
      <project-config> → adopting project's `.apache-steward/` directory -->
 
-# verify-apache-steward
+# setup-verify-steward
 
 This skill is the **integration check** for adopters who consume
 the `apache-steward` framework as a git submodule of their
@@ -41,11 +41,11 @@ It confirms the framework is wired in correctly so the rest of
 the framework's skills and tools resolve from the right paths.
 
 The companion skill is
-[`verify-secure-config`](../verify-secure-config/SKILL.md), which
+[`setup-verify-secure-config`](../setup-verify-secure-config/SKILL.md), which
 verifies the *secure-agent setup* (sandbox, hooks, status line,
 clean-env wrapper). The two are independent: an adopter can have
 the framework correctly integrated as a submodule but no secure
-setup wired (verify-secure-config catches that), or have the
+setup wired (setup-verify-secure-config catches that), or have the
 secure setup wired against a stale / un-init'd framework
 submodule (this skill catches that). Run both for a complete
 adopter-side health check.
@@ -125,7 +125,7 @@ inside `project.md` to enumerate unfilled fields. Distinguish:
 - ⚠ for unfilled fields that are convenience-only or apply
   only to optional flows — mailing-list addresses (only the
   import / sync skills need them), CVE tooling URLs (only
-  the allocate-cve skill), Gmail / PonyMail OAuth flags
+  the security-allocate-cve skill), Gmail / PonyMail OAuth flags
   (only the email-using skills).
 
 Print the unfilled-field list with line numbers so the user
@@ -183,7 +183,7 @@ output. The leading character classifies the state:
 - `+` prefix = the submodule's `HEAD` is *ahead of* the SHA
   recorded in the parent's index. The user has either pulled
   the framework directly without committing the new pointer
-  in the parent (`upgrade-apache-steward` skill mentions this
+  in the parent (`setup-upgrade-steward` skill mentions this
   case), or has hand-checked-out a different SHA. Surface as
   ⚠ — the framework still works, but the parent will record
   a different pointer on the next commit. Remediation: commit
@@ -231,7 +231,7 @@ step list, ordered most → least urgent:
 - ⚠ on check 5 (`+` prefix, pointer ahead) → name the
   remediation choice (commit the new pointer in the parent,
   or reset the submodule). The
-  [`upgrade-apache-steward`](../upgrade-apache-steward/SKILL.md)
+  [`setup-upgrade-steward`](../setup-upgrade-steward/SKILL.md)
   skill is the natural place this state usually originates.
 - ⚠ on check 6 (no post-merge hook) → print the install
   recipe and tell the user this is optional ergonomics.
@@ -240,7 +240,7 @@ step list, ordered most → least urgent:
   them when the user adopts those skills.
 
 Recommend
-[`verify-secure-config`](../verify-secure-config/SKILL.md) as
+[`setup-verify-secure-config`](../setup-verify-secure-config/SKILL.md) as
 the natural next-step skill if the user has not run it yet —
 the two skills are independent but together cover the
 adopter-side health check.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -322,7 +322,7 @@ and the failure mode is silent. Make `git submodule update --init
 into a post-merge hook (`.git/hooks/post-merge` →
 `#!/bin/sh\nexec git submodule update --init --recursive`). Same
 rule applies to the framework's own
-[`upgrade-apache-steward`](.claude/skills/upgrade-apache-steward/SKILL.md)
+[`setup-upgrade-steward`](.claude/skills/setup-upgrade-steward/SKILL.md)
 skill: when invoked from inside an adopter tracker, it reminds
 the user to follow up with submodule update on the parent.
 
@@ -505,7 +505,7 @@ When editing or generating any text destined for a public audience,
 the load-bearing scrub is for **content** that came from the
 tracker (severity scores, CWE assignments, label transitions, comment
 quotes), not for the URL itself. The
-`fix-security-issue` skill's pre-push grep follows this convention
+`security-fix-issue` skill's pre-push grep follows this convention
 — it warns on `CVE-`, *"security fix"*, *"vulnerability"*,
 *"advisory"*, and verbatim-content patterns, but it does **not**
 flag a bare `<tracker>` URL or `#NNN` reference on its own.
@@ -680,7 +680,7 @@ Concretely, the issue template has two separate fields for this:
   been sent (Step 13 of the process). This is the URL that ends up
   as the `vendor-advisory` reference on the public CVE record.
   Before the advisory is sent the field stays empty; the
-  `sync-security-issue` skill scans the users-list archive for the
+  `security-sync-issues` skill scans the users-list archive for the
   CVE ID and proposes populating the field automatically once the
   advisory lands.
 
@@ -794,11 +794,11 @@ them is a **request or a fact**, not a briefing:
   patience…"). A plain *"Thanks,"* / *"Regards,"* is enough.
 - Any open question that was already asked on the thread and is
   still awaiting a reply (see the "Do not re-ask" rule in the
-  `sync-security-issue` skill — pinging twice gets us blocklisted).
+  `security-sync-issues` skill — pinging twice gets us blocklisted).
 
 **Exception: the initial receipt-of-confirmation reply.** The first
 message the security team sends to a new reporter, drafted by the
-`import-security-issue` skill, uses the *"Confirmation of receiving
+`security-import-issues` skill, uses the *"Confirmation of receiving
 the report"* canned response from
 [`<project-config>/canned-responses.md`](<project-config>/canned-responses.md)
 **verbatim**. That template is longer because it introduces the process
@@ -830,7 +830,7 @@ directly. The drafting rules for that case — different `To:`, same
 threading behaviour (prefer `threadId`, fall back to the inbound
 subject), terse body — live in
 [`tools/gmail/asf-relay.md`](tools/gmail/asf-relay.md). The detection
-signals the `import-security-issue` skill uses to classify a candidate
+signals the `security-import-issues` skill uses to classify a candidate
 as a relay live in that skill's Step 3.
 
 ### Point reporters to the project's Security Model, don't re-explain it
@@ -853,7 +853,7 @@ repository) rather than duplicated in the canned responses.
 
 Whenever a CVE ID appears in text this repository produces — status
 comments on `<tracker>` issues, proposals from the
-`sync-security-issue` skill, recap messages, canned-response drafts
+`security-sync-issues` skill, recap messages, canned-response drafts
 to reporters, internal notes — render it as a **clickable link**,
 not as bare text. The canonical link is the adopting project's CVE-tool
 record URL, which any security team member can click through to the
@@ -994,7 +994,7 @@ reporter emails, advisory references). What still must not appear
 publicly is the *contents* the link points at — comment quotes,
 labels, body excerpts, severity assessments — and, before the
 advisory ships, the security framing of the change. The scrubbing
-grep the `fix-security-issue` skill runs before pushing anything
+grep the `security-fix-issue` skill runs before pushing anything
 public flags content leaks (CVE IDs, *"vulnerability"*, *"security
 fix"* phrasing, verbatim tracker quotes); a bare tracker URL or
 `#NNN` reference on its own does not trigger the scrub.
@@ -1024,7 +1024,7 @@ in
 The authoritative roster and the release-manager rotation list live in
 [`<project-config>/release-trains.md`](<project-config>/release-trains.md).
 
-The sync-security-issue and fix-security-issue skills should render
+The security-sync-issues and security-fix-issue skills should render
 every maintainer / security-team / release-manager reference in the
 status comments they post as an `@` handle. Before publishing a status
 comment, the skills must grep for names of known people and flag any
@@ -1052,7 +1052,7 @@ commit message or an ad-hoc comment.
 
 Currently available:
 
-- [`import-security-issue`](.claude/skills/import-security-issue/SKILL.md) —
+- [`security-import-issues`](.claude/skills/security-import-issues/SKILL.md) —
   the on-ramp of the process. Scans `<security-list>` for threads
   that have not yet been copied into `<tracker>` as tracking issues,
   classifies each candidate (real report vs. automated-scan / consolidated /
@@ -1065,7 +1065,7 @@ Currently available:
   Gmail `threadId`. This is Step 2 of the handling process in
   [`README.md`](README.md) and the first skill a triager runs in a morning
   sweep.
-- [`deduplicate-security-issue`](.claude/skills/deduplicate-security-issue/SKILL.md) —
+- [`security-deduplicate-issues`](.claude/skills/security-deduplicate-issues/SKILL.md) —
   merges two tracking issues that describe the same root-cause
   vulnerability discovered independently by different reporters. Copies
   the dropped tracker's body verbatim into the kept tracker as a
@@ -1074,15 +1074,15 @@ Currently available:
   tracker's CVE JSON attachment so both finders land in `credits[]`, and
   closes the dropped tracker with the `duplicate` label. Refuses to
   operate across different scope labels (those require a scope split
-  via `sync-security-issue`, not a dedupe). Typically invoked after
-  `import-security-issue` Step 2a surfaces a STRONG GHSA-ID match with
+  via `security-sync-issues`, not a dedupe). Typically invoked after
+  `security-import-issues` Step 2a surfaces a STRONG GHSA-ID match with
   an existing tracker.
-- [`sync-security-issue`](.claude/skills/sync-security-issue/SKILL.md) —
+- [`security-sync-issues`](.claude/skills/security-sync-issues/SKILL.md) —
   reconciles a security issue with its GitHub discussion, its
   `<security-list>` mail thread, and any fixing PRs; proposes label,
   milestone, field, and draft-email updates; and prompts the user to confirm each
   change before applying it. Points the user at
-  [`allocate-cve`](.claude/skills/allocate-cve/SKILL.md) when a CVE is
+  [`security-allocate-cve`](.claude/skills/security-allocate-cve/SKILL.md) when a CVE is
   needed. **At the end of every run** it also invokes
   [`generate-cve-json`](tools/vulnogram/generate-cve-json/SKILL.md) with
   `--attach` to refresh the CVE JSON attachment on the tracking issue (auto-
@@ -1090,7 +1090,7 @@ Currently available:
   in the *PR with the fix* body field), so the attached JSON stays in
   lock-step with the issue body. Skipped only when no CVE has been allocated
   yet, or when the issue has been closed as invalid / not-CVE-worthy / duplicate.
-- [`allocate-cve`](.claude/skills/allocate-cve/SKILL.md) — walks the
+- [`security-allocate-cve`](.claude/skills/security-allocate-cve/SKILL.md) — walks the
   user through allocating a CVE via the adopting project's CVE-tool
   allocation form (for Airflow, ASF Vulnogram at
   <https://cveprocess.apache.org/allocatecve>; see
@@ -1111,11 +1111,11 @@ Currently available:
   a collapsed status-change comment, regenerates the CVE JSON attachment
   in the body via `generate-cve-json --attach`, and (when relevant)
   drafts a reporter status update on the original mail thread. **Always
-  hands off to `sync-security-issue`** at the end so the allocation-
+  hands off to `security-sync-issues`** at the end so the allocation-
   triggered changes are reconciled with the milestone, assignee, fix-PR
   state, and reporter-thread state in one continuous flow.
-- [`fix-security-issue`](.claude/skills/fix-security-issue/SKILL.md) — runs
-  `sync-security-issue` first, then analyses the issue discussion to decide
+- [`security-fix-issue`](.claude/skills/security-fix-issue/SKILL.md) — runs
+  `security-sync-issues` first, then analyses the issue discussion to decide
   whether the reported problem is easily fixable (clear consensus, small scope,
   known location). If it is, proposes an implementation plan, writes the change
   in the user's local `<upstream>` clone (path from
@@ -1165,4 +1165,4 @@ When adding a new skill:
 - [`tools/github/`](tools/github/) — GitHub tool adapter: `tool.md` (overview), `operations.md` (`gh` CLI / API catalogue), `issue-template.md` (body-field schema), `labels.md` (lifecycle-label taxonomy), `project-board.md` (Projects V2 GraphQL).
 - [`tools/gmail/`](tools/gmail/) — Gmail tool adapter: `tool.md` (overview), `operations.md` (MCP catalogue + no-update limitation), `threading.md` (prefer-`threadId`-else-subject-fallback rule), `asf-relay.md` (ASF-security-relay drafting), `search-queries.md` (query templates), `ponymail-archive.md` (ASF PonyMail URL construction).
 - [`tools/vulnogram/`](tools/vulnogram/) — Vulnogram (ASF CVE tool) adapter: `tool.md` (overview), `allocation.md` (PMC-gated allocation flow), `record.md` (record URLs + `#source` paste + `DRAFT`/`REVIEW`/`PUBLIC` state machine + reviewer-comment signal), `generate-cve-json/` (CVE-5.x JSON generator — Python project).
-- [`tools/cve-org/`](tools/cve-org/) — public CVE registry adapter: `tool.md` covers the MITRE CVE Services API v2 `check-published` recipe, used by `sync-security-issue` to verify that a closed tracker's CVE has propagated from the CNA tool to cve.org before sending the reporter the final *"CVE is live"* email.
+- [`tools/cve-org/`](tools/cve-org/) — public CVE registry adapter: `tool.md` covers the MITRE CVE Services API v2 `check-published` recipe, used by `security-sync-issues` to verify that a closed tracker's CVE has propagated from the CNA tool to cve.org before sending the reporter the final *"CVE is live"* email.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -90,13 +90,13 @@ four — no hard-coded project assumptions anywhere.
 │
 ├── .claude/
 │   └── skills/                    # Agent workflows (invoked via the Skill tool)
-│       ├── import-security-issue/SKILL.md
-│       ├── import-security-issue-from-pr/SKILL.md
-│       ├── sync-security-issue/SKILL.md
-│       ├── allocate-cve/SKILL.md
-│       ├── fix-security-issue/SKILL.md
-│       ├── deduplicate-security-issue/SKILL.md
-│       └── invalidate-security-issue/SKILL.md
+│       ├── security-import-issues/SKILL.md
+│       ├── security-import-issue-from-pr/SKILL.md
+│       ├── security-sync-issues/SKILL.md
+│       ├── security-allocate-cve/SKILL.md
+│       ├── security-fix-issue/SKILL.md
+│       ├── security-deduplicate-issues/SKILL.md
+│       └── security-invalidate-issue/SKILL.md
 │
 ├── config/                        # Runtime configuration layer
 │   ├── README.md                  # Configuration tutorial + placeholder rule
@@ -268,8 +268,8 @@ uv run ruff format             # auto-format (check-only in CI)
 uv run mypy                    # type-check
 ```
 
-The package is invoked by the [`sync-security-issue`](.claude/skills/sync-security-issue/SKILL.md)
-and [`allocate-cve`](.claude/skills/allocate-cve/SKILL.md) skills via
+The package is invoked by the [`security-sync-issues`](.claude/skills/security-sync-issues/SKILL.md)
+and [`security-allocate-cve`](.claude/skills/security-allocate-cve/SKILL.md) skills via
 `uv run --project tools/vulnogram/generate-cve-json generate-cve-json
 <N> --attach` from the repo root — that is the canonical invocation
 any new behaviour has to stay compatible with.

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
   - [3. GitHub connection (GitHub MCP / `gh` CLI)](#3-github-connection-github-mcp--gh-cli)
   - [4. PMC membership (only for CVE allocation)](#4-pmc-membership-only-for-cve-allocation)
   - [5. Browser (for the human-click steps)](#5-browser-for-the-human-click-steps)
-  - [6. Local `<upstream>` clone (only for `fix-security-issue`)](#6-local-upstream-clone-only-for-fix-security-issue)
+  - [6. Local `<upstream>` clone (only for `security-fix-issue`)](#6-local-upstream-clone-only-for-security-fix-issue)
   - [7. `uv` (for `generate-cve-json`)](#7-uv-for-generate-cve-json)
 - [Shared conventions](#shared-conventions)
   - [Keeping the reporter informed](#keeping-the-reporter-informed)
@@ -140,7 +140,7 @@ section — a browser and your `<tracker>` collaborator access are
 enough.
 
 If you plan to **run any of the agent skills** (`import`, `sync`,
-`allocate-cve`, `fix`, `generate-cve-json`, `deduplicate`) — typically
+`security-allocate-cve`, `fix`, `generate-cve-json`, `deduplicate`) — typically
 as a rotational triager, remediation developer, or release manager —
 check the following setup **before** invoking a skill. Each skill also
 runs a short Step 0 pre-flight against the same list and stops with a
@@ -169,7 +169,7 @@ configs.
 
 ### 2. Email connection (Gmail MCP, today)
 
-The import, sync, and allocate-cve skills **read the security-list
+The import, sync, and security-allocate-cve skills **read the security-list
 mail thread** associated with each tracker and draft replies on that
 thread. Today this goes through the
 [Claude Gmail MCP](https://docs.anthropic.com/en/docs/build-with-claude/mcp)
@@ -188,8 +188,8 @@ without connecting their personal Gmail — authenticating directly
 against ASF credentials (and, eventually, the ASF's new MFA) will be
 sufficient. Until then, Gmail MCP is the way.
 
-**Without this connection:** `import-security-issue` cannot find new
-reports, `sync-security-issue` cannot reconcile status with the mail
+**Without this connection:** `security-import-issues` cannot find new
+reports, `security-sync-issues` cannot reconcile status with the mail
 thread, and no skill can draft replies to reporters. The skills will
 refuse to start and tell you to configure the MCP first.
 
@@ -204,7 +204,7 @@ CLI directly for some calls. What the skills need:
   security-team roster is maintained per-project; for the active
   project see
   [`<project-config>/release-trains.md`](<project-config>/release-trains.md#security-team-roster).
-- For `fix-security-issue`: a fork of `<upstream>` on your GitHub
+- For `security-fix-issue`: a fork of `<upstream>` on your GitHub
   account (the skill pushes a branch there before opening the PR
   via `gh pr create --web`).
 
@@ -212,7 +212,7 @@ CLI directly for some calls. What the skills need:
 
 The adopting project's CVE-tool allocation form is **PMC-gated** on
 the server side — only the project's PMC members can submit a CVE
-allocation. Non-PMC triagers can still run `allocate-cve`; the
+allocation. Non-PMC triagers can still run `security-allocate-cve`; the
 skill detects this up front (it asks *"are you a PMC member of
 `<PROJECT>`?"*) and produces a relay message for a PMC member to
 click through instead. For Airflow the concrete tool is ASF's
@@ -231,7 +231,7 @@ paste, the `gh pr create --web` compose view. The skills prepare
 the URL and the exact text to paste and hand it off to the browser;
 they do not try to automate those clicks.
 
-### 6. Local `<upstream>` clone (only for `fix-security-issue`)
+### 6. Local `<upstream>` clone (only for `security-fix-issue`)
 
 The fix skill writes the change in your local clone, runs local
 checks and tests, pushes a branch to your fork, and opens a PR via
@@ -326,19 +326,19 @@ the tracker.
 A typical triage sweep runs three skills in order:
 
 1. **`import new reports`** —
-   [`import-security-issue`](.claude/skills/import-security-issue/SKILL.md)
+   [`security-import-issues`](.claude/skills/security-import-issues/SKILL.md)
    scans `<security-list>` for threads not yet imported,
    classifies each candidate (real report vs. automated-scan / consolidated /
    media / spam), and proposes a tracker per valid report plus a
    receipt-of-confirmation Gmail draft. See
    [Step 2](#step-2--import-the-report).
 2. **`sync all`** —
-   [`sync-security-issue`](.claude/skills/sync-security-issue/SKILL.md)
+   [`security-sync-issues`](.claude/skills/security-sync-issues/SKILL.md)
    reconciles every open tracker against its mail thread, the fix PR, the
    release train, and the users@ archive. Proposes label / milestone /
    assignee / body changes in one pass.
 3. **`allocate CVE for issue #N`** —
-   [`allocate-cve`](.claude/skills/allocate-cve/SKILL.md) when a report has
+   [`security-allocate-cve`](.claude/skills/security-allocate-cve/SKILL.md) when a report has
    been assessed as valid. See [Step 6](#step-6--allocate-the-cve).
 
 Nothing is applied without an explicit confirmation — each skill is a
@@ -355,7 +355,7 @@ When the report is confirmed valid, apply exactly one scope label from
 the project's scope set (declared in
 [`<project-config>/scope-labels.md`](<project-config>/scope-labels.md)).
 If a report affects more than one scope, split into per-scope trackers
-before allocation — the `sync-security-issue` skill surfaces this as
+before allocation — the `security-sync-issues` skill surfaces this as
 a blocker. See
 [Step 5](#step-5--land-the-validinvalid-consensus).
 
@@ -364,37 +364,37 @@ If discussion stalls for about 30 days, escalate to a broader audience per
 
 ### Allocating the CVE
 
-Use [`allocate-cve`](.claude/skills/allocate-cve/SKILL.md). The skill asks up
+Use [`security-allocate-cve`](.claude/skills/security-allocate-cve/SKILL.md). The skill asks up
 front whether you are on the PMC; if not, it reshapes the recipe into an
 ``@``-mention relay message you forward to a PMC member on the tracker or on
 the `<security-list>` thread. Once the allocated `CVE-YYYY-NNNNN`
 is pasted back, the skill wires it into the tracker in one pass (the *CVE
 tool link* body field, the `cve allocated` label, a status-change comment, a
-refreshed CVE-JSON attachment) and hands off to `sync-security-issue` to
+refreshed CVE-JSON attachment) and hands off to `security-sync-issues` to
 reconcile the rest of the tracker. See [Step 6](#step-6--allocate-the-cve)
 for the full detail.
 
 ### Tools you use most
 
-- [`import-security-issue`](.claude/skills/import-security-issue/SKILL.md) —
+- [`security-import-issues`](.claude/skills/security-import-issues/SKILL.md) —
   *"import new reports"* at the start of each triage sweep. The entry point
   into the process for `<security-list>` reports.
-- [`import-security-issue-from-pr`](.claude/skills/import-security-issue-from-pr/SKILL.md) —
+- [`security-import-issue-from-pr`](.claude/skills/security-import-issue-from-pr/SKILL.md) —
   *"import a tracker from PR <N>"* when a security-relevant fix landed
   publicly without going through `<security-list>` and the team has agreed
   it warrants a CVE. Lands directly in the `Assessed` column.
-- [`sync-security-issue`](.claude/skills/sync-security-issue/SKILL.md) —
+- [`security-sync-issues`](.claude/skills/security-sync-issues/SKILL.md) —
   *"sync <issue-ref>"* or *"sync all"*. Surfaces stalled issues, missing
   fields, credit replies, and scope-split requirements in one combined
   proposal.
-- [`allocate-cve`](.claude/skills/allocate-cve/SKILL.md) — *"allocate a CVE
+- [`security-allocate-cve`](.claude/skills/security-allocate-cve/SKILL.md) — *"allocate a CVE
   for <issue-ref>"*.
 - [`generate-cve-json`](tools/vulnogram/generate-cve-json/SKILL.md) — to
   refresh the paste-ready JSON embedded in the issue body on demand.
-- [`deduplicate-security-issue`](.claude/skills/deduplicate-security-issue/SKILL.md) —
+- [`security-deduplicate-issues`](.claude/skills/security-deduplicate-issues/SKILL.md) —
   when two trackers describe the same root-cause bug discovered
   independently.
-- [`invalidate-security-issue`](.claude/skills/invalidate-security-issue/SKILL.md) —
+- [`security-invalidate-issue`](.claude/skills/security-invalidate-issue/SKILL.md) —
   *"close NN as invalid"* once Step 5 lands a consensus-invalid
   decision. Applies the `invalid` label, archives the project-board
   item, and (for `<security-list>`-imported trackers) drafts a reply
@@ -417,11 +417,11 @@ ownership. See [Step 7](#step-7--self-assign-and-implement-the-fix).
 ### Attempting an automated fix
 
 Before writing the fix by hand, consider letting the
-[`fix-security-issue`](.claude/skills/fix-security-issue/SKILL.md) skill try
+[`security-fix-issue`](.claude/skills/security-fix-issue/SKILL.md) skill try
 it first. Invoked as *"try to fix issue #N"* (or *"draft a PR for #N"*), the
 skill:
 
-- runs `sync-security-issue` first to make sure the tracker's state is
+- runs `security-sync-issues` first to make sure the tracker's state is
   current;
 - reads the full tracker discussion and the linked `security@` mail
   thread and decides whether the issue is *easily fixable* — clear
@@ -440,7 +440,7 @@ skill:
   and similar leakage before being written or pushed;
 - updates the `<tracker>` tracking issue with the new PR
   link and applies the `pr created` label, handing back off to
-  `sync-security-issue`.
+  `security-sync-issues`.
 
 The skill refuses to proceed in cases where a human decision still
 needs to happen: reports that are still being assessed, reports not
@@ -477,7 +477,7 @@ tests manually before asking for review. Once approved, re-open the PR in
 
 ### Handoff to the release manager
 
-Once the `<upstream>` PR merges, `sync-security-issue` moves the tracker
+Once the `<upstream>` PR merges, `security-sync-issues` moves the tracker
 from `pr created` to `pr merged` and sets the milestone of the release the
 fix will ship in. The tracker then waits for the release train. When the
 release ships, sync swaps `pr merged` → `fix released` and the tracker
@@ -486,12 +486,12 @@ becomes the release manager's responsibility. See
 
 ### Tools you use most
 
-- [`fix-security-issue`](.claude/skills/fix-security-issue/SKILL.md) —
+- [`security-fix-issue`](.claude/skills/security-fix-issue/SKILL.md) —
   *"try to fix issue #N"*. Proposes a plan, writes the code, runs local
   tests, and opens a `--web` PR with a scrubbed title/body. See
   [Attempting an automated fix](#attempting-an-automated-fix) above for
   the full flow and the cases where the skill refuses to proceed.
-- [`sync-security-issue`](.claude/skills/sync-security-issue/SKILL.md) — to
+- [`security-sync-issues`](.claude/skills/security-sync-issues/SKILL.md) — to
   keep the tracker's labels, milestone, and assignee aligned with the PR
   state as it moves through review and merge.
 
@@ -499,7 +499,7 @@ becomes the release manager's responsibility. See
 
 You own the tracker from the moment the fix actually ships (`fix released`)
 to a closed tracking issue with a PUBLISHED CVE record. The hand-off from
-the remediation developer is automatic: `sync-security-issue` detects the
+the remediation developer is automatic: `security-sync-issues` detects the
 milestone version on PyPI / the Helm registry, swaps `pr merged` →
 `fix released`, and assigns the advisory-send to you.
 
@@ -521,7 +521,7 @@ issue yet** — see [Step 13](#step-13--send-the-advisory).
 ### Capturing the public archive URL
 
 This is a handoff the sync skill handles for you: once the advisory has
-been archived on the users@ list, the next `sync-security-issue` run finds
+been archived on the users@ list, the next `security-sync-issues` run finds
 the URL, populates the *Public advisory URL* body field, regenerates the
 CVE JSON attachment, and moves the label to `announced`. See
 [Step 14](#step-14--capture-the-public-advisory-url).
@@ -547,7 +547,7 @@ security team to push the information to `cve.org`. See
 
 ### Tools you use most
 
-- [`sync-security-issue`](.claude/skills/sync-security-issue/SKILL.md) —
+- [`security-sync-issues`](.claude/skills/security-sync-issues/SKILL.md) —
   *"sync announced"* at the start of each release window, to
   see the `announced` backlog needing a Vulnogram push. Also
   *"sync CVE-YYYY-NNNN"* to drill into one specific CVE before sending the
@@ -572,7 +572,7 @@ issue to the project's security mailing list).
 ### Step 2 — Import the report
 
 **Import the report into `<tracker>` as a tracking issue.** The
-[`import-security-issue`](.claude/skills/import-security-issue/SKILL.md)
+[`security-import-issues`](.claude/skills/security-import-issues/SKILL.md)
 skill is the on-ramp of the process: it scans `<security-list>`
 for threads that have not yet been imported, classifies each candidate
 (real report vs. automated-scan / consolidated / media / spam), extracts
@@ -599,14 +599,14 @@ security-relevant fix lands as a public PR on `<upstream>` without ever
 going through `<security-list>` (a contributor opens a routine-looking
 fix that the security team later realises warrants a CVE). For that
 case, use
-[`import-security-issue-from-pr`](.claude/skills/import-security-issue-from-pr/SKILL.md)
-instead of `import-security-issue`. The skill takes a PR URL/number,
+[`security-import-issue-from-pr`](.claude/skills/security-import-issue-from-pr/SKILL.md)
+instead of `security-import-issues`. The skill takes a PR URL/number,
 detects scope from the changed file paths, and creates the tracker
 directly in the **`Assessed`** column with the scope label applied —
 the deliberate import implies the security team has already
 informally concluded the report is a security issue, so the
 validity-discussion gate at Step 5 is skipped and the tracker is
-ready for `allocate-cve` immediately. There is no reporter to ack on
+ready for `security-allocate-cve` immediately. There is no reporter to ack on
 this path, so no Gmail draft is created. Only use this skill when the
 security relevance is already agreed; for genuinely-uncertain reports,
 discuss in security team chat first and then either route through
@@ -765,7 +765,7 @@ list. The `needs triage` label should then be removed.
 
 If we agree the issue is invalid, a team member closes the issue and
 responds to the reporter with that information. The
-[`invalidate-security-issue`](.claude/skills/invalidate-security-issue/SKILL.md)
+[`security-invalidate-issue`](.claude/skills/security-invalidate-issue/SKILL.md)
 skill is the apply mechanism: it labels the tracker `invalid`, posts
 a short closing comment, archives the project-board item, and — when
 the tracker has an inbound `<security-list>` thread — drafts a
@@ -786,7 +786,7 @@ project's CVE tool (see
 The allocation action is PMC-gated on the server side, so a triager
 who is not on the PMC cannot complete the allocation themselves —
 they prepare the request (using the
-[`allocate-cve`](.claude/skills/allocate-cve/SKILL.md) skill, which
+[`security-allocate-cve`](.claude/skills/security-allocate-cve/SKILL.md) skill, which
 strips any redundant project prefix from the title per
 `<project-config>/title-normalization.md` and builds a relay
 message) and forward it to a PMC member via an `@`-mention on the
@@ -795,7 +795,7 @@ allocated and reported the `CVE-YYYY-NNNNN` back, the skill can be
 re-invoked with the ID as an override to wire the allocated CVE into
 the tracker: the *CVE tool link* body field, the `cve allocated`
 label, a status-change comment, and a refreshed CVE-JSON body embed.
-The skill then hands off to `sync-security-issue` to reconcile the
+The skill then hands off to `security-sync-issues` to reconcile the
 rest of the tracker (milestone, assignee, fix-PR state,
 reporter-thread drafts) in the same flow.
 
@@ -881,7 +881,7 @@ to users — the final release artefact (per the adopting project's
 release-train conventions; for Airflow see
 [`<project-config>/milestones.md`](<project-config>/milestones.md))
 is live on the project's package index — the issue moves from
-`pr merged` to `fix released`. The `sync-security-issue` skill
+`pr merged` to `fix released`. The `security-sync-issues` skill
 detects the release (by checking the project's package index for
 the milestone version) and proposes the label swap on the next run,
 so in practice this transition is automatic; a security team member
@@ -897,7 +897,7 @@ this ownership hand-off implicit; splitting them makes it explicit and
 surfaces a `fix released` backlog the release manager can drive from the
 board.
 
-**Hand-off comment.** The same `sync-security-issue` pass that proposes
+**Hand-off comment.** The same `security-sync-issues` pass that proposes
 the `pr merged` → `fix released` swap also proposes posting an explicit
 **release-manager hand-off comment** on the tracker — a self-contained,
 numbered checklist (steps 13–15 from the RM's perspective) that
@@ -948,7 +948,7 @@ the `announced - emails sent` label and removes the `fix released` label.
 **The issue stays open** at this point — it is closed only at Step 15
 below, after the public archive URL has been captured (Step 14) and the
 CVE record has been moved to PUBLIC in Vulnogram (Step 15). This
-gives the `sync-security-issue` skill one more handoff where it can
+gives the `security-sync-issues` skill one more handoff where it can
 notice a missing archive URL and prompt for it before the issue is
 forgotten.
 
@@ -956,12 +956,12 @@ forgotten.
 
 **Capture the public advisory URL and move the tracker to
 `announced`.** Once the announcement email has been delivered
-and archived, this is done by the next `sync-security-issue` run (or the
+and archived, this is done by the next `security-sync-issues` run (or the
 release manager, if they want to drive it by hand):
 
 * retrieves the archive URL from the
   [users@ list archive](https://lists.apache.org/list.html?<users-list>) —
-  the `sync-security-issue` skill scans the archive for the CVE ID on
+  the `security-sync-issues` skill scans the archive for the CVE ID on
   every run and proposes the URL automatically once it finds a match;
 * pastes the URL into the tracking issue's **Public advisory URL** body
   field (the field was added to the issue template specifically for this
@@ -977,7 +977,7 @@ release manager, if they want to drive it by hand):
   in Vulnogram.
 
 Until the *Public advisory URL* field is populated, the
-`sync-security-issue` skill will not propose moving the issue to
+`security-sync-issues` skill will not propose moving the issue to
 `announced` — this is deliberate: the field is what the CVE
 record's public `vendor-advisory` reference will point at, and publishing
 a CVE with an empty reference leaks a broken record into `cve.org`.
@@ -1010,7 +1010,7 @@ same person who sent the advisory in Step 13):
   tool — **this is the final action** that propagates the record to
   [`cve.org`](https://cve.org);
 * **closes the issue** — do not update any labels. That closes
-  the lifecycle. The `sync-security-issue` skill follows the close
+  the lifecycle. The `security-sync-issues` skill follows the close
   with an explicit `archiveProjectV2Item` mutation so the closed
   tracker leaves the active board permanently
   (see [`tools/github/project-board.md` — *Archive a board item*](tools/github/project-board.md#archive-a-board-item--terminal-state-cleanup)).
@@ -1046,8 +1046,8 @@ the issue forward. Closing dispositions (`invalid`, `not CVE worthy`,
 
 ```mermaid
 flowchart TD
-    A([report on project security list]) -->|step 2: import-security-issue| B[needs triage]
-    A2([security-relevant fix in public PR]) -->|step 2 alt: import-security-issue-from-pr| C
+    A([report on project security list]) -->|step 2: security-import-issues| B[needs triage]
+    A2([security-relevant fix in public PR]) -->|step 2 alt: security-import-issue-from-pr| C
     B -->|step 5: consensus invalid| X1([invalid / not CVE worthy / duplicate / wontfix])
     B -->|step 5: consensus valid| C["scope label<br/>(project-specific — see<br/>projects/&lt;PROJECT&gt;/scope-labels.md)"]
     C -->|step 6: CVE reserved by PMC member| D[cve allocated]
@@ -1087,7 +1087,7 @@ labels the adopting project defines.
 | --- | --- | --- | --- |
 | `needs triage` | Freshly filed; assessment not yet started. | 1 | 5 |
 | `<scope>` | Scope of the vulnerability. Exactly one project-specific scope label is set. | 5 | never (sticks for the lifetime of the issue) |
-| `cve allocated` | A CVE has been reserved for the issue. Allocation itself is PMC-gated (only the adopting project's PMC members can submit the CVE-tool allocation form); a non-PMC triager relays a request to a PMC member via the [`allocate-cve`](.claude/skills/allocate-cve/SKILL.md) skill. | 6 | never |
+| `cve allocated` | A CVE has been reserved for the issue. Allocation itself is PMC-gated (only the adopting project's PMC members can submit the CVE-tool allocation form); a non-PMC triager relays a request to a PMC member via the [`security-allocate-cve`](.claude/skills/security-allocate-cve/SKILL.md) skill. | 6 | never |
 | `pr created` | A public fix PR has been opened on `<upstream>` but has not yet merged. | 10 | 11 (replaced by `pr merged`) |
 | `pr merged` | The fix PR has merged into `<upstream>`; no release with the fix has shipped yet. | 11 | 12 (replaced by `fix released` when the release ships) |
 | `fix released` | A release containing the fix has shipped to users; advisory has not been sent yet. | 12 | 13 (replaced by `announced - emails sent`) |
@@ -1095,7 +1095,7 @@ labels the adopting project defines.
 | `announced` | The public advisory URL has been captured in the tracking issue's *Public advisory URL* body field and the attached CVE JSON has been regenerated so its `references[]` now carries the `vendor-advisory` URL. The tracking issue is waiting for the release manager to copy the CVE JSON into the project's CVE tool, move the record to PUBLIC, and close the issue (Step 15). No label changes at close — the issue closes with `announced` still set. | 14 | never (stays on the issue after closing) |
 | `wontfix` / `invalid` / `not CVE worthy` / `duplicate` | Closing dispositions for reports that are not valid or not CVE-worthy. | 5 / 6 | — |
 
-The [`sync-security-issue`](.claude/skills/sync-security-issue/SKILL.md)
+The [`security-sync-issues`](.claude/skills/security-sync-issues/SKILL.md)
 skill keeps these labels honest: on every run it detects the current state
 of the issue, the fix PR, and the release train, and proposes the label
 transitions the process requires.
@@ -1132,8 +1132,8 @@ SH
 chmod +x .git/hooks/post-merge
 ```
 
-The framework's `upgrade-apache-steward` skill (in this repo's
-[`.claude/skills/upgrade-apache-steward/SKILL.md`](.claude/skills/upgrade-apache-steward/SKILL.md))
+The framework's `setup-upgrade-steward` skill (in this repo's
+[`.claude/skills/setup-upgrade-steward/SKILL.md`](.claude/skills/setup-upgrade-steward/SKILL.md))
 upgrades the framework checkout itself; if the user is consuming
 the framework as a tracker submodule, the skill reminds them to
 follow up with submodule update on the parent tracker.

--- a/how-to-fix-a-security-issue.md
+++ b/how-to-fix-a-security-issue.md
@@ -33,7 +33,7 @@ page is the two-minute summary.
 2. **Triage.**
    A rotating triager imports new reports into the private
    `<tracker>` repository (see the
-   [`import-security-issue`](.claude/skills/import-security-issue/SKILL.md)
+   [`security-import-issues`](.claude/skills/security-import-issues/SKILL.md)
    skill), classifies each candidate, and drafts a
    receipt-of-confirmation reply to the reporter. The team then
    discusses CVE-worthiness in the issue comments and — once the
@@ -43,7 +43,7 @@ page is the two-minute summary.
    For the rarer case where a security-relevant fix lands as a
    public PR on `<upstream>` without ever hitting `<security-list>`,
    the triager uses
-   [`import-security-issue-from-pr`](.claude/skills/import-security-issue-from-pr/SKILL.md)
+   [`security-import-issue-from-pr`](.claude/skills/security-import-issue-from-pr/SKILL.md)
    instead. The skill creates the tracker directly with a scope
    label and the `Assessed` board column — the deliberate import
    implies the validity assessment has already happened informally,
@@ -52,7 +52,7 @@ page is the two-minute summary.
 
    When the team's discussion lands a *consensus-invalid* decision,
    the triager applies that decision via the
-   [`invalidate-security-issue`](.claude/skills/invalidate-security-issue/SKILL.md)
+   [`security-invalidate-issue`](.claude/skills/security-invalidate-issue/SKILL.md)
    skill: it adds the `invalid` label, posts a short closing
    comment, archives the project-board item, and — when the
    tracker has an inbound `<security-list>` thread — drafts a
@@ -70,13 +70,13 @@ page is the two-minute summary.
    A PMC member of the adopting project allocates a CVE through the
    project's CVE tool (for Airflow, ASF Vulnogram). The allocation
    is PMC-gated; non-PMC triagers use the
-   [`allocate-cve`](.claude/skills/allocate-cve/SKILL.md) skill to
+   [`security-allocate-cve`](.claude/skills/security-allocate-cve/SKILL.md) skill to
    produce a relay message for a PMC member to click through.
 
 4. **Remediation.**
    A security-team member writes the fix in the public `<upstream>`
    repository (see the
-   [`fix-security-issue`](.claude/skills/fix-security-issue/SKILL.md)
+   [`security-fix-issue`](.claude/skills/security-fix-issue/SKILL.md)
    skill, which can draft the PR automatically). The public PR is
    scrubbed of CVE references, tracker-repo references, and any
    *"security fix"* signal — per the confidentiality rules in

--- a/new-members-onboarding.md
+++ b/new-members-onboarding.md
@@ -150,7 +150,7 @@ perspective:
   codebase.
 - **Release manager** is usually inherited rather than volunteered for:
   when you cut a release that contains a security fix,
-  `sync-security-issue` hands those trackers to you with
+  `security-sync-issues` hands those trackers to you with
   `fix released` and you own them through the advisory + Vulnogram
   steps.
 
@@ -188,7 +188,7 @@ There is also a fourth command for anyone willing to take on a
 remediation-developer turn:
 
 - **`try to fix issue #N`** —
-  [`fix-security-issue`](.claude/skills/fix-security-issue/SKILL.md)
+  [`security-fix-issue`](.claude/skills/security-fix-issue/SKILL.md)
   attempts to land the fix for a triaged tracker in one go. It runs a
   pre-fix sync, reads the discussion on the tracker to build a fix
   plan, shows you the plan, and — only after you confirm — writes the

--- a/projects/_template/README.md
+++ b/projects/_template/README.md
@@ -72,7 +72,7 @@ the rest.
 
 | File | Purpose |
 |---|---|
-| [`title-normalization.md`](title-normalization.md) | Regex cascade the `allocate-cve` skill applies to tracker titles before pasting them into the CVE-tool allocation form. |
+| [`title-normalization.md`](title-normalization.md) | Regex cascade the `security-allocate-cve` skill applies to tracker titles before pasting them into the CVE-tool allocation form. |
 
 ### Remediation workflow
 
@@ -94,7 +94,7 @@ the rest.
 - [ ] `scope-labels.md` lists at least one scope label (exactly-one-of rule).
 - [ ] `security-model.md` points at the project's authoritative Security-Model URL.
 - [ ] `release-trains.md` has at least one current release branch + its RM.
-- [ ] `canned-responses.md` has at least the *"Confirmation of receiving the report"* template filled in (the `import-security-issue` skill sends this verbatim).
+- [ ] `canned-responses.md` has at least the *"Confirmation of receiving the report"* template filled in (the `security-import-issues` skill sends this verbatim).
 - [ ] `config/active-project.md` updated to the new directory name if this working tree should target the new project.
 - [ ] Root `README.md` *"Current projects"* table updated with a row for the new project + a link to this `README.md`.
 - [ ] `prek run --all-files` passes.

--- a/projects/_template/canned-responses.md
+++ b/projects/_template/canned-responses.md
@@ -38,7 +38,7 @@ project's Security Model (see
 [`security-model.md`](security-model.md)) rather than paraphrasing
 it.
 
-The [`import-security-issue`](../../.claude/skills/import-security-issue/SKILL.md)
+The [`security-import-issues`](../../.claude/skills/security-import-issues/SKILL.md)
 skill sends the *Confirmation of receiving the report* template
 verbatim on every new inbound report — that one is **load-bearing**
 and must exist before the skill is useful. The rest can be filled in
@@ -56,7 +56,7 @@ the adopting project's voice.
 TODO: short confirmation that the report has been received, the
 security team will assess it, and what the reporter should expect
 next. Include the credit-preference question. Sent verbatim by
-`import-security-issue`.
+`security-import-issues`.
 
 ### Negative assessment — out of scope per the Security Model
 
@@ -107,12 +107,12 @@ Minimum set (one per lifecycle transition):
 
 | Template | Process step | Sent by |
 |---|---|---|
-| CVE allocated | Step 6 | `allocate-cve` skill |
-| Fix PR opened | Step 10 | `fix-security-issue` / `sync-security-issue` skill |
-| Fix PR merged | Step 11 | `sync-security-issue` skill |
-| Release shipped (fix released) | Step 12 | `sync-security-issue` skill |
-| Advisory sent | Step 13 | Release manager + `sync-security-issue` follow-up |
-| CVE published on cve.org | post-Step 15 | `sync-security-issue` skill (recently-closed scan) |
+| CVE allocated | Step 6 | `security-allocate-cve` skill |
+| Fix PR opened | Step 10 | `security-fix-issue` / `security-sync-issues` skill |
+| Fix PR merged | Step 11 | `security-sync-issues` skill |
+| Release shipped (fix released) | Step 12 | `security-sync-issues` skill |
+| Advisory sent | Step 13 | Release manager + `security-sync-issues` follow-up |
+| CVE published on cve.org | post-Step 15 | `security-sync-issues` skill (recently-closed scan) |
 | Credit correction | Step 16 | Release manager |
 
 Each row above corresponds to a section below; flesh out the

--- a/projects/_template/fix-workflow.md
+++ b/projects/_template/fix-workflow.md
@@ -18,12 +18,12 @@
 
 # TODO: `<Project Name>` — remediation PR workflow specifics
 
-Project-specific mechanics of how the `fix-security-issue` skill
+Project-specific mechanics of how the `security-fix-issue` skill
 opens a public fix PR on the project's `<upstream>` repository. Only
 the bits that are **specific to this project** live here; the
 generic flow (clone → branch → commit → push → `gh pr create --web`)
 is described in the
-[`fix-security-issue`](../../.claude/skills/fix-security-issue/SKILL.md)
+[`security-fix-issue`](../../.claude/skills/security-fix-issue/SKILL.md)
 skill itself.
 
 ## Upstream repository
@@ -49,7 +49,7 @@ TODO: list the project's developer toolchain. Example shape:
 - TODO: package manager, e.g. `uv`, `cargo`, `mvn`.
 - TODO: any project-specific dev shell or test harness.
 
-The `fix-security-issue` skill assumes a clean clone of `<upstream>`
+The `security-fix-issue` skill assumes a clean clone of `<upstream>`
 reachable from the agent's working directory (path from
 `config/user.md → environment.upstream_clone`), with a remote named
 for the user's GitHub fork that `gh pr create` can push to.

--- a/projects/_template/milestones.md
+++ b/projects/_template/milestones.md
@@ -17,7 +17,7 @@
 The project uses GitHub milestones on its `<tracker>` repository to
 pin an issue to the release it ships in. Milestones are the hand-off
 signal from the remediation developer to the release manager; the
-`sync-security-issue` skill creates and assigns them as part of the
+`security-sync-issues` skill creates and assigns them as part of the
 `pr merged` → `fix released` transition.
 
 TODO: list every milestone format the project uses, one row per
@@ -52,7 +52,7 @@ TODO:
 ## What the milestone unlocks
 
 Once the milestone is set on a `pr merged` tracker, the
-`sync-security-issue` skill watches for the release to ship and
+`security-sync-issues` skill watches for the release to ship and
 proposes the `pr merged` → `fix released` label swap, which hands
 ownership off to the release manager for steps 13–15. See the
 repo-level [`../../README.md`](../../README.md) for the step-by-step

--- a/projects/_template/scope-labels.md
+++ b/projects/_template/scope-labels.md
@@ -26,7 +26,7 @@ handling process (valid/invalid consensus landed). The scope:
   table below).
 
 TODO: list the project's scope labels, one row per label. If a report
-affects more than one scope, the `sync-security-issue` skill surfaces
+affects more than one scope, the `security-sync-issues` skill surfaces
 this as a blocker and the triager splits the report into per-scope
 trackers.
 

--- a/projects/_template/title-normalization.md
+++ b/projects/_template/title-normalization.md
@@ -21,7 +21,7 @@ should be the **bare description** — no project prefix, no
 redundant version suffix, no reporter-added tag like
 `[ Security Report ]`.
 
-The [`allocate-cve`](../../.claude/skills/allocate-cve/SKILL.md)
+The [`security-allocate-cve`](../../.claude/skills/security-allocate-cve/SKILL.md)
 skill reads this file for the exact strip cascade to apply to the
 tracker title before pasting it into the allocation form.
 
@@ -68,7 +68,7 @@ in this file once you settle on it.
 ## Sanity check
 
 Show the stripped title and the original title side by side in the
-allocate-cve proposal so the user can spot any over-stripping
+security-allocate-cve proposal so the user can spot any over-stripping
 before pasting into the CVE tool. If the strip collapses the title
 to fewer than 3 words, surface that as a warning and propose a
 manual override — over-stripping is worse than leaving one

--- a/secure-agent-internals.md
+++ b/secure-agent-internals.md
@@ -197,7 +197,7 @@ Mitigations available today, ordered from cheapest to strongest:
 - Issue `Bash` calls one command at a time, not as chained
   pipelines. The deny pattern then matches the actual command
   that runs. The agent-guided
-  `verify-secure-config` skill does this deliberately when
+  `setup-verify-secure-config` skill does this deliberately when
   running its denial checks.
 - On hosts where `Bash(*)` chained execution is a meaningful
   exfiltration concern, run an outbound packet filter

--- a/secure-agent-setup.md
+++ b/secure-agent-setup.md
@@ -90,37 +90,37 @@ privilege-elevating runs without you saying so.
 ```text
 1. Open Claude Code in your tracker repo (or any directory).
 2. If you consume the framework as a submodule of your tracker
-   (the canonical adopter pattern), run /verify-apache-steward
+   (the canonical adopter pattern), run /setup-verify-steward
    to confirm `.apache-steward/`, the submodule, and the
    project-config under it are wired correctly. Read-only —
    surfaces gaps, never auto-fixes.
 3. Run /setup-secure-config — guided first-time install of
    the secure-agent setup (sandbox, hooks, status line,
    clean-env wrapper).
-4. Run /verify-secure-config — confirms ✓/✗/⚠ for every piece
+4. Run /setup-verify-secure-config — confirms ✓/✗/⚠ for every piece
    of the secure-agent setup.
 5. When you want to be on the framework's latest, run
-   /upgrade-apache-steward — pulls your local airflow-steward
+   /setup-upgrade-steward — pulls your local airflow-steward
    checkout to origin/main with --ff-only, refuses to touch a
    dirty working tree, surfaces what arrived. Then run
-   /update-secure-config to surface user-side drift the
+   /setup-update-secure-config to surface user-side drift the
    upgrade introduced (new permissions.deny entries,
    user-scope script copies older than the framework, pinned
    tool bumps that warrant a host install).
 6. Optional: if you maintain a private dotfile-style sync repo
    per
    [Syncing user-scope config across machines](#syncing-user-scope-config-across-machines),
-   run /sync-shared-config to push local edits to the remote
+   run /setup-sync-shared-config to push local edits to the remote
    so other machines pick them up.
 ```
 
 The skills are at
-[`.claude/skills/verify-apache-steward/`](.claude/skills/verify-apache-steward/SKILL.md),
+[`.claude/skills/setup-verify-steward/`](.claude/skills/setup-verify-steward/SKILL.md),
 [`.claude/skills/setup-secure-config/`](.claude/skills/setup-secure-config/SKILL.md),
-[`.claude/skills/verify-secure-config/`](.claude/skills/verify-secure-config/SKILL.md),
-[`.claude/skills/upgrade-apache-steward/`](.claude/skills/upgrade-apache-steward/SKILL.md),
-[`.claude/skills/update-secure-config/`](.claude/skills/update-secure-config/SKILL.md),
-[`.claude/skills/sync-shared-config/`](.claude/skills/sync-shared-config/SKILL.md).
+[`.claude/skills/setup-verify-secure-config/`](.claude/skills/setup-verify-secure-config/SKILL.md),
+[`.claude/skills/setup-upgrade-steward/`](.claude/skills/setup-upgrade-steward/SKILL.md),
+[`.claude/skills/setup-update-secure-config/`](.claude/skills/setup-update-secure-config/SKILL.md),
+[`.claude/skills/setup-sync-shared-config/`](.claude/skills/setup-sync-shared-config/SKILL.md).
 Each skill references back into the canonical sections of this
 document rather than duplicating them, so anything the skill walks
 you through has a longer-form section here you can read for

--- a/tools/cve-org/tool.md
+++ b/tools/cve-org/tool.md
@@ -33,10 +33,10 @@ readable lookup.
 
 One capability: **publication state check**. Given a `CVE-ID`,
 answer *"is this record live on cve.org yet?"*. Used by
-`sync-security-issue` to drive the *"notify the reporter that the
+`security-sync-issues` to drive the *"notify the reporter that the
 CVE is published"* proposal (see the
 [*"Check recently-closed trackers for CVE publication state"*
-section](../../.claude/skills/sync-security-issue/SKILL.md)
+section](../../.claude/skills/security-sync-issues/SKILL.md)
 in the sync skill).
 
 ## URLs

--- a/tools/github/issue-template.md
+++ b/tools/github/issue-template.md
@@ -39,12 +39,12 @@ renamed, or removed:
 2. **The project manifest** — `<project-config>/project.md` declares
    the concrete field name each skill role maps to. Renaming the
    field in the YAML requires updating this mapping.
-3. **The skills that write fresh issue bodies** — `import-security-issue`
+3. **The skills that write fresh issue bodies** — `security-import-issues`
    emits a heredoc body with the full field set; when the schema
    changes, the heredoc must change in lock-step.
 
 No skill parses the YAML at runtime. The field list is hand-
-maintained in the project manifest and in the `import-security-issue`
+maintained in the project manifest and in the `security-import-issues`
 heredoc, and the three surfaces are kept aligned by convention.
 
 ## Field roles the skills use
@@ -63,7 +63,7 @@ The generic lifecycle refers to fields by these roles:
 | `remediation-developer` | CVE JSON generator | sync (auto-populated from `pr-with-fix` author when set; manual edits preserved) | Person(s) who authored the fix; one credit per line. |
 | `cwe` | CVE JSON generator | sync proposes, user confirms | CWE number for the CVE 5.x `problemTypes[]`. |
 | `severity` | CVE JSON generator | sync proposes, user confirms | CVSS severity; never copy the reporter's self-assigned value. |
-| `cve-tool-link` | sync, allocate-cve (blocker check) | allocate-cve | Canonical link to the CVE record in the project's CVE tool. |
+| `cve-tool-link` | sync, security-allocate-cve (blocker check) | security-allocate-cve | Canonical link to the CVE record in the project's CVE tool. |
 
 The concrete field names each role maps to for the adopting project
 live in the project manifest.

--- a/tools/github/labels.md
+++ b/tools/github/labels.md
@@ -50,7 +50,7 @@ These are mutually exclusive — a tracker closes with exactly one of:
 |---|---|
 | `invalid` | Report is not a vulnerability per the project's Security Model. |
 | `not CVE worthy` | Reproducible but not severe / scoped enough to warrant a CVE (e.g. self-XSS, DoS by authenticated admin). |
-| `duplicate` | Root-cause-equivalent to another tracker; kept tracker carries the CVE. See the `deduplicate-security-issue` skill. |
+| `duplicate` | Root-cause-equivalent to another tracker; kept tracker carries the CVE. See the `security-deduplicate-issues` skill. |
 | `wontfix` | Will not be fixed (e.g. feature-not-bug, deprecated surface being removed in the next release). |
 
 ## Secondary labels
@@ -64,7 +64,7 @@ These do not gate state transitions but carry coordination signals.
 
 ## Maintenance
 
-The `sync-security-issue` skill is the authority on label transitions
+The `security-sync-issues` skill is the authority on label transitions
 — on every run it detects the current state (labels + body fields +
 fix-PR state + release state) and proposes the label transitions the
 process requires.

--- a/tools/github/project-board.md
+++ b/tools/github/project-board.md
@@ -26,7 +26,7 @@
 The **project board** is the security team's primary overview surface:
 a Projects V2 board where every tracking issue sits in exactly one
 `Status` column representing its current lifecycle state. The
-`sync-security-issue` skill reads the current column as part of its
+`security-sync-issues` skill reads the current column as part of its
 state-gather, and reconciles it against the issue's labels + body
 state as part of its apply loop.
 
@@ -59,7 +59,7 @@ security tracker carries the label:
 1. The repo's [issue template](issue-template.md) lists `security
    issue` in its `labels:` frontmatter, so any tracker created via
    *New issue → Airflow Security Issue* gets the label automatically.
-2. The `import-security-issue` skill passes `--label 'security issue'`
+2. The `security-import-issues` skill passes `--label 'security issue'`
    on every `gh issue create` it runs.
 
 Manually-opened issues (no template, no skill) will not appear on the

--- a/tools/github/status-rollup.md
+++ b/tools/github/status-rollup.md
@@ -116,14 +116,14 @@ line tells the reader at a glance *what* the entry represents:
 
 | Emitting skill | `<Action>` value | Optional parenthetical |
 |---|---|---|
-| `import-security-issue` | `Import` | class + reporter, e.g. `Import (Report, Jane Doe)` |
-| `sync-security-issue` (ordinary pass) | `Sync` | one-phrase headline, e.g. `Sync (pr merged → fix released)` |
-| `sync-security-issue` (escalation, Step 4) | `Sync` | `Sync (Step 4 escalation)` |
-| `sync-security-issue` (reformat-only, migrating legacy comments) | `Reformat` | `Reformat (N legacy comments folded)` |
-| `allocate-cve` | `CVE allocated` | the allocated ID, e.g. `CVE allocated (CVE-2026-40913)` |
-| `deduplicate-security-issue`, on the kept tracker | `Merge (kept)` | dropped side's number, e.g. `Merge (kept) (from #305)` |
-| `deduplicate-security-issue`, on the dropped tracker | `Merge (dropped)` | kept side's number, e.g. `Merge (dropped) (into #244)` |
-| `fix-security-issue` | `Fix PR` | upstream PR number, e.g. `Fix PR (<upstream>#65346)` |
+| `security-import-issues` | `Import` | class + reporter, e.g. `Import (Report, Jane Doe)` |
+| `security-sync-issues` (ordinary pass) | `Sync` | one-phrase headline, e.g. `Sync (pr merged → fix released)` |
+| `security-sync-issues` (escalation, Step 4) | `Sync` | `Sync (Step 4 escalation)` |
+| `security-sync-issues` (reformat-only, migrating legacy comments) | `Reformat` | `Reformat (N legacy comments folded)` |
+| `security-allocate-cve` | `CVE allocated` | the allocated ID, e.g. `CVE allocated (CVE-2026-40913)` |
+| `security-deduplicate-issues`, on the kept tracker | `Merge (kept)` | dropped side's number, e.g. `Merge (kept) (from #305)` |
+| `security-deduplicate-issues`, on the dropped tracker | `Merge (dropped)` | kept side's number, e.g. `Merge (dropped) (into #244)` |
+| `security-fix-issue` | `Fix PR` | upstream PR number, e.g. `Fix PR (<upstream>#65346)` |
 
 The parenthetical is optional; include it when it adds information a
 scroller actually wants (the CVE ID, the dedupe counterpart, the PR
@@ -181,7 +181,7 @@ gh issue view <N> --repo <tracker> \
 
 The matching comment is the rollup. If the query returns nothing,
 there is no rollup yet (expected on a fresh tracker where
-`import-security-issue` has not run, or on a legacy tracker that
+`security-import-issues` has not run, or on a legacy tracker that
 pre-dates this convention).
 
 Use the **first** match chronologically if the query somehow returns
@@ -277,7 +277,7 @@ A comment is a candidate for folding when **all** of the following hold:
    - Legacy bare-text prefixes (no leading `**`): `Sync status (`,
      `Sync YYYY-MM-DD`, `Status update`
    - Content tells when the prefix is idiosyncratic:
-     `sync-security-issue skill`, `re-triage`,
+     `security-sync-issues skill`, `re-triage`,
      `Reporter notification still pending`, `Outstanding — Step `,
      a verbatim `generate-cve-json` embed block.
 
@@ -383,8 +383,8 @@ audit the change.
 
 ## Referenced by
 
-- [`.claude/skills/import-security-issue/SKILL.md`](../../.claude/skills/import-security-issue/SKILL.md) — creates the rollup with the first entry.
-- [`.claude/skills/sync-security-issue/SKILL.md`](../../.claude/skills/sync-security-issue/SKILL.md) — appends per-sync entries and runs the fold-legacy sub-step.
-- [`.claude/skills/allocate-cve/SKILL.md`](../../.claude/skills/allocate-cve/SKILL.md) — appends the CVE-allocation entry.
-- [`.claude/skills/deduplicate-security-issue/SKILL.md`](../../.claude/skills/deduplicate-security-issue/SKILL.md) — appends the merge entry on both trackers.
-- [`.claude/skills/fix-security-issue/SKILL.md`](../../.claude/skills/fix-security-issue/SKILL.md) — appends the fix-PR entry.
+- [`.claude/skills/security-import-issues/SKILL.md`](../../.claude/skills/security-import-issues/SKILL.md) — creates the rollup with the first entry.
+- [`.claude/skills/security-sync-issues/SKILL.md`](../../.claude/skills/security-sync-issues/SKILL.md) — appends per-sync entries and runs the fold-legacy sub-step.
+- [`.claude/skills/security-allocate-cve/SKILL.md`](../../.claude/skills/security-allocate-cve/SKILL.md) — appends the CVE-allocation entry.
+- [`.claude/skills/security-deduplicate-issues/SKILL.md`](../../.claude/skills/security-deduplicate-issues/SKILL.md) — appends the merge entry on both trackers.
+- [`.claude/skills/security-fix-issue/SKILL.md`](../../.claude/skills/security-fix-issue/SKILL.md) — appends the fix-PR entry.

--- a/tools/gmail/asf-relay.md
+++ b/tools/gmail/asf-relay.md
@@ -62,7 +62,7 @@ Placeholder convention:
 
 ## How the skills detect relay cases
 
-The `import-security-issue` skill classifies candidates into
+The `security-import-issues` skill classifies candidates into
 `Report`, `ASF-security relay`, and several non-import classes; the
 classification feeds this drafting path.
 

--- a/tools/gmail/draft-backends.md
+++ b/tools/gmail/draft-backends.md
@@ -175,8 +175,8 @@ to the user before drafting a new one"*.
 Caught live on 2026-04-25 during the [`<tracker>#346`](https://github.com/<tracker>/issues/346)
 fix-skill flow: when **multiple `oauth_curl`-backed drafts pile up on
 the same Gmail thread** within a single skill flow (typical sequence:
-allocate-cve drafts a CVE-allocated message → sync-security-issue
-drafts a corrected version with updated state → fix-security-issue
+security-allocate-cve drafts a CVE-allocated message → security-sync-issues
+drafts a corrected version with updated state → security-fix-issue
 drafts the final version after a state change), the drafts all carry
 the `DRAFT` label in the Gmail API but **only the most recent surfaces
 in the user's global Drafts folder in Gmail's UI**. The earlier ones

--- a/tools/gmail/operations.md
+++ b/tools/gmail/operations.md
@@ -73,7 +73,7 @@ mcp__claude_ai_Gmail__search_threads(
 ```
 
 Returns an array of `{threadId, snippet, …}` objects. Use `pageSize`
-deliberately — some skills (e.g. `sync-security-issue`) impose a
+deliberately — some skills (e.g. `security-sync-issues`) impose a
 hard Gmail-call budget per issue to avoid running up the MCP quota
 on many-tracker sweeps.
 
@@ -92,7 +92,7 @@ mcp__claude_ai_Gmail__get_thread(
 Returns the full message history of a thread. Body reads are
 expensive — most skills filter candidates down on metadata first and
 only fetch bodies for the narrow set that actually warrants it
-(`import-security-issue` does this explicitly at Step 3).
+(`security-import-issues` does this explicitly at Step 3).
 
 ## Write — drafts only, never send
 
@@ -190,7 +190,7 @@ mcp__claude_ai_Gmail__list_drafts(
 )
 ```
 
-Used by `sync-security-issue` to verify that a draft flagged as stale
+Used by `security-sync-issues` to verify that a draft flagged as stale
 in a previous status comment still exists before carrying the flag
 forward. See the *"self-replicating stale-draft flag"* paragraph in
 that skill.

--- a/tools/gmail/ponymail-archive.md
+++ b/tools/gmail/ponymail-archive.md
@@ -7,8 +7,8 @@
     - [Archive search (query returns a list-page with matching threads)](#archive-search-query-returns-a-list-page-with-matching-threads)
     - [Archive API (JSON response, the sync skill uses this first)](#archive-api-json-response-the-sync-skill-uses-this-first)
     - [Resolved thread URL (what the skill records in the tracker)](#resolved-thread-url-what-the-skill-records-in-the-tracker)
-  - [Use case — `import-security-issue`](#use-case--import-security-issue)
-  - [Use case — `sync-security-issue`](#use-case--sync-security-issue)
+  - [Use case — `security-import-issues`](#use-case--security-import-issues)
+  - [Use case — `security-sync-issues`](#use-case--security-sync-issues)
   - [When the archive is not available](#when-the-archive-is-not-available)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
@@ -97,7 +97,7 @@ field (for public lookups). Field-role names are defined in
 [`../github/issue-template.md`](../github/issue-template.md#field-roles-the-skills-use);
 project-specific concrete field names live in the project manifest.
 
-## Use case — `import-security-issue`
+## Use case — `security-import-issues`
 
 The security list's PonyMail archive is not anonymously queryable
 (the list is gated behind ASF LDAP), so the skill **cannot** fetch
@@ -127,7 +127,7 @@ CVE-JSON generator does not export it to `references[]`. See the
 *"CVE references must never point at non-public mailing-list
 threads"* rule in [`../../AGENTS.md`](../../AGENTS.md).
 
-## Use case — `sync-security-issue`
+## Use case — `security-sync-issues`
 
 The public `users@` archive **is** anonymously queryable. On every
 sync run, if the tracker has `announced - emails sent` but the

--- a/tools/gmail/search-queries.md
+++ b/tools/gmail/search-queries.md
@@ -6,10 +6,10 @@
   - [Gmail operator cheat-sheet](#gmail-operator-cheat-sheet)
   - [GitHub-notification exclusions](#github-notification-exclusions)
   - [Query templates by skill](#query-templates-by-skill)
-    - [`import-security-issue` — candidate-listing query](#import-security-issue--candidate-listing-query)
-    - [`import-security-issue` — prior-rejection search](#import-security-issue--prior-rejection-search)
-    - [`sync-security-issue` — reporter-thread lookup by distinctive phrase](#sync-security-issue--reporter-thread-lookup-by-distinctive-phrase)
-    - [`sync-security-issue` — CVE-review-comment search](#sync-security-issue--cve-review-comment-search)
+    - [`security-import-issues` — candidate-listing query](#security-import-issues--candidate-listing-query)
+    - [`security-import-issues` — prior-rejection search](#security-import-issues--prior-rejection-search)
+    - [`security-sync-issues` — reporter-thread lookup by distinctive phrase](#security-sync-issues--reporter-thread-lookup-by-distinctive-phrase)
+    - [`security-sync-issues` — CVE-review-comment search](#security-sync-issues--cve-review-comment-search)
     - [Release `[RESULT][VOTE]` attribution](#release-resultvote-attribution)
   - [Budget discipline](#budget-discipline)
 
@@ -69,7 +69,7 @@ the list), trim or replace these as needed.
 
 ## Query templates by skill
 
-### `import-security-issue` — candidate-listing query
+### `security-import-issues` — candidate-listing query
 
 Inbound threads that might be new reports, minus GitHub-notification
 bots, within a time window:
@@ -94,7 +94,7 @@ instead.
 Adjust the time window per the user's selector (`since:` →
 `newer_than:` or `after:`; `import all` → `newer_than:90d`).
 
-### `import-security-issue` — prior-rejection search
+### `security-import-issues` — prior-rejection search
 
 Run in Step 2b of the import skill on candidates heading for a
 negative-response disposition. The goal is to find **prior similar
@@ -155,7 +155,7 @@ roster member, or rely on `list:` + the no-`from:notifications@github.com`
 filter as in template 1 and classify the result set by sender
 after the fact.
 
-### `sync-security-issue` — reporter-thread lookup by distinctive phrase
+### `security-sync-issues` — reporter-thread lookup by distinctive phrase
 
 When a tracking issue's GitHub title does not match the original
 email subject (common — the triager paraphrases the subject when
@@ -172,7 +172,7 @@ Pick a phrase that is rare in the security list's volume — a
 function name, an endpoint path, an error string — rather than a
 common word.
 
-### `sync-security-issue` — CVE-review-comment search
+### `security-sync-issues` — CVE-review-comment search
 
 The project's CVE tool (Vulnogram for ASF) notifies the security
 list by email when a reviewer leaves a comment on the CVE record.
@@ -213,8 +213,8 @@ the project's release-trains file (for Airflow,
 
 Gmail MCP calls are metered. Skill-level rules:
 
-- `import-security-issue` runs exactly one list scan per invocation.
-- `sync-security-issue` runs at most one reporter-thread search +
+- `security-import-issues` runs exactly one list scan per invocation.
+- `security-sync-issues` runs at most one reporter-thread search +
   two CVE-review searches per tracking issue (i.e. ≤ 3 per tracker;
   ≤ ~60 on a 20-tracker sweep).
 - No skill retries on its own. If a search fails, surface the

--- a/tools/gmail/tool.md
+++ b/tools/gmail/tool.md
@@ -40,7 +40,7 @@ Related, adjacent tool:
 
 | Capability | File | What it covers |
 |---|---|---|
-| ASF PonyMail archive lookups | [`ponymail-archive.md`](ponymail-archive.md) | URL-construction pattern for the ASF's `lists.apache.org` archive (used by `sync-security-issue` to scan the public `users@` archive for the advisory URL, and by `import-security-issue` to resolve a pastable thread URL for the private `security@` list) |
+| ASF PonyMail archive lookups | [`ponymail-archive.md`](ponymail-archive.md) | URL-construction pattern for the ASF's `lists.apache.org` archive (used by `security-sync-issues` to scan the public `users@` archive for the advisory URL, and by `security-import-issues` to resolve a pastable thread URL for the private `security@` list) |
 
 ## Why this is its own tool
 

--- a/tools/ponymail/operations.md
+++ b/tools/ponymail/operations.md
@@ -273,7 +273,7 @@ mcp__ponymail__search_list(
 
 Filter by a distinctive function name, endpoint path, or error
 string — same heuristic as the Gmail equivalent in
-[`../gmail/search-queries.md`](../gmail/search-queries.md#sync-security-issue--reporter-thread-lookup-by-distinctive-phrase).
+[`../gmail/search-queries.md`](../gmail/search-queries.md#security-sync-issues--reporter-thread-lookup-by-distinctive-phrase).
 
 ### Find the `[RESULT][VOTE]` thread for a release
 

--- a/tools/vulnogram/allocation.md
+++ b/tools/vulnogram/allocation.md
@@ -20,7 +20,7 @@ The Vulnogram-side mechanics of CVE allocation (step 6 of the generic
 handling process in [`../../README.md`](../../README.md)). The generic
 flow of *"walk the triager through an allocation, capture the ID,
 wire it into the tracker"* lives in the
-[`allocate-cve`](../../.claude/skills/allocate-cve/SKILL.md) skill;
+[`security-allocate-cve`](../../.claude/skills/security-allocate-cve/SKILL.md) skill;
 this file documents the **Vulnogram-specific** parts that skill reads.
 
 Per-project configuration (allocation URL, record URL template, org
@@ -47,7 +47,7 @@ project the allocation is against. This is not something the skill
 can work around — a non-PMC user who clicks *Allocate* sees the
 button grey out.
 
-**Practical consequence.** The `allocate-cve` skill asks up front
+**Practical consequence.** The `security-allocate-cve` skill asks up front
 *"are you a PMC member?"*:
 
 - **PMC** — recipe is self-service: click the URL, paste the title,
@@ -56,7 +56,7 @@ button grey out.
   a comment on the tracker (`@`-mentioning a PMC member) or sends
   on the project's `security_list`. The PMC member reads the relay,
   clicks through, allocates, and posts the ID back. The original
-  triager (or the PMC member) can then re-invoke `allocate-cve` with
+  triager (or the PMC member) can then re-invoke `security-allocate-cve` with
   the CVE ID as an override to resume from the wire-back step.
 
 Concrete PMC-member handles live in the project's roster file (for
@@ -75,13 +75,13 @@ source is the ASF project page,
 | **Summary** | Tracker body's *public-summary* field. |
 | **Reporter credits** | Tracker body's *reporter-credit* field. |
 
-The `allocate-cve` skill renders this mapping as a numbered recipe
+The `security-allocate-cve` skill renders this mapping as a numbered recipe
 the user copy-pastes into the form in one pass.
 
 ## After the CVE is allocated
 
 Once the PMC member has reported the `CVE-YYYY-NNNNN` back, the
-`allocate-cve` skill wires it into the tracker in one coordinated
+`security-allocate-cve` skill wires it into the tracker in one coordinated
 pass — the generic steps (populate the *cve-tool-link* body field,
 add the `cve allocated` label, post a status-change comment,
 regenerate the CVE JSON attachment, draft a reporter status update)
@@ -100,6 +100,6 @@ are tool-agnostic; the Vulnogram-specific output is:
 Allocating a CVE against the wrong product (e.g. `apache-airflow`
 when the fix actually lives in `apache-airflow-providers-smtp`) is a
 multi-hour cleanup involving Vulnogram support and the release
-manager. The `allocate-cve` skill's Step 1 blocker checks refuse to
+manager. The `security-allocate-cve` skill's Step 1 blocker checks refuse to
 proceed without a scope label precisely because of this — see the
 skill file for the hard-check details.

--- a/tools/vulnogram/generate-cve-json/SKILL.md
+++ b/tools/vulnogram/generate-cve-json/SKILL.md
@@ -70,7 +70,7 @@ diff the two to see what the tool has added / what you changed by hand.
   - `--remediation-developer "Name"` — append a `type: "remediation
     developer"` credit on top of whatever the body's *Remediation
     developer* field already lists (auto-populated by the
-    `sync-security-issue` skill from the linked PR's author). Repeat
+    `security-sync-issues` skill from the linked PR's author). Repeat
     the flag to add multiple developers; duplicates between the
     body field and CLI flags are dropped silently. The reporter
     credit(s) from the *Reporter credited as* field are always
@@ -114,7 +114,7 @@ diff the two to see what the tool has added / what you changed by hand.
 ## Prerequisites on the tracking issue
 
 For the generated JSON to be useful, the issue body should already be
-filled in through a prior `sync-security-issue` run. In particular:
+filled in through a prior `security-sync-issues` run. In particular:
 
 - **Short public summary for publish** — becomes the CVE description.
 - **Affected versions** — becomes the CVE `affected[]` list. The script
@@ -152,7 +152,7 @@ filled in through a prior `sync-security-issue` run. In particular:
   emits a `versions[]` entry without `lessThan` (open-ended upper
   bound — *"affected from \<low\> onwards, no fix released yet"*).
   When the wave ships and the version is known, the
-  `sync-security-issue` skill replaces each `NEXT VERSION` with the
+  `security-sync-issues` skill replaces each `NEXT VERSION` with the
   actual `< X.Y.Z` and the next regen produces a fully-bounded entry.
   Case-insensitive; combines with a lower bound (e.g.
   `>= 2.0.0, < NEXT VERSION` becomes `{version: "2.0.0", status: "affected"}`).
@@ -161,7 +161,7 @@ filled in through a prior `sync-security-issue` run. In particular:
   `references[]`. Keep whatever the reporter or triager put there.
 - **Public advisory URL** — each URL in this field is extracted and
   added to `references[]` with `tags: ["vendor-advisory"]`. Populated
-  by the release manager (or the `sync-security-issue` skill) once
+  by the release manager (or the `security-sync-issues` skill) once
   the advisory is archived on `<users-list>`. The
   `--advisory-url` CLI flag still exists for ad-hoc overrides.
 - **PR with the fix** — each URL in this field becomes a reference URL.
@@ -184,7 +184,7 @@ filled in through a prior `sync-security-issue` run. In particular:
   with `type: "remediation developer"`. Same parsing rules as
   *Reporter credited as* (newline-separated, `Full Name, Affiliation`
   is one credit, bullets stripped). Auto-populated by the
-  `sync-security-issue` skill from the linked PR's author the first
+  `security-sync-issues` skill from the linked PR's author the first
   time *PR with the fix* is set; manual edits survive subsequent
   syncs (the skill only proposes appending names that aren't already
   there). The `--remediation-developer` CLI flag adds further names
@@ -240,7 +240,7 @@ in to.
 
 Fetch the issue body and check every template field the script reads. If
 a field is missing or still `_No response_`, either run
-[`sync-security-issue`](../../../.claude/skills/sync-security-issue/SKILL.md) first to fill it
+[`security-sync-issues`](../../../.claude/skills/security-sync-issues/SKILL.md) first to fill it
 in, or override it on the command line.
 
 ```bash
@@ -270,7 +270,7 @@ uv run --project <framework>/tools/vulnogram/generate-cve-json generate-cve-json
 contains and that Vulnogram expects filled in (the body field usually
 encodes only the upper bound). The remediation developer credit comes
 from the body's *Remediation developer* field, populated by the
-`sync-security-issue` skill from the linked PR's author — no CLI flag
+`security-sync-issues` skill from the linked PR's author — no CLI flag
 needed in the normal flow. For a fix that landed in `3.2.2` and was
 first introduced in `3.0.0`, for example:
 
@@ -464,7 +464,7 @@ the local JSON file to match tool-side changes. Re-run the script instead
 output against the current Vulnogram state, and paste the merged JSON
 back. This keeps the tracking issue as the single source of truth: if
 Vulnogram shows something different from the generated JSON, either the
-issue body is out of date and needs a `sync-security-issue` run, or the
+issue body is out of date and needs a `security-sync-issues` run, or the
 tool-side difference is intentional and the reviewer will keep it.
 
 ---
@@ -511,8 +511,8 @@ tool-side difference is intentional and the reviewer will keep it.
   step 13 (fill in CVE tool fields and send advisory from the tool)
   and step 15 (paste the attached JSON into Vulnogram's #source tab,
   move the CVE to PUBLIC, close the issue).
-- [`sync-security-issue`](../../../.claude/skills/sync-security-issue/SKILL.md) — the sibling
+- [`security-sync-issues`](../../../.claude/skills/security-sync-issues/SKILL.md) — the sibling
   skill that populates the tracking issue fields this skill consumes.
-- [`fix-security-issue`](../../../.claude/skills/fix-security-issue/SKILL.md) — the other
+- [`security-fix-issue`](../../../.claude/skills/security-fix-issue/SKILL.md) — the other
   sibling skill that opens a public PR and updates the tracking issue
   with the fix URL.

--- a/tools/vulnogram/generate-cve-json/src/generate_cve_json/cve_json.py
+++ b/tools/vulnogram/generate-cve-json/src/generate_cve_json/cve_json.py
@@ -481,7 +481,7 @@ def parse_affected_versions(value: str, version_start_override: str | None) -> l
     sync skill replaces ``< NEXT VERSION`` with the actual ``< X.Y.Z``
     upper bound and the next regen produces a fully-bounded entry.
     See the ``NEXT VERSION`` rule in
-    ``.claude/skills/sync-security-issue/SKILL.md`` for the lifecycle.
+    ``.claude/skills/security-sync-issues/SKILL.md`` for the lifecycle.
 
     ``--version-start`` overrides the low bound unconditionally when set,
     because the issue body rarely specifies it and a reviewer usually
@@ -1547,7 +1547,7 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
             "Name to add to `credits[]` with type 'remediation developer'. "
             "In normal use, the developer name lives in the issue body's "
             "*Remediation developer* field (auto-populated by the "
-            "`sync-security-issue` skill from the linked PR's author). "
+            "`security-sync-issues` skill from the linked PR's author). "
             "This flag is an additional / override mechanism: names "
             "passed here are appended to whatever the body already "
             "specifies, with duplicates silently dropped. Repeat the "
@@ -1705,7 +1705,7 @@ def main(argv: list[str] | None = None) -> int:
     description = summary or title
 
     # Advisory URLs come from two sources: the body's "Public advisory URL"
-    # field (populated by the release manager / sync-security-issue skill
+    # field (populated by the release manager / security-sync-issues skill
     # once the advisory is archived on users@airflow.apache.org) and any
     # --advisory-url CLI overrides. Both are forwarded to the references
     # builder; de-duplication happens there.

--- a/tools/vulnogram/record.md
+++ b/tools/vulnogram/record.md
@@ -93,7 +93,7 @@ expects when the release manager triggers the advisory email send.
 
 **`READY` → `PUBLIC`** is a human release-manager click in Vulnogram
 after the advisory archive URL has been captured on the tracker. The
-generic `sync-security-issue` skill's Step 2b does not propose this
+generic `security-sync-issues` skill's Step 2b does not propose this
 transition — it is a Step 15 release-manager action. The
 publication-ready notification comment (see
 [*Release-manager checklist*](#release-manager-checklist) below)
@@ -119,9 +119,9 @@ whether reviewer comments are still pending.
 ASF CNA reviewers leave comments on `REVIEW`-state records. Those
 comments do **not** surface on the tracking issue directly —
 Vulnogram notifies by email to the project's `security_list`
-instead, with the CVE ID in the subject line. The `sync-security-issue`
+instead, with the CVE ID in the subject line. The `security-sync-issues`
 skill's Step 1e reads those emails (Gmail search recipe lives in
-[`../gmail/search-queries.md`](../gmail/search-queries.md#sync-security-issue--cve-review-comment-search))
+[`../gmail/search-queries.md`](../gmail/search-queries.md#security-sync-issues--cve-review-comment-search))
 and surfaces each open reviewer comment in Step 2b as an actionable
 body-field proposal on the tracker.
 
@@ -137,7 +137,7 @@ OAuth-gated and not readable from skill context).
 
 The `cveprocess.apache.org/cve5/<CVE-ID>.json` endpoint exists but
 is behind ASF OAuth and is **not** readable from agent-skill
-context — the `sync-security-issue` skill therefore never curls it;
+context — the `security-sync-issues` skill therefore never curls it;
 Gmail is the load-bearing signal source.
 
 ## Record-generator round trip
@@ -161,7 +161,7 @@ has one canonical JSON to paste into `#source` at step 15.
 ## Release-manager checklist
 
 When the `<upstream>` release containing a fix ships, the
-`sync-security-issue` skill swaps the tracker's `pr merged` label to
+`security-sync-issues` skill swaps the tracker's `pr merged` label to
 `fix released`, reassigns the issue to the release manager, and posts
 an explicit **release-manager hand-off comment** on the tracker (the
 template body lives in
@@ -182,7 +182,7 @@ and **three** when reviewer comments arrive:
 2. **(conditional) Re-paste after reviewer comments.** ASF CNA
    reviewers may leave comments while the record sits in `REVIEW`
    (see [*Reviewer-comment signal*](#reviewer-comment-signal) above).
-   The `sync-security-issue` skill detects them automatically and
+   The `security-sync-issues` skill detects them automatically and
    proposes matching body-field updates on the tracker; the security
    team confirms and the embedded JSON regenerates. Once the body has
    settled (no more pending reviewer-comment proposals), re-paste the
@@ -208,7 +208,7 @@ and **three** when reviewer comments arrive:
    `announced - emails sent` label and remove `fix released`.
 
 6. **Wait for the publication-ready notification comment.** The
-   `sync-security-issue` skill scans the public users-list archive
+   `security-sync-issues` skill scans the public users-list archive
    for the CVE ID on every run. Once it finds the archived advisory,
    it populates the tracker's *Public advisory URL* body field,
    regenerates the CVE JSON to carry the archive URL as a
@@ -225,7 +225,7 @@ and **three** when reviewer comments arrive:
    The record propagates to `cve.org` once the state lands.
 
 8. **Close the tracker.** Close as completed; do not update any
-   labels. The `sync-security-issue` skill's apply step archives the
+   labels. The `security-sync-issues` skill's apply step archives the
    project-board item afterwards (per the *archive-from-board* recipe
    in [`../github/project-board.md`](../github/project-board.md))
    so the closed tracker leaves the active board.

--- a/tools/vulnogram/release-manager-handoff-comment.md
+++ b/tools/vulnogram/release-manager-handoff-comment.md
@@ -12,7 +12,7 @@
 
 <!--
      Comment-template body for the release-manager hand-off comment
-     posted by `sync-security-issue` at the `pr merged` → `fix released`
+     posted by `security-sync-issues` at the `pr merged` → `fix released`
      transition (Step 12 of the lifecycle).
 
      Placeholders the skill substitutes:
@@ -60,18 +60,18 @@ reference without leaving this issue.
 
 The paste-ready CVE JSON is embedded in this tracker's
 [issue body](JSON_ANCHOR_URL) and is regenerated automatically on
-every body change by the [`sync-security-issue`](FRAMEWORK_SYNC_SKILL_URL) skill.
+every body change by the [`security-sync-issues`](FRAMEWORK_SYNC_SKILL_URL) skill.
 
 ### Step-by-step
 
 1. **First paste — `DRAFT` → `REVIEW`.** Open the [`#source` tab](SOURCE_TAB_URL) on the CVE record. Copy the embedded JSON from the tracker body above, paste into the form, **Save**. Move the record `DRAFT` → `REVIEW` via the Vulnogram UI.
-2. **Wait for CNA review.** Reviewer comments arrive by email on `SECURITY_LIST` with the CVE ID in the subject line. The `sync-security-issue` skill detects them automatically and proposes matching body-field updates on this tracker; the security team confirms and the embedded JSON regenerates. **If no reviewer comments arrive (common case), skip to step 4.** Otherwise, once the body has settled, re-paste the regenerated JSON into `#source` and **Save** again.
+2. **Wait for CNA review.** Reviewer comments arrive by email on `SECURITY_LIST` with the CVE ID in the subject line. The `security-sync-issues` skill detects them automatically and proposes matching body-field updates on this tracker; the security team confirms and the embedded JSON regenerates. **If no reviewer comments arrive (common case), skip to step 4.** Otherwise, once the body has settled, re-paste the regenerated JSON into `#source` and **Save** again.
 3. **Set `READY`.** Vulnogram UI action — the record is now ready for the advisory-send step.
 4. **Preview the advisory email** on the [email tab](EMAIL_TAB_URL) of the CVE record. Inspect how the email will render: subject, body, recipient list. The preview surfaces formatting issues (truncation, broken markdown, missing patch links) that the JSON view does not. If anything needs to change, edit the corresponding body field on this tracker, wait for the JSON to regenerate, re-paste in `#source`, and re-preview before sending.
 5. **Send advisory emails** from Vulnogram. The form sends to `USERS_LIST` and `ANNOUNCE_LIST`. Then on this tracker, add the `announced - emails sent` label and remove `fix released`.
-6. **(automatic) Archive URL captured.** The `sync-security-issue` skill scans the [users-list archive](ARCHIVE_SCAN_URL) for the CVE ID on every run. Once it finds the advisory, it populates the *Public advisory URL* body field, regenerates the CVE JSON to carry the archive URL as a `vendor-advisory` reference, and adds the `announced` label — **and posts a follow-up comment on this tracker** giving you the explicit go-ahead for the final paste below.
+6. **(automatic) Archive URL captured.** The `security-sync-issues` skill scans the [users-list archive](ARCHIVE_SCAN_URL) for the CVE ID on every run. Once it finds the advisory, it populates the *Public advisory URL* body field, regenerates the CVE JSON to carry the archive URL as a `vendor-advisory` reference, and adds the `announced` label — **and posts a follow-up comment on this tracker** giving you the explicit go-ahead for the final paste below.
 7. **Second paste — `REVIEW` → `PUBLIC`.** *Only after the follow-up comment in step 6 fires.* Re-open [`#source`](SOURCE_TAB_URL), paste the now-final JSON (carrying the archive URL in `references[]`), **Save**, move `REVIEW` → `PUBLIC` via the Vulnogram UI. The record propagates to `cve.org` once the state lands.
-8. **Close the tracker** — close as completed; do not update any labels. The `sync-security-issue` skill archives the project-board item so the closed tracker leaves the active board.
+8. **Close the tracker** — close as completed; do not update any labels. The `security-sync-issues` skill archives the project-board item so the closed tracker leaves the active board.
 
 ---
 

--- a/tools/vulnogram/release-manager-publication-comment.md
+++ b/tools/vulnogram/release-manager-publication-comment.md
@@ -11,7 +11,7 @@
 
 <!--
      Comment-template body for the publication-ready notification
-     comment posted by `sync-security-issue` when the *Public advisory
+     comment posted by `security-sync-issues` when the *Public advisory
      URL* body field has just been populated and the CVE JSON has been
      regenerated to carry the archive URL as a `vendor-advisory`
      reference (Step 14 of the lifecycle).
@@ -59,6 +59,6 @@ You can now do the final paste + state move:
 1. Open the [`#source` tab](SOURCE_TAB_URL) on the CVE record.
 2. Copy the regenerated JSON from this tracker's [issue body](JSON_ANCHOR_URL) and paste into the form. **Save**.
 3. Move the record `REVIEW` → `PUBLIC` via the Vulnogram UI. The record propagates to [`cve.org`](CVE_ORG_URL) once the state lands.
-4. **Close this tracker** — close as completed; do not update any labels. The `sync-security-issue` skill archives the project-board item afterwards.
+4. **Close this tracker** — close as completed; do not update any labels. The `security-sync-issues` skill archives the project-board item afterwards.
 
 That terminates the lifecycle. Thanks for driving this one.

--- a/tools/vulnogram/tool.md
+++ b/tools/vulnogram/tool.md
@@ -47,8 +47,8 @@ wrapper around the generic schema builders).
 
 ## How the generic skills address the CVE tool
 
-The generic `sync-security-issue`, `allocate-cve`, and
-`deduplicate-security-issue` skills frame their CVE-tool-facing steps
+The generic `security-sync-issues`, `security-allocate-cve`, and
+`security-deduplicate-issues` skills frame their CVE-tool-facing steps
 in project-tool-agnostic terms — *"regenerate the CVE artifact via
 the project's CVE tool"*, *"walk the user through the allocation
 flow"*, *"capture the reviewer-comment signal"*. They then delegate


### PR DESCRIPTION
## Summary
- Rename 13 skills with `setup-` / `security-` category prefixes (flat-on-disk — Claude Code only discovers flat `.claude/skills/<name>/`, nested subdirs verified empirically as not picked up).
- Drop `apache-` from `*-apache-steward` skill names (pre-empts the framework rename to `apache/steward`); pluralise batch-style skills (`security-import-issues`, `security-sync-issues`, `security-deduplicate-issues`).
- Update cross-references in 46 files (README, AGENTS.md, CONTRIBUTING.md, secure-agent-setup.md, secure-agent-internals.md, projects/_template/, tools/, `generate-cve-json` docstrings). 353/353 insertions/deletions — pure rename, no semantic change.

Preparation for adding the `pr-*` skill family (`pr-triage`, `pr-stats`, `pr-maintainer-review`) lifted from `apache/airflow` in a follow-up PR.

## Rename table

| Old | New |
|---|---|
| `setup-secure-config` | *(unchanged — already prefixed)* |
| `verify-secure-config` | `setup-verify-secure-config` |
| `update-secure-config` | `setup-update-secure-config` |
| `upgrade-apache-steward` | `setup-upgrade-steward` |
| `verify-apache-steward` | `setup-verify-steward` |
| `sync-shared-config` | `setup-sync-shared-config` |
| `import-security-issue` | `security-import-issues` |
| `import-security-issue-from-md` | `security-import-issues-from-md` |
| `import-security-issue-from-pr` | `security-import-issue-from-pr` |
| `sync-security-issue` | `security-sync-issues` |
| `fix-security-issue` | `security-fix-issue` |
| `allocate-cve` | `security-allocate-cve` |
| `deduplicate-security-issue` | `security-deduplicate-issues` |
| `invalidate-security-issue` | `security-invalidate-issue` |

## Breaking change for adopters

Adopters using the framework via submodule + symlinks (e.g. the `airflow-s` tracker) need to:
1. Bump their submodule pointer to the merge commit of this PR.
2. Update any project-side `.claude/skills/<name>` symlinks to the new names.

## Test plan
- [x] Claude Code discovers all renamed skills (live-change detection picked them up in-session)
- [x] No bare references to old names remain in tracked files (grep audit)
- [x] No double-prefix collisions (`setup-setup-`, `security-security-`)
- [x] Pre-commit hook passes locally
- [ ] CI link-check (lychee) passes
- [ ] Reviewer eyeballs the rename table for plural/singular consistency

🤖 Generated with [Claude Code](https://claude.com/claude-code)