### PR TITLE
feat(setup-steward): auto-overwrite committed bootstrap skill on upgrade

### DIFF
--- a/.claude/skills/setup-steward/upgrade.md
+++ b/.claude/skills/setup-steward/upgrade.md
@@ -76,9 +76,10 @@ For each kind of drift, present:
   reconciliation in Step 5).
 - **`setup-steward` skill changed in the framework** —
   surface as a separate note. The adopter's *committed*
-  copy of `setup-steward` may need re-copying from the new
-  snapshot; that is an explicit project-level decision, not
-  auto-applied.
+  copy of `setup-steward` will be auto-overwritten from the
+  new snapshot in [Step 6b](#step-6b--overwrite-the-committed-setup-steward-skill-from-the-new-snapshot)
+  so the bootstrap stays in sync with the framework version
+  the project just pinned.
 
 Ask for explicit confirmation before deleting and re-
 installing.
@@ -156,6 +157,62 @@ the families the adopter previously picked, and offer to
 symlink them in.
 
 For the double-symlinked convention, refresh both layers.
+
+## Step 6b — Overwrite the committed `setup-steward` skill from the new snapshot
+
+The adopter-side committed `setup-steward` skill is the
+**only** framework skill that lives as a committed copy
+rather than a gitignored symlink (per
+[`SKILL.md` Golden rule 6](SKILL.md#golden-rules)). When the
+framework's `setup-steward` evolves — new sub-action, lock-
+format change, drift-detection refinement — the adopter's
+copy must follow, or the bootstrap on a fresh clone will run
+old logic against a new snapshot.
+
+This step keeps the two in sync **automatically on every
+upgrade**:
+
+1. Compute the diff between the adopter-side
+   `<adopter-skills-dir>/setup-steward/` (committed copy)
+   and the snapshot's
+   `.apache-steward/.claude/skills/setup-steward/`.
+2. **If the adopter has local modifications** to their
+   committed copy beyond what's in the snapshot — surface
+   the diff and stop. Do **not** silently overwrite local
+   work. The user either (a) confirms the modifications can
+   be discarded, (b) decides to upstream them as a PR
+   against `apache/airflow-steward` first, or (c) defers the
+   bootstrap-skill update to a later upgrade run.
+3. **If there are no local modifications** (or the user
+   confirmed in 2), copy the snapshot's `setup-steward`
+   over the committed copy:
+
+   ```bash
+   # For the flat layout:
+   rm -rf .claude/skills/setup-steward
+   cp -r .apache-steward/.claude/skills/setup-steward \
+         .claude/skills/setup-steward
+
+   # For the double-symlinked layout (e.g. apache/airflow):
+   rm -rf .github/skills/setup-steward
+   cp -r .apache-steward/.claude/skills/setup-steward \
+         .github/skills/setup-steward
+   # The .claude/skills/setup-steward symlink does not need
+   # touching — it points at .github/skills/setup-steward
+   # which is now the new content.
+   ```
+
+4. The new bootstrap-skill content lands as **modified files
+   in `git status`** at the adopter's committed-skill path.
+   The user reviews the diff and commits it as part of the
+   upgrade PR; on merge, every other contributor's next
+   `/setup-steward` run loads the matching version.
+
+The adopter shouldn't modify the bootstrap copy locally —
+the framework's hard rule is *"local mods go in
+`.apache-steward-overrides/`, framework changes go via PR
+to `apache/airflow-steward`"*. But if they did, this step
+catches it before the overwrite would erase their work.
 
 ## Step 7 — Update `<local-lock>`
 

--- a/.claude/skills/setup-steward/verify.md
+++ b/.claude/skills/setup-steward/verify.md
@@ -136,9 +136,25 @@ snapshot's `.apache-steward/.claude/skills/setup-steward/`.
 
 - ✓ if same content.
 - ⚠ if different — the adopter's committed copy has
-  drifted. Suggest re-copying from the snapshot per the
-  install recipe. The user may have intentional local
-  tweaks; surface as ⚠ not ✗.
+  drifted from the snapshot. The remediation depends on
+  *which way* the drift goes:
+
+  - **Snapshot is newer than the committed copy** (typical
+    case after a framework upgrade where the adopter has
+    not yet rerun `/setup-steward upgrade`). Run
+    `/setup-steward upgrade` — its
+    [Step 6b](upgrade.md#step-6b--overwrite-the-committed-setup-steward-skill-from-the-new-snapshot)
+    auto-overwrites the committed copy with the snapshot's
+    version, surfaces local modifications first if any
+    exist, and lands the change in `git status` for the
+    user to commit.
+  - **Committed copy is newer than the snapshot** (the
+    adopter modified the bootstrap skill directly; an
+    anti-pattern per the framework's hard rule). The
+    framework-side fix is to upstream the modifications as
+    a PR against `apache/airflow-steward`; the local fix
+    is to revert the modifications and use
+    `.apache-steward-overrides/` instead.
 
 ### 8. Post-checkout hook installed
 


### PR DESCRIPTION
## Summary

When `/setup-steward upgrade` refreshes the snapshot to a new framework version, automatically replace the adopter-side committed `setup-steward` skill (the only framework artefact they commit) with the version from the just-installed snapshot.

## Why

The committed `setup-steward` is the **only** framework skill an adopter copies into their repo (Golden rule 6: *"copy this skill, symlink the rest"*). When the framework's `setup-steward` evolves — new sub-action, lock-format change, drift-detection refinement, recipe addition — the adopter's copy must follow, or the bootstrap on a fresh clone will run **old logic against a new snapshot**.

Before this PR, `upgrade` only *surfaced* the drift between the committed copy and the snapshot. After this PR, `upgrade` actually fixes it.

## Behaviour change

**`upgrade.md`** adds a new `Step 6b — Overwrite the committed setup-steward skill from the new snapshot` (between symlink refresh and local-lock update):

1. Diff the adopter-side committed `setup-steward` against the snapshot's `setup-steward`.
2. **If the adopter has local modifications** beyond the snapshot's content — surface the diff and stop. Do NOT silently overwrite local work. The user either:
   - confirms the modifications can be discarded, OR
   - upstreams them as a framework PR first, OR
   - defers the bootstrap-skill update to a later upgrade.
3. **Otherwise**, `cp -r` the snapshot's `setup-steward` over the committed copy. The new content lands in `git status` for the user to commit as part of the upgrade PR.

Layout-aware:
- **Flat**: `cp` into `.claude/skills/setup-steward/`.
- **Double-symlinked**: `cp` into `.github/skills/setup-steward/`. The `.claude/skills/setup-steward` symlink keeps pointing at the right (now-updated) location.

**`verify.md`** Check 7 ("setup-steward up to date") updated to distinguish the two drift directions:

- **Snapshot newer than committed** (typical post-framework-upgrade case before the adopter has rerun `/setup-steward upgrade`) → point at upgrade's Step 6b auto-overwrite.
- **Committed newer than snapshot** (anti-pattern: adopter modified bootstrap directly) → upstream the modifications as a PR against `apache/airflow-steward`, or revert to use `.apache-steward-overrides/` instead.

**`upgrade.md`** Step 2 ("Surface what changed") updated to reflect that bootstrap-skill drift is no longer a manual decision — Step 6b handles it.

## Test plan

- [x] All `prek run --all-files` hooks pass (markdownlint, typos, doctoc, check-placeholders)
- [x] Step 6b heading anchor (`#step-6b--overwrite-the-committed-setup-steward-skill-from-the-new-snapshot`) is reachable from `verify.md`'s back-reference
- [ ] Reviewer eyeballs the local-modification protection flow: cardinal sin would be silently overwriting work the adopter painted into the bootstrap copy
- [ ] CI link-check (lychee) passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)