### PR TITLE
docs(AGENTS): tool credentials live in $HOME, never in project tree

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -338,6 +338,28 @@ layered defence the framework dogfoods (`.claude/settings.json`
 sandbox + tool permissions + clean-env wrapper, with system tools
 pinned per-tool with a 7-day default upstream cooldown).
 
+**Tool credentials live under `$HOME`, never in the project tree.**
+Any persistent token, API key, OAuth refresh token, or session
+cookie a framework tool needs goes under a well-known home-directory
+path — `~/.config/apache-steward/<tool>` for tools the framework
+owns, or whatever upstream convention the third-party tool already
+uses. The existing exemplars: Gmail OAuth at
+`~/.config/apache-steward/gmail-oauth.json` (see
+[`tools/gmail/oauth-draft/src/oauth_draft/credentials.py`](tools/gmail/oauth-draft/src/oauth_draft/credentials.py)),
+PonyMail session cookie at `~/.ponymail-mcp/session.json`, GitHub
+auth via `gh auth` (`~/.config/gh/`). Two reasons this is
+non-negotiable: (1) the standard sandbox
+([`docs/setup/secure-agent-setup.md`](docs/setup/secure-agent-setup.md))
+denies reads on home-dir credential paths, so an in-tree credential
+silently bypasses that boundary — every credential read becomes an
+explicit, visible sandbox-bypass moment instead of a silent in-tree
+file slurp; (2) one credential file serves every clone / worktree /
+project, not re-acquired per checkout. New tool integrations MUST
+follow the pattern. If a credential is found in-tree (legacy,
+copy-paste from upstream docs, generated to a temp scratch path),
+relocate it to a home-dir path and update the tool to read from
+there — never leave it in place "because it's already there".
+
 This repository uses [`prek`](https://github.com/j178/prek) (a fast, Rust-based drop-in
 replacement for `pre-commit`) to run pre-commit hooks that keep the documentation
 consistent — regenerating the `doctoc` tables of contents, stripping trailing whitespace,


### PR DESCRIPTION
## Summary

Codify the credential-storage convention every existing framework tool already follows, so future tool integrations follow the same pattern.

- Gmail OAuth → `~/.config/apache-steward/gmail-oauth.json`
- PonyMail session cookie → `~/.ponymail-mcp/session.json`
- GitHub auth → `gh auth` (`~/.config/gh/`)

Two reasons it's non-negotiable:

1. The standard sandbox (see `docs/setup/secure-agent-setup.md`) denies reads on home-dir credential paths. An in-tree credential silently bypasses that boundary — every credential read should be an explicit, visible sandbox-bypass moment, not a silent in-tree file slurp.
2. One credential file should serve every clone / worktree / project, not be re-acquired per checkout.

The new principle slots in as a sibling to the existing *"Run the agent in the credential-isolation setup"* block under `## Local setup`.

## Test plan

- [ ] Visual review of the AGENTS.md diff — paragraph reads cleanly alongside the credential-isolation block above it.
- [ ] No tool code change required: existing tools (`tools/gmail/oauth-draft/src/oauth_draft/credentials.py`, `tools/ponymail/`, `tools/github/`) already follow the rule.