### PR TITLE
docs: surface upcoming repo rename + list candidate names for the working-group poll

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -52,8 +52,10 @@ choices matter.
 
 ## Repository purpose
 
-This repository (`apache/airflow-steward`, future-renamed to
-`apache/steward`) is the **generic, project-agnostic framework**.
+This repository (currently `apache/airflow-steward`, **to be
+renamed** to `apache/steward` — see the `Heads-up — rename in
+flight` note at the top of [`README.md`](README.md)) is the
+**generic, project-agnostic framework**.
 It contains skills, tool adapters, generic process documentation,
 and a project-template scaffold — and **no project-specific
 content**. Adopting projects pull this repository in as a submodule

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -53,9 +53,10 @@ choices matter.
 ## Repository purpose
 
 This repository (currently `apache/airflow-steward`, **to be
-renamed** to `apache/steward` — see the `Heads-up — rename in
-flight` note at the top of [`README.md`](README.md)) is the
-**generic, project-agnostic framework**.
+renamed** — final name TBD per a working-group poll, see the
+`Heads-up — rename in flight, name not yet chosen` note at the
+top of [`README.md`](README.md) for the candidate list and
+timeline) is the **generic, project-agnostic framework**.
 It contains skills, tool adapters, generic process documentation,
 and a project-template scaffold — and **no project-specific
 content**. Adopting projects pull this repository in as a submodule

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
 **Table of Contents**  *generated with [DocToc](https://github.com/thlorenz/doctoc)*
 
-- [apache-steward](#apache-steward)
+- [Apache Steward (to be renamed)](#apache-steward-to-be-renamed)
   - [Skill families](#skill-families)
   - [Adopting the framework](#adopting-the-framework)
   - [Keeping the submodule current](#keeping-the-submodule-current)
@@ -13,13 +13,24 @@
 <!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->
 
-# apache-steward
+# Apache Steward (to be renamed)
+
+> **Heads-up — rename in flight.** This repository is currently
+> served from `apache/airflow-steward`; it is in the process of
+> being renamed to `apache/steward` to reflect its project-
+> agnostic identity (the framework stewards multiple ASF project
+> workflows, not just Airflow's). Until the rename lands on the
+> GitHub side, every clone URL, git-submodule reference, and CI
+> integration still uses the legacy `apache/airflow-steward`
+> slug — all path examples in this README and the linked docs
+> use that slug verbatim. The rename will only change the GitHub
+> repository slug; existing checkouts will keep working with a
+> single `git remote set-url`.
 
 Reusable, project-agnostic framework for ASF-project automation.
-Currently served from `apache/airflow-steward` for legacy reasons;
-future-renamed to `apache/steward`. Adopters pull this repository
-into their own tracker as a git submodule and ship project-specific
-configuration alongside it under `<project-config>/`.
+Adopters pull this repository into their own tracker as a git
+submodule and ship project-specific configuration alongside it
+under `<project-config>/`.
 
 ## Skill families
 

--- a/README.md
+++ b/README.md
@@ -15,17 +15,36 @@
 
 # Apache Steward (to be renamed)
 
-> **Heads-up — rename in flight.** This repository is currently
-> served from `apache/airflow-steward`; it is in the process of
-> being renamed to `apache/steward` to reflect its project-
-> agnostic identity (the framework stewards multiple ASF project
-> workflows, not just Airflow's). Until the rename lands on the
-> GitHub side, every clone URL, git-submodule reference, and CI
-> integration still uses the legacy `apache/airflow-steward`
-> slug — all path examples in this README and the linked docs
-> use that slug verbatim. The rename will only change the GitHub
-> repository slug; existing checkouts will keep working with a
-> single `git remote set-url`.
+> **Heads-up — rename in flight, name not yet chosen.** This
+> repository is currently served from `apache/airflow-steward`
+> and is going to be renamed to a **different** name — *not*
+> `apache/steward`. The current name carries `airflow` for
+> legacy reasons, but the framework is project-agnostic (it
+> stewards multiple ASF project workflows, not just Airflow's),
+> so the working group steering it will pick a new name that
+> reflects that. The final name will be chosen by **discussion
+> followed by a poll** among the working-group members.
+>
+> **Current candidate names** (the list is open for additions
+> during the **week of 4–9 May 2026**, after which the poll
+> opens):
+>
+> - Apache Mentor
+> - Apache Reeve
+> - Apache Guild
+> - Apache Minerva
+> - Apache Magpie
+> - Apache Beacon
+> - Apache Compass
+> - Apache Lexicon
+> - Apache Polyglot
+>
+> Until the rename lands on the GitHub side, every clone URL,
+> git-submodule reference, and CI integration still uses the
+> legacy `apache/airflow-steward` slug — all path examples in
+> this README and the linked docs use that slug verbatim. The
+> rename will only change the GitHub repository slug; existing
+> checkouts will keep working with a single `git remote set-url`.
 
 Reusable, project-agnostic framework for ASF-project automation.
 Adopters pull this repository into their own tracker as a git


### PR DESCRIPTION
## Summary
Make the repository's pending rename visible to anyone landing on the README or `AGENTS.md`. The new name is **not yet chosen** — it will be picked by the working group via discussion + poll.

## Changes

**`README.md`:**
- Title: `apache-steward` → `Apache Steward (to be renamed)`. Surfaces the rename status in every link, GitHub preview, and search-result snippet.
- New `> Heads-up — rename in flight, name not yet chosen.` blockquote up front:
  - The new name is **not** `apache/steward` — it will be a different, project-agnostic name (the framework stewards multiple ASF project workflows, not just Airflow's).
  - The final name will be chosen by **discussion followed by a poll** among the working-group members.
  - The candidate list is open for additions during the **week of 4–9 May 2026**, after which the poll opens.
  - Current candidates listed: Apache Mentor, Apache Reeve, Apache Guild, Apache Minerva, Apache Magpie, Apache Beacon, Apache Compass, Apache Lexicon, Apache Polyglot.
  - Operational note: until the rename lands, every clone URL / submodule reference / CI integration still uses the legacy `apache/airflow-steward` slug — all path examples in the docs use that slug verbatim. The rename will only change the GitHub repository slug; existing checkouts will keep working with a single `git remote set-url`.

**`AGENTS.md`:**
- "Repository purpose" section: remove the `apache/steward` target reference; point at the README heads-up for the candidate list and timeline.

doctoc TOC regenerated for `README.md`.

## Test plan
- [x] `prek run --all-files` passes
- [x] No `apache/steward` (singular target) references remain anywhere except the heads-up's "*not* `apache/steward`" call-out (intentional)
- [ ] Reviewer confirms the candidate list matches what the working group has agreed to surface publicly
- [ ] Reviewer confirms the 4–9 May 2026 deadline window is current
- [ ] CI link-check (lychee) passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)