### PR TITLE
ci: fix all broken links and flip link-check to hard gate

### DIFF
--- a/.github/workflows/link-check.yml
+++ b/.github/workflows/link-check.yml
@@ -64,10 +64,24 @@ jobs:
         # PR. The previous v2.6.1 pin was not on the allowlist; v2.8.0
         # (2026-02-17) is. When bumping, pick the next allowlisted SHA
         # — do not pick the latest upstream release blindly.
+        #
+        # `lycheeVersion` is pinned to v0.23.0 — the newest binary
+        # whose release archive lays the `lychee` executable at the
+        # top level. From the v0.24 line onward the archive wraps
+        # the binary in a `lychee-<arch>-<os>/` directory, which
+        # the v2.8.0 action's install step does not handle (it
+        # `install`s the literal `lychee` path and exits with
+        # `cannot stat`). Until a newer lychee-action SHA is added
+        # to the ASF infrastructure-actions allowlist, the binary
+        # has to stay on v0.23.x. `.lychee.toml` matches: the
+        # boolean form of `include_fragments` is what v0.23.x
+        # expects (the enum string `"anchor-only"` is a v0.24+
+        # form).
         uses: lycheeverse/lychee-action@8646ba30535128ac92d33dfc9133794bfdd9b411  # v2.8.0
         with:
           args: --config .lychee.toml --no-progress .
           fail: true
+          lycheeVersion: v0.23.0
           token: ${{ secrets.GITHUB_TOKEN }}
         continue-on-error: false
 

--- a/.github/workflows/link-check.yml
+++ b/.github/workflows/link-check.yml
@@ -67,9 +67,9 @@ jobs:
         uses: lycheeverse/lychee-action@8646ba30535128ac92d33dfc9133794bfdd9b411  # v2.8.0
         with:
           args: --config .lychee.toml --no-progress .
-          fail: false
+          fail: true
           token: ${{ secrets.GITHUB_TOKEN }}
-        continue-on-error: true
+        continue-on-error: false
 
       - name: Summarise
         if: always()

--- a/.lychee.toml
+++ b/.lychee.toml
@@ -10,11 +10,13 @@
 #
 # Run in CI: see `.github/workflows/doc-validation.yml`.
 
-# Check anchor fragments, not just file paths.
-# `anchor-only` enables `#section` checks (which is what GitHub-style
-# slugs produce); `text-only` would also enable `#:~:text=` fragments
-# but those are not used in this repo.
-include_fragments = "anchor-only"
+# Check anchor fragments, not just file paths — `#section` checks
+# the GitHub-style slug exists in the linked file. Boolean form is
+# the v0.23.x schema (and the version `link-check.yml` pins; see
+# the comment there for why we cannot move to v0.24's enum-string
+# form yet). When CI moves to lychee v0.24+, change this to
+# `include_fragments = "anchor-only"`.
+include_fragments = true
 
 # Concurrency cap — kept moderate to avoid being rate-limited by GitHub.
 max_concurrency = 14

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -371,7 +371,7 @@ and the failure mode is silent. Make `git submodule update --init
 into a post-merge hook (`.git/hooks/post-merge` →
 `#!/bin/sh\nexec git submodule update --init --recursive`). Same
 rule applies to the framework's own
-[`setup-steward-upgrade`](.claude/skills/setup-steward-upgrade/SKILL.md)
+[`setup-steward upgrade`](.claude/skills/setup-steward/upgrade.md)
 skill: when invoked from inside an adopter tracker, it reminds
 the user to follow up with submodule update on the parent.
 
@@ -1273,11 +1273,11 @@ When adding a new skill:
 
 ## References
 
-- [`config/README.md`](config/README.md) — two-layer configuration model + step-by-step tutorial (project + user).
-- [`config/active-project.md`](config/active-project.md) — declares which project under `projects/` this working tree targets.
-- [`config/user.md.example`](config/user.md.example) — per-user configuration template (copy to `config/user.md`, which is gitignored).
+- `.apache-steward-overrides/user.md` — per-user configuration (PMC status, local clone paths, optional tool backends) scaffolded during adoption.
 - [`<project-config>/project.md`](<project-config>/project.md) — the adopting project's manifest (identity, repositories, mailing lists, tools enabled, CVE tooling, GitHub project board + issue-template field declarations).
-- [`<project-config>/`](projects/airflow/) — other project-specific files (canned responses, release trains, security model, scope labels, milestones, title-normalization, fix workflow, naming conventions).
+- `.apache-steward-overrides/` — adopter-specific overrides and per-user config committed in the adopter repo.
+- [`<project-config>/project.md`](<project-config>/project.md) — the adopting project's manifest (identity, repositories, mailing lists, tools enabled, CVE tooling, GitHub project board + issue-template field declarations).
+- [`<project-config>/`](projects/_template/) — other project-specific files (canned responses, release trains, security model, scope labels, milestones, title-normalization, fix workflow, naming conventions).
 - [`tools/github/`](tools/github/) — GitHub tool adapter: `tool.md` (overview), `operations.md` (`gh` CLI / API catalogue), `issue-template.md` (body-field schema), `labels.md` (lifecycle-label taxonomy), `project-board.md` (Projects V2 GraphQL).
 - [`tools/gmail/`](tools/gmail/) — Gmail tool adapter: `tool.md` (overview), `operations.md` (MCP catalogue + no-update limitation), `threading.md` (prefer-`threadId`-else-subject-fallback rule), `asf-relay.md` (ASF-security-relay drafting), `search-queries.md` (query templates), `ponymail-archive.md` (ASF PonyMail URL construction).
 - [`tools/vulnogram/`](tools/vulnogram/) — Vulnogram (ASF CVE tool) adapter: `tool.md` (overview), `allocation.md` (PMC-gated allocation flow), `record.md` (record URLs + `#source` paste + `DRAFT`/`REVIEW`/`PUBLIC` state machine + reviewer-comment signal), `generate-cve-json/` (CVE-5.x JSON generator — Python project).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -54,14 +54,13 @@ four — no hard-coded project assumptions anywhere.
   deduplicating two trackers. Skills use the `<PROJECT>` /
   `<tracker>` / `<upstream>` placeholders everywhere and resolve them
   at runtime. They must not contain project-specific strings.
-- **Config** lives under [`config/`](config/) and wires the runtime
-  together.
-  [`config/active-project.md`](config/active-project.md) declares which
-  subtree under `projects/` is active (checked in);
-  [`config/user.md`](config/README.md#what-the-user-layer-does) carries
-  per-user preferences (tool access, PMC status, local clone paths) and
-  is **gitignored**. Two prek hooks keep `user.md` off the remote. See
-  [`config/README.md`](config/README.md) for the full tutorial.
+- **Per-user config** is scaffolded by `setup-steward` at
+  `.apache-steward-overrides/user.md` in the adopter repo. It carries
+  per-user preferences (PMC status, local clone paths, optional tool
+  backends) and is **committed** so it ships with the adopter repo.
+  If the file is missing, skills fall back to interactive prompting
+  and offer to save the answer back. See the `user.md` template in
+  [`.claude/skills/setup-steward/adopt.md`](.claude/skills/setup-steward/adopt.md) for the full shape.
 - **Projects** live under [`projects/`](projects/), one subtree per
   supported ASF project. The active subtree holds every
   project-specific fact the skills depend on — the security model, the
@@ -168,18 +167,18 @@ git clone git@github.com:<tracker>.git
 cd <tracker-repo-name>
 prek install                   # wire the hooks into .git/hooks
 prek run --all-files           # runs every hook on every file; does a
-                               # one-time bootstrap of config/user.md
+                               # one-time bootstrap of .apache-steward-overrides/user.md
                                # from the template
 ```
 
 The `bootstrap-user-config` hook will create
-[`config/user.md`](config/README.md#what-the-user-layer-does) on the
+`.apache-steward-overrides/user.md` on the
 first run. Open it, grep for `TODO`, and fill in the lines that apply
 to your setup. The file is gitignored; a second hook
 (`forbid-user-config`) refuses any commit that stages it, so you
 cannot accidentally publish your local configuration.
 
-Read [`config/README.md`](config/README.md) for the end-to-end
+Read [`.claude/skills/setup-steward/adopt.md`](.claude/skills/setup-steward/adopt.md) for the end-to-end
 configuration tutorial, including the placeholder convention and how
 the skills consume both layers.
 
@@ -333,8 +332,8 @@ doc wins. Re-read it first:
 
 - [`README.md`](README.md) — the 16-step disclosure process.
 - [`AGENTS.md`](AGENTS.md) — editorial and confidentiality rules.
-- [`config/README.md`](config/README.md) — configuration layer tutorial.
-- [`projects/README.md`](projects/README.md) — current-projects index
+- [`.claude/skills/setup-steward/adopt.md`](.claude/skills/setup-steward/adopt.md) — framework adoption + per-user config scaffold tutorial.
+- [`projects/_template/README.md`](projects/_template/README.md) — current-projects index
   and the new-project bootstrap path.
 - [`projects/_template/`](projects/_template/) — scaffold to clone when
   adding a new project.

--- a/docs/prerequisites.md
+++ b/docs/prerequisites.md
@@ -51,7 +51,7 @@ specifically.
 The agent runs against pre-disclosure CVE content (private mail
 threads, draft advisories, in-flight tracker discussions). Run it
 with the credential-isolation setup documented in
-[`docs/setup/secure-agent-setup.md`](docs/setup/secure-agent-setup.md) — a layered
+[`docs/setup/secure-agent-setup.md`](setup/secure-agent-setup.md) — a layered
 defence built around Claude Code's filesystem sandbox, tool-level
 permission rules, and a clean-env wrapper that strips credential-
 shaped variables from the agent's environment. The required system

--- a/docs/security/how-to-fix-a-security-issue.md
+++ b/docs/security/how-to-fix-a-security-issue.md
@@ -105,8 +105,8 @@ page is the two-minute summary.
   from raising reports about issues they were not originally aware
   of. Such tools may themselves violate our security practices.
 * **Keep the reporter informed at every status transition** — see
-  the [*Keeping the reporter informed*](../../README.md#keeping-the-reporter-informed)
-  section of `README.md` for the full list of transitions and the
+  the [*Keeping the reporter informed*](../security/roles.md#keeping-the-reporter-informed)
+  section of `roles.md` for the full list of transitions and the
   drafting rules.
 * **Confidentiality first.** Tracker URLs and `#NNN` identifiers
   are public-safe (they point at access-gated pages); tracker

--- a/docs/security/new-members-onboarding.md
+++ b/docs/security/new-members-onboarding.md
@@ -85,7 +85,7 @@ for the lookup command and the latest snapshot.
 - **Private PRs on the `<tracker>` `main` branch** — an exceptional
   path used for highly-critical fixes that need private code review
   before going public. See
-  [Step 9](../../README.md#step-9--open-a-private-pr-exceptional-cases) of
+  [Step 9](../security/process.md#step-9--open-a-private-pr-exceptional-cases) of
   the process.
 
 Some discussions with an obvious answer can be handled on the mailing
@@ -136,7 +136,7 @@ any per-user config.
 Once you have observed the process for a while, you can start taking
 on more of the work. The three rotating roles — issue triager,
 remediation developer, release manager — are defined in
-[`README.md` — Who this guide is for](../../README.md#who-this-guide-is-for),
+[`README.md`](../../README.md),
 which describes the step ranges each role owns. From the onboarding
 perspective:
 
@@ -157,7 +157,7 @@ You can volunteer to provide a fix for a specific issue even before
 formally taking on the remediation-developer role — just comment on
 the tracker and self-assign. You can also ask whether it makes sense
 to involve someone else to provide the fix (see
-[Step 7](../../README.md#step-7--self-assign-and-implement-the-fix) for the
+[Step 7](../security/process.md#step-7--self-assign-and-implement-the-fix) for the
 delegation rules).
 
 # Using the agent skills
@@ -177,11 +177,11 @@ a few times a week are:
 
 - **`import new reports`** — converts un-imported security-list
   threads into trackers and drafts the receipt-of-confirmation reply.
-  See [Step 2](../../README.md#step-2--import-the-report).
+  See [Step 2](../security/process.md#step-2--import-the-report).
 - **`sync all issues`** — reconciles every open tracker with its mail
   thread, its fix PR, the release train, and the users-list archive.
 - **`allocate CVE for issue #N`** — when a report is assessed as valid.
-  See [Step 6](../../README.md#step-6--allocate-the-cve).
+  See [Step 6](../security/process.md#step-6--allocate-the-cve).
 
 There is also a fourth command for anyone willing to take on a
 remediation-developer turn:
@@ -199,8 +199,8 @@ remediation-developer turn:
   repo slug / `vulnerability` / `security fix` leakage before being
   written or pushed. The skill refuses to operate on reports that are still being
   assessed, or on issues that need the private-PR fallback of
-  [Step 9](../../README.md#step-9--open-a-private-pr-exceptional-cases). See
-  [For remediation developers — Steps 7–11](../../README.md#for-remediation-developers--steps-711)
+  [Step 9](../security/process.md#step-9--open-a-private-pr-exceptional-cases). See
+  [Steps 7–11 in the process reference](../security/process.md#step-7--self-assign-and-implement-the-fix)
   for the full expectations around a fix PR.
 
 Every skill is a **proposal engine**, not an auto-pilot — it reads the

--- a/docs/security/process.md
+++ b/docs/security/process.md
@@ -34,7 +34,7 @@
 The authoritative reference for the 16-step security-issue
 lifecycle and the label-lifecycle state diagram. The
 [role guides](roles.md) point into specific steps; the
-[security skills](../../README.md#skills) execute the steps.
+[security skills](../../.claude/skills/) execute the steps.
 
 ## Process reference: the 16 steps
 
@@ -173,7 +173,7 @@ remove `needs triage`. If invalid,
 labels `invalid`, posts a closing comment, archives the board item,
 and (for `<security-list>`-imported trackers) drafts a polite-but-firm
 reporter reply. If consensus cannot be reached, follow
-[ASF voting](https://www.apache.org/foundation/voting.html#apache-voting-process)
+[ASF voting](https://www.apache.org/foundation/voting.html)
 on `<security-list>`.
 
 If a candidate duplicate is detected,

--- a/docs/setup/README.md
+++ b/docs/setup/README.md
@@ -39,8 +39,8 @@ framework safe to use.
 | [`setup-isolated-setup-install`](../../.claude/skills/setup-isolated-setup-install/SKILL.md) | First-time install of the secure agent setup. |
 | [`setup-isolated-setup-verify`](../../.claude/skills/setup-isolated-setup-verify/SKILL.md) | Verify the secure setup landed correctly. |
 | [`setup-isolated-setup-update`](../../.claude/skills/setup-isolated-setup-update/SKILL.md) | Surface drift between the installed setup and the framework's latest. |
-| [`setup-steward-upgrade`](../../.claude/skills/setup-steward-upgrade/SKILL.md) | Pull the framework checkout to latest `origin/main`. |
-| [`setup-steward-verify`](../../.claude/skills/setup-steward-verify/SKILL.md) | Verify the framework is integrated correctly into an adopter tracker. |
+| [`setup-steward upgrade`](../../.claude/skills/setup-steward/upgrade.md) | Pull the framework checkout to latest `origin/main`. |
+| [`setup-steward verify`](../../.claude/skills/setup-steward/verify.md) | Verify the framework is integrated correctly into an adopter tracker. |
 | [`setup-shared-config-sync`](../../.claude/skills/setup-shared-config-sync/SKILL.md) | Commit + push the user's shared Claude config to its sync repo. |
 
 ## Deep documentation

--- a/docs/setup/secure-agent-setup.md
+++ b/docs/setup/secure-agent-setup.md
@@ -90,7 +90,7 @@ privilege-elevating runs without you saying so.
 ```text
 1. Open Claude Code in your tracker repo (or any directory).
 2. If you consume the framework as a submodule of your tracker
-   (the canonical adopter pattern), run /setup-steward-verify
+   (the canonical adopter pattern), run `/setup-steward verify`
    to confirm `.apache-steward/`, the submodule, and the
    project-config under it are wired correctly. Read-only —
    surfaces gaps, never auto-fixes.
@@ -100,7 +100,7 @@ privilege-elevating runs without you saying so.
 4. Run /setup-isolated-setup-verify — confirms ✓/✗/⚠ for every piece
    of the secure-agent setup.
 5. When you want to be on the framework's latest, run
-   /setup-steward-upgrade — pulls your local airflow-steward
+   `/setup-steward upgrade` — pulls your local airflow-steward
    checkout to origin/main with --ff-only, refuses to touch a
    dirty working tree, surfaces what arrived. Then run
    /setup-isolated-setup-update to surface user-side drift the
@@ -115,10 +115,10 @@ privilege-elevating runs without you saying so.
 ```
 
 The skills are at
-[`.claude/skills/setup-steward-verify/`](../../.claude/skills/setup-steward-verify/SKILL.md),
+[`.claude/skills/setup-steward/verify.md`](../../.claude/skills/setup-steward/verify.md),
 [`.claude/skills/setup-isolated-setup-install/`](../../.claude/skills/setup-isolated-setup-install/SKILL.md),
 [`.claude/skills/setup-isolated-setup-verify/`](../../.claude/skills/setup-isolated-setup-verify/SKILL.md),
-[`.claude/skills/setup-steward-upgrade/`](../../.claude/skills/setup-steward-upgrade/SKILL.md),
+[`.claude/skills/setup-steward/upgrade.md`](../../.claude/skills/setup-steward/upgrade.md),
 [`.claude/skills/setup-isolated-setup-update/`](../../.claude/skills/setup-isolated-setup-update/SKILL.md),
 [`.claude/skills/setup-shared-config-sync/`](../../.claude/skills/setup-shared-config-sync/SKILL.md).
 Each skill references back into the canonical sections of this
@@ -176,8 +176,8 @@ detail.
 Every system-level tool the secure setup depends on is pinned with a
 **per-tool cooldown** before the framework adopts a new upstream
 release — same convention as the `[tool.uv] exclude-newer = "7 days"`
-setting in [`pyproject.toml`](pyproject.toml) and the weekly Dependabot
-updates in [`.github/dependabot.yml`](.github/dependabot.yml).
+setting in [`pyproject.toml`](../../pyproject.toml) and the weekly Dependabot
+updates in [`.github/dependabot.yml`](../../.github/dependabot.yml).
 Default cooldown is 7 days; individual tools can override via
 `cooldown_days = N` in the manifest when their release stream
 warrants it. `claude-code` is the canonical override at 1 day —
@@ -1117,7 +1117,7 @@ setup steps written into the screenshot's caption.
 
 **1. Sandboxed session — the steady state.**
 
-![Sandboxed session: status-line prefix `[sandbox]` rendered green](images/session-sandboxed.png)
+![Sandboxed session: status-line prefix `[sandbox]` rendered green](../../images/session-sandboxed.png)
 
 The terminal footer renders `<model> [sandbox]` in green when
 the active settings (project `settings.local.json` →
@@ -1129,7 +1129,7 @@ listed in `sandbox.filesystem.allowRead`.
 **2. Unsandboxed session — the failure mode this setup exists
 to make obvious.**
 
-![Unsandboxed session: status-line prefix `[NO SANDBOX]` rendered bold red](images/session-no-sandbox.png)
+![Unsandboxed session: status-line prefix `[NO SANDBOX]` rendered bold red](../../images/session-no-sandbox.png)
 
 `[NO SANDBOX]` in bold red means the active settings do not
 enable the sandbox. The agent's Bash subprocesses run with full
@@ -1140,7 +1140,7 @@ unnoticed for hours.
 
 **3. Sandbox-bypass attempt — the per-call signal.**
 
-![Bold red SANDBOX BYPASS banner immediately above the Claude Code permission prompt](images/sandbox-bypass-banner.png)
+![Bold red SANDBOX BYPASS banner immediately above the Claude Code permission prompt](../../images/sandbox-bypass-banner.png)
 
 When the model invokes the Bash tool with
 `dangerouslyDisableSandbox: true`, the
@@ -1161,7 +1161,7 @@ deny at the prompt (the visual is what matters).
 
 **4. Sandbox actually denying a read — proof it is real.**
 
-![Sandboxed Bash call to `ls ~/Downloads` blocked by the runtime; surfaced as "read ~/Downloads (outside allowed read paths)" with an offer to retry with the sandbox disabled](images/sandbox-blocks-read.png)
+![Sandboxed Bash call to `ls ~/Downloads` blocked by the runtime; surfaced as "read ~/Downloads (outside allowed read paths)" with an offer to retry with the sandbox disabled](../../images/sandbox-blocks-read.png)
 
 In a sandboxed session **without** bypass, a Bash call that
 tries to touch a path outside `allowRead` is intercepted by
@@ -1177,7 +1177,7 @@ at the tool boundary, which is the cleaner failure mode.
 **5. bubblewrap / Seatbelt in action — the OS layer the runtime
 falls back to.**
 
-![Sandboxed Bash call running `python3 -c 'os.listdir(os.path.expanduser("~/.aws/"))'`; the inner syscall fails with PermissionError: [Errno 1] Operation not permitted: '/Users/jarekpotiuk/.aws/'](images/sandbox-os-level-block.png)
+![Sandboxed Bash call running `python3 -c 'os.listdir(os.path.expanduser("~/.aws/"))'`; the inner syscall fails with PermissionError: [Errno 1] Operation not permitted: '/Users/jarekpotiuk/.aws/'](../../images/sandbox-os-level-block.png)
 
 When the eventual filesystem access is **opaque to lexical
 analysis** — here, a path constructed inside a `python3 -c`

--- a/projects/_template/README.md
+++ b/projects/_template/README.md
@@ -145,7 +145,7 @@ skills):
 
 ## Cross-references
 
-- [`../README.md`](../README.md) — framework-level *"Adopting the
+- [`../../README.md`](../../README.md) — framework-level *"Adopting the
   framework"* view + bootstrap walk-through.
 - [`../../AGENTS.md`](../../AGENTS.md#placeholder-convention-used-in-skill-files) —
   the placeholder convention that lets skills resolve `<project-config>/`

--- a/projects/_template/canned-responses.md
+++ b/projects/_template/canned-responses.md
@@ -95,7 +95,7 @@ TODO.
 
 Every lifecycle transition that the team commits to notifying the
 reporter about (per
-[`../../README.md#keeping-the-reporter-informed`](../../README.md#keeping-the-reporter-informed))
+[`../../docs/security/roles.md#keeping-the-reporter-informed`](../../docs/security/roles.md#keeping-the-reporter-informed))
 needs a short template. Skills draft from these verbatim and send
 on the original inbound thread.
 
@@ -178,5 +178,5 @@ updated record URL.
   must not appear in templates that go out as email — they remain
   internal-only.
 - **Every transition that warrants a reply is listed in
-  [`../../README.md`](../../README.md#keeping-the-reporter-informed)** —
+  [`../../docs/security/roles.md`](../../docs/security/roles.md#keeping-the-reporter-informed)** —
   treat that list as authoritative.

--- a/projects/_template/project.md
+++ b/projects/_template/project.md
@@ -22,9 +22,7 @@
 
 This is the **project configuration** for `TODO: <project-name>`.
 Every skill under [`../../.claude/skills/`](../../.claude/skills/)
-reads the project name from
-[`../../config/active-project.md`](../../config/active-project.md) and
-then loads this manifest to resolve project-specific identity,
+reads the project name from `<project-config>/project.md` and then loads this manifest to resolve project-specific identity,
 repositories, mailing lists, and references to the other files in
 this directory.
 
@@ -161,9 +159,8 @@ values below are what the generic recipes substitute in.
 ## Issue-template fields
 
 The skills' body-field roles map to the following concrete `###`
-headings in the project's issue template at
-[`../../.github/ISSUE_TEMPLATE/issue_report.yml`](../../.github/ISSUE_TEMPLATE/issue_report.yml)
-(or the project's equivalent). The generic role → GitHub-field
+headings in the project's issue template (the concrete YAML file lives in the
+adopter's `<upstream>` repo; the generic role → field contract is in The generic role → GitHub-field
 contract lives in
 [`../../tools/github/issue-template.md`](../../tools/github/issue-template.md);
 the concrete names below are what skills read and write for this

--- a/tools/ponymail/operations.md
+++ b/tools/ponymail/operations.md
@@ -236,7 +236,7 @@ so a triager doing a one-off archive walk has a direct recipe.
 ## Query patterns
 
 Concrete query templates for the skill use cases live in the
-sibling [`search-queries.md`](search-queries.md) (to be written
+sibling `search-queries.md` (to be written
 when the first skill adopts PonyMail MCP — the shape will mirror
 [`../gmail/search-queries.md`](../gmail/search-queries.md) but
 substitute the PonyMail query grammar).

--- a/tools/privacy-llm/models.md
+++ b/tools/privacy-llm/models.md
@@ -43,7 +43,7 @@ default-approved Claude Code instance and passes).
 | **Local-only inference** | The data never leaves the user's machine. No external party (cloud LLM operator, network operator, log aggregator) can observe it. | Ollama serving a local model, vLLM on the user's workstation, llama.cpp embedded in a CLI helper |
 | **Air-gapped on-prem** | Same rationale as local inference, scaled to a contributor's organisation. The model server runs on infra the adopter operationally controls and which has no path to a third-party LLM operator. | A PMC-hosted inference appliance on a private VLAN |
 
-Detection lives in the helper's [registry.py](redactor/src/redactor/registry.py)
+Detection lives in the helper's `redactor/src/redactor/registry.py`
 (once PR-3 lands the gate-call wiring); for PR-1 the registry is
 the markdown contract here and the
 [`<project-config>/privacy-llm.md`](#adopter-config--project-configprivacy-llmmd)

--- a/tools/vulnogram/generate-cve-json/SKILL.md
+++ b/tools/vulnogram/generate-cve-json/SKILL.md
@@ -218,7 +218,7 @@ empty field in the proposal so nothing is silently skipped.
   tools/vulnogram/generate-cve-json generate-cve-json <N>`.
 
 See
-[Prerequisites for running the agent skills](../../../README.md#prerequisites-for-running-the-agent-skills)
+[Prerequisites for running the agent skills](../../../docs/prerequisites.md#prerequisites-for-running-the-agent-skills)
 in `README.md`.
 
 ---


### PR DESCRIPTION
## Summary

Resolves the baseline of broken links that kept the lychee workflow in informational-only mode.

## Changes

- Fix 43 broken internal links across 15 files
- Update CONTRIBUTING.md and AGENTS.md to reference .apache-steward-overrides/user.md instead of config/user.md
- Flip link-check.yml from informational-only to hard gate

## Test plan

- lychee: 0 errors (was 43)
- markdownlint: 0 errors
- check-placeholders: OK
