### PR TITLE
feat(privacy-llm): PR-3 — approved-LLM gate-check + skill-side wiring

### DIFF
--- a/.claude/skills/security-cve-allocate/SKILL.md
+++ b/.claude/skills/security-cve-allocate/SKILL.md
@@ -200,10 +200,16 @@ Before touching the tracker, verify:
    confirm the reporter's preferred CVE credit shape — that
    read follows the [redact-after-fetch protocol](../../../tools/privacy-llm/wiring.md#redact-after-fetch-protocol)
    per [`tools/privacy-llm/wiring.md`](../../../tools/privacy-llm/wiring.md).
-   No outbound draft is composed here, so no reveal step. The
-   pre-flight check is the same one-liner as the other security
-   skills: confirm `<project-config>/privacy-llm.md` exists and
-   `~/.config/apache-steward/` is writable.
+   No outbound draft is composed here, so no reveal step. Run
+   the gate-check the same way the other security skills do:
+
+   ```bash
+   uv run --project <framework>/tools/privacy-llm/checker \
+     privacy-llm-check
+   ```
+
+   Plus confirm `~/.config/apache-steward/` is writable (for the
+   redactor's mapping file).
 
 If any check fails, stop with a clear message. Do not start
 filling in the tracker until all four are green — a partial

--- a/.claude/skills/security-issue-import-from-md/SKILL.md
+++ b/.claude/skills/security-issue-import-from-md/SKILL.md
@@ -172,11 +172,17 @@ Before parsing the file, verify:
 4. **Privacy-LLM contract.** The input markdown can carry
    third-party PII the same way a `<security-list>` mail body
    can — researcher names cited in a finding, victim emails in
-   a reproduction step, and so on. Apply the same pre-flight
-   from
+   a reproduction step, and so on. Run the gate-check first —
+   non-zero exit is a hard stop:
+
+   ```bash
+   uv run --project <framework>/tools/privacy-llm/checker \
+     privacy-llm-check
+   ```
+
+   Plus the rest of the pre-flight items from
    [`tools/privacy-llm/wiring.md`](../../../tools/privacy-llm/wiring.md#step-0--pre-flight)
-   that the Gmail-touching skills do (config loads,
-   `~/.config/apache-steward/` writable, collaborator source
+   (`~/.config/apache-steward/` writable, collaborator source
    reachable). Findings parsed in Step 1 below feed the
    redact-after-fetch protocol the same way Gmail bodies do —
    the file IS the source-of-truth here, treat it like an

--- a/.claude/skills/security-issue-import/SKILL.md
+++ b/.claude/skills/security-issue-import/SKILL.md
@@ -191,10 +191,21 @@ Before touching any candidate thread, verify:
    for the one-time setup instructions.
 4. **Privacy-LLM contract.** This skill reads `<security-list>`
    bodies that may contain third-party PII the reporter
-   discloses about other people. Before fetching any body,
-   load `<project-config>/privacy-llm.md` (template at
+   discloses about other people. Run the gate-check first —
+   non-zero exit is a hard stop:
+
+   ```bash
+   uv run --project <framework>/tools/privacy-llm/checker \
+     privacy-llm-check
+   ```
+
+   The checker auto-locates `<project-config>/privacy-llm.md`
+   (template at
    [`projects/_template/privacy-llm.md`](../../../projects/_template/privacy-llm.md))
-   and verify:
+   and verifies every entry in *Currently configured LLM stack*
+   is approved per
+   [`tools/privacy-llm/models.md`](../../../tools/privacy-llm/models.md#the-pre-flight-check).
+   In addition, verify:
    - `~/.config/apache-steward/` is writable (the redactor's
      mapping file lives there);
    - the configured collaborator source is reachable via

--- a/.claude/skills/security-issue-invalidate/SKILL.md
+++ b/.claude/skills/security-issue-invalidate/SKILL.md
@@ -170,9 +170,15 @@ Before any work, verify:
 4. **Privacy-LLM contract.** This skill drafts a closing reply
    on the inbound `<security-list>` Gmail thread, so it reads
    the original report's body to mine the team's reasoning
-   (Step 3) and assembles an outbound draft (Step 6). Before
-   either, load `<project-config>/privacy-llm.md` and verify
-   the pre-flight items in
+   (Step 3) and assembles an outbound draft (Step 6). Run the
+   gate-check first — non-zero exit is a hard stop:
+
+   ```bash
+   uv run --project <framework>/tools/privacy-llm/checker \
+     privacy-llm-check
+   ```
+
+   Plus the rest of the pre-flight items in
    [`tools/privacy-llm/wiring.md`](../../../tools/privacy-llm/wiring.md#step-0--pre-flight).
    The Step 3 read follows the
    [redact-after-fetch protocol](../../../tools/privacy-llm/wiring.md#redact-after-fetch-protocol);

--- a/.claude/skills/security-issue-sync/SKILL.md
+++ b/.claude/skills/security-issue-sync/SKILL.md
@@ -382,9 +382,17 @@ Before reading any tracker state, verify:
    they meant.
 5. **Privacy-LLM contract.** This skill reads `<security-list>`
    bodies (and may read `<private-list>` content when escalating)
-   that may contain third-party PII. Before fetching any body,
-   load `<project-config>/privacy-llm.md` and verify the
-   pre-flight items in
+   that may contain third-party PII. Run the gate-check first —
+   non-zero exit is a hard stop, and pass `--reads-private-list`
+   because escalation paths in this skill may read PMC-private
+   foundation lists:
+
+   ```bash
+   uv run --project <framework>/tools/privacy-llm/checker \
+     privacy-llm-check --reads-private-list
+   ```
+
+   Plus the rest of the pre-flight items in
    [`tools/privacy-llm/wiring.md`](../../../tools/privacy-llm/wiring.md#step-0--pre-flight) —
    `~/.config/apache-steward/` is writable, the configured
    collaborator source is reachable, the redaction-tuning knobs

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -180,3 +180,30 @@ repos:
         entry: uv run --directory tools/privacy-llm/redactor pytest
         files: ^tools/privacy-llm/redactor/(src|tests|pyproject\.toml)
         pass_filenames: false
+
+  - repo: local
+    hooks:
+      - id: checker-ruff-check
+        name: ruff check (checker)
+        language: system
+        entry: uv run --directory tools/privacy-llm/checker ruff check
+        files: ^tools/privacy-llm/checker/(src|tests|pyproject\.toml)
+        pass_filenames: false
+      - id: checker-ruff-format
+        name: ruff format (checker)
+        language: system
+        entry: uv run --directory tools/privacy-llm/checker ruff format --check
+        files: ^tools/privacy-llm/checker/(src|tests|pyproject\.toml)
+        pass_filenames: false
+      - id: checker-mypy
+        name: mypy (checker)
+        language: system
+        entry: uv run --directory tools/privacy-llm/checker mypy
+        files: ^tools/privacy-llm/checker/(src|tests|pyproject\.toml)
+        pass_filenames: false
+      - id: checker-pytest
+        name: pytest (checker)
+        language: system
+        entry: uv run --directory tools/privacy-llm/checker pytest
+        files: ^tools/privacy-llm/checker/(src|tests|pyproject\.toml)
+        pass_filenames: false

--- a/tools/privacy-llm/checker/.gitignore
+++ b/tools/privacy-llm/checker/.gitignore
@@ -1,0 +1,7 @@
+__pycache__/
+*.py[cod]
+.venv/
+.pytest_cache/
+.ruff_cache/
+.mypy_cache/
+.coverage

--- a/tools/privacy-llm/checker/README.md
+++ b/tools/privacy-llm/checker/README.md
@@ -1,0 +1,113 @@
+<!-- START doctoc generated TOC please keep comment here to allow auto update -->
+<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
+**Table of Contents**  *generated with [DocToc](https://github.com/thlorenz/doctoc)*
+
+- [checker](#checker)
+  - [Run](#run)
+  - [Config file lookup](#config-file-lookup)
+  - [Test](#test)
+  - [Lint / type-check](#lint--type-check)
+  - [Referenced by](#referenced-by)
+
+<!-- END doctoc generated TOC please keep comment here to allow auto update -->
+
+<!-- Licensed to the Apache Software Foundation (ASF) under one
+     or more contributor license agreements.  See the NOTICE file
+     distributed with this work for additional information
+     regarding copyright ownership.  The ASF licenses this file
+     to you under the Apache License, Version 2.0 (the
+     "License"); you may not use this file except in compliance
+     with the License.  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+     Unless required by applicable law or agreed to in writing,
+     software distributed under the License is distributed on an
+     "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+     KIND, either express or implied.  See the License for the
+     specific language governing permissions and limitations
+     under the License. -->
+
+# checker
+
+Stdlib-only Python project implementing the approved-LLM gate-check
+for the apache-steward privacy-llm tool. One console script:
+
+| Console script | Purpose |
+|---|---|
+| `privacy-llm-check` | Parse `<project-config>/privacy-llm.md`, verify every entry in the *Currently configured LLM stack* section is approved per the rules in [`../models.md`](../models.md). Exit 0 if all approved, 1 with stderr explanation otherwise (2 if the config file cannot be located or parsed). |
+
+The behavioural contract — which entries are default-approved, which
+require an opt-in declaration with a data-residency contract + PMC
+sign-off — lives in [`../models.md`](../models.md). The skill-side
+wiring contract is in [`../wiring.md`](../wiring.md). This README
+covers local invocation.
+
+## Run
+
+From the framework's root (this repository when running standalone;
+the snapshot path inside an adopting tracker repo):
+
+```bash
+# Default lookup — reads <cwd>/.apache-steward/privacy-llm.md or
+# <cwd>/.apache-steward-overrides/privacy-llm.md.
+uv run --project tools/privacy-llm/checker privacy-llm-check
+
+# Skill-style invocation: tells the user the check fires because
+# the skill may read <private-list> content.
+uv run --project tools/privacy-llm/checker privacy-llm-check --reads-private-list
+
+# Explicit config path:
+uv run --project tools/privacy-llm/checker privacy-llm-check \
+  --config <project-config>/privacy-llm.md
+
+# Quiet mode (no output on approval; non-zero exit + stderr on rejection):
+uv run --project tools/privacy-llm/checker privacy-llm-check --quiet
+```
+
+Skill files reference the same invocation via the `<framework>`
+placeholder so the path resolves in either context:
+
+```bash
+uv run --project <framework>/tools/privacy-llm/checker privacy-llm-check ...
+```
+
+`<framework>` substitutes to the snapshot path inside an adopting
+project (typically `.apache-steward/apache-steward/`) and to `.`
+when running standalone — see the placeholder convention in
+[`AGENTS.md`](../../../AGENTS.md#placeholder-convention-used-in-skill-files).
+
+## Config file lookup
+
+In order of precedence:
+
+| Source | Notes |
+|---|---|
+| `--config <path>` | Explicit override; absolute or relative to `<cwd>`. |
+| `$PRIVACY_LLM_CONFIG` | Environment-variable override. |
+| `<cwd>/.apache-steward/privacy-llm.md` | Standard adopter location (the framework's `<project-config>` substitutes here). |
+| `<cwd>/.apache-steward-overrides/privacy-llm.md` | Alternative location used by adopters who keep overrides in a separate dir. |
+
+If none of the candidates exist, the checker exits 2 with the list
+of paths it tried.
+
+## Test
+
+```bash
+uv run --project tools/privacy-llm/checker --group dev pytest
+```
+
+## Lint / type-check
+
+```bash
+uv run --project tools/privacy-llm/checker --group dev ruff check src tests
+uv run --project tools/privacy-llm/checker --group dev ruff format --check src tests
+uv run --project tools/privacy-llm/checker --group dev mypy
+```
+
+## Referenced by
+
+- [`tools/privacy-llm/tool.md`](../tool.md) — tool overview.
+- [`tools/privacy-llm/models.md`](../models.md) — approved-model registry contract that the checker implements.
+- [`tools/privacy-llm/wiring.md`](../wiring.md) — skill-side wiring contract; the checker is called from Step 0 pre-flight.
+- [`projects/_template/privacy-llm.md`](../../../projects/_template/privacy-llm.md) — adopter template; this is the file the checker parses.

--- a/tools/privacy-llm/checker/pyproject.toml
+++ b/tools/privacy-llm/checker/pyproject.toml
@@ -1,0 +1,88 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[project]
+name = "checker"
+version = "0.1.0"
+description = "Approved-LLM gate-check for the apache-steward privacy-llm tool — parse <project-config>/privacy-llm.md and verify the active LLM stack against the approved-model registry."
+readme = "README.md"
+requires-python = ">=3.11"
+license = { text = "Apache-2.0" }
+# stdlib-only — re + urllib.parse + pathlib + argparse are all that's
+# needed. Keeps the gate-check cheap to invoke from skills.
+dependencies = []
+
+[project.scripts]
+privacy-llm-check = "checker.check:main"
+
+[dependency-groups]
+dev = [
+  "mypy>=1.11",
+  "pytest>=8.0",
+  "ruff>=0.6",
+]
+
+[tool.hatch.build.targets.wheel]
+packages = ["src/checker"]
+
+[tool.ruff]
+line-length = 110
+target-version = "py311"
+src = ["src", "tests"]
+
+[tool.ruff.lint]
+select = [
+  "E",     # pycodestyle errors
+  "W",     # pycodestyle warnings
+  "F",     # pyflakes
+  "I",     # isort
+  "B",     # flake8-bugbear
+  "UP",    # pyupgrade
+  "SIM",   # flake8-simplify
+  "C4",    # flake8-comprehensions
+  "RUF",   # ruff-specific
+]
+ignore = [
+  "E501",  # line-too-long — the 110-char limit above is already generous
+]
+
+[tool.ruff.lint.per-file-ignores]
+"tests/**" = ["B", "SIM", "RUF059"]  # tuple-unpack of (rc, out, err) keeps test sites uniform
+
+[tool.mypy]
+python_version = "3.11"
+files = ["src", "tests"]
+warn_unused_ignores = true
+warn_redundant_casts = true
+warn_unreachable = true
+check_untyped_defs = true
+no_implicit_optional = true
+disallow_untyped_defs = true
+disallow_incomplete_defs = true
+
+[[tool.mypy.overrides]]
+module = "tests.*"
+disallow_untyped_defs = false
+disallow_incomplete_defs = false
+
+[tool.pytest.ini_options]
+minversion = "8.0"
+addopts = "-ra -q"
+testpaths = ["tests"]

--- a/tools/privacy-llm/checker/src/checker/__init__.py
+++ b/tools/privacy-llm/checker/src/checker/__init__.py
@@ -1,0 +1,30 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""Approved-LLM gate-check for the apache-steward privacy-llm tool.
+
+Single console script: ``privacy-llm-check`` (:mod:`checker.check`).
+
+Parses ``<project-config>/privacy-llm.md``, extracts the active LLM
+stack and the opt-in third-party-endpoint registry, applies the
+approval rules from ``tools/privacy-llm/models.md``, and exits 0
+if every entry in the active stack is approved — exit 1 with a
+stderr explanation otherwise.
+
+Skills shell out to this command at Step 0 (pre-flight) when they
+may read ``<private-list>`` content. The contract is documented
+in ``tools/privacy-llm/wiring.md``.
+"""

--- a/tools/privacy-llm/checker/src/checker/check.py
+++ b/tools/privacy-llm/checker/src/checker/check.py
@@ -1,0 +1,248 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""``privacy-llm-check`` — verify the active LLM stack is approved.
+
+Exit codes:
+
+- ``0`` — every entry in the *Currently configured LLM stack*
+  section is approved per the rules in
+  ``tools/privacy-llm/models.md``.
+- ``1`` — at least one entry is unapproved (or the config file is
+  missing values an opt-in entry needs); the stderr explanation
+  names the offending entries.
+- ``2`` — the config file could not be located or parsed.
+
+Skills shell out to this command at Step 0 (pre-flight) when they
+may read ``<private-list>`` content. The wiring contract is in
+``tools/privacy-llm/wiring.md``.
+"""
+
+from __future__ import annotations
+
+import argparse
+import dataclasses
+import sys
+
+from checker.config import (
+    LLMEntry,
+    OptInEntry,
+    ParsedConfig,
+    host_of,
+    locate_config_path,
+    parse_config,
+)
+
+# Hosts that resolve to "local-only inference" — not over the wire.
+_LOCAL_HOSTS = frozenset({"localhost", "127.0.0.1", "::1"})
+
+# Free-text matches for the always-approved Claude Code entry.
+# Case-insensitive, matched as a substring of the bullet's raw
+# text. Adopters may write "Claude Code (the agent ...)" or
+# "Claude Code itself" or just "Claude Code" — all fine.
+_CLAUDE_CODE_MATCH = "claude code"
+
+
+@dataclasses.dataclass(frozen=True)
+class Verdict:
+    """The check result for one ``LLMEntry``."""
+
+    entry: LLMEntry
+    approved: bool
+    reason: str
+
+
+def _approve_by_default_rules(entry: LLMEntry) -> Verdict | None:
+    """Return a verdict if the entry matches a default-approved rule;
+    otherwise ``None`` (the caller falls back to the opt-in match)."""
+    if _CLAUDE_CODE_MATCH in entry.raw.lower():
+        return Verdict(entry, True, "Claude Code itself (default-approved)")
+    if entry.url is not None:
+        host = host_of(entry.url)
+        if host is None:
+            return Verdict(entry, False, f"unparseable URL host in {entry.url!r}")
+        if host in _LOCAL_HOSTS:
+            return Verdict(entry, True, f"local-only inference at {host} (default-approved)")
+        if host.endswith(".apache.org") or host == "apache.org":
+            return Verdict(entry, True, f"*.apache.org-hosted endpoint at {host} (default-approved)")
+    return None
+
+
+def _approve_by_opt_in(entry: LLMEntry, opt_in: list[OptInEntry]) -> Verdict:
+    """Match ``entry`` against the adopter's opt-in registry.
+
+    A match requires either:
+    - the entry's URL appears in the opt-in entry's ``name`` (free-text), OR
+    - the entry's first non-URL token sequence matches the opt-in entry's name
+      (case-insensitive substring on either side).
+
+    A *valid* match additionally requires the opt-in entry to carry
+    a non-empty ``Data-residency contract`` and ``Approved-by`` line.
+    """
+    raw_lc = entry.raw.lower()
+    url_lc = entry.url.lower() if entry.url else ""
+    for opt in opt_in:
+        name_lc = opt.name.lower()
+        # Match if either the bullet's raw text contains the opt-in
+        # name, or vice versa, or the URL is a substring of the
+        # opt-in name (or vice versa).
+        if not (
+            name_lc in raw_lc
+            or _shortname(name_lc) in raw_lc
+            or (url_lc and (url_lc in name_lc or name_lc in url_lc))
+        ):
+            continue
+        if not opt.data_residency:
+            return Verdict(
+                entry,
+                False,
+                f"opt-in entry {opt.name!r} matches but is missing the 'Data-residency contract' sub-bullet",
+            )
+        if not opt.approved_by or _is_placeholder(opt.approved_by):
+            return Verdict(
+                entry,
+                False,
+                f"opt-in entry {opt.name!r} matches but the 'Approved-by' "
+                f"sub-bullet is missing or still has placeholder text "
+                f"({opt.approved_by!r}); a real PMC member must sign off.",
+            )
+        return Verdict(entry, True, f"opt-in entry {opt.name!r} (data-residency + approved-by present)")
+    return Verdict(
+        entry,
+        False,
+        "no default-approval rule matches and no opt-in entry was declared "
+        "for this LLM. Add an entry under 'Approved third-party endpoints "
+        "(opt-in)' with a Data-residency contract line and an Approved-by "
+        "sign-off, or remove this LLM from the active stack.",
+    )
+
+
+def _shortname(name_lc: str) -> str:
+    """Heuristic: take the leading word(s) before the first ``—`` /
+    ``-`` / ``,`` / ``(`` so that ``aws bedrock — eu-central-1``
+    matches a stack bullet that just says ``aws bedrock``."""
+    for sep in (" — ", " - ", ",", "(", ":"):
+        if sep in name_lc:
+            return name_lc.split(sep, 1)[0].strip()
+    return name_lc
+
+
+def _is_placeholder(text: str) -> bool:
+    """Recognise the template's placeholder forms so we don't accept
+    them as valid sign-off."""
+    lc = text.lower().strip()
+    if not lc:
+        return True
+    return any(
+        marker in lc for marker in ("<pmc-member-initials>", "<initials>", "<yyyy-mm-dd>", "yyyy-mm-dd")
+    )
+
+
+def check_stack(config: ParsedConfig) -> list[Verdict]:
+    """Run every default-approval rule, falling back to the opt-in
+    registry. Returns one :class:`Verdict` per LLM stack entry."""
+    out: list[Verdict] = []
+    for entry in config.llm_stack:
+        v = _approve_by_default_rules(entry)
+        if v is None:
+            v = _approve_by_opt_in(entry, config.opt_in)
+        out.append(v)
+    return out
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        prog="privacy-llm-check",
+        description=(
+            "Verify every entry in <project-config>/privacy-llm.md's "
+            "'Currently configured LLM stack' is approved per "
+            "tools/privacy-llm/models.md."
+        ),
+    )
+    parser.add_argument(
+        "--config",
+        default=None,
+        help=(
+            "Path to the privacy-llm.md config. Default: "
+            "$PRIVACY_LLM_CONFIG, then "
+            "<cwd>/.apache-steward/privacy-llm.md, then "
+            "<cwd>/.apache-steward-overrides/privacy-llm.md."
+        ),
+    )
+    parser.add_argument(
+        "--reads-private-list",
+        action="store_true",
+        help=(
+            "Set this when the calling skill may read <private-list> "
+            "content. The check itself is the same — the flag just "
+            "tells the user via the printed banner why the gate is firing."
+        ),
+    )
+    parser.add_argument(
+        "--quiet",
+        action="store_true",
+        help="On approval, print nothing. On rejection, print stderr only.",
+    )
+    args = parser.parse_args(argv)
+
+    try:
+        path = locate_config_path(args.config)
+    except FileNotFoundError as e:
+        print(str(e), file=sys.stderr)
+        return 2
+    try:
+        cfg = parse_config(path)
+    except OSError as e:
+        print(f"{path}: {e}", file=sys.stderr)
+        return 2
+
+    verdicts = check_stack(cfg)
+    if not verdicts:
+        print(
+            f"{path}: 'Currently configured LLM stack' is empty — at least "
+            f"one entry (typically 'Claude Code') is required.",
+            file=sys.stderr,
+        )
+        return 1
+
+    bad = [v for v in verdicts if not v.approved]
+    if not bad:
+        if not args.quiet:
+            banner = "privacy-llm-check: every active-stack entry is approved" + (
+                " (skill reads <private-list>)" if args.reads_private_list else ""
+            )
+            print(banner)
+            for v in verdicts:
+                print(f"  ✓ {v.entry.raw}  —  {v.reason}")
+        return 0
+
+    print(
+        f"privacy-llm-check: {len(bad)} of {len(verdicts)} "
+        f"active-stack entr{'y is' if len(bad) == 1 else 'ies are'} not approved.",
+        file=sys.stderr,
+    )
+    for v in verdicts:
+        marker = "✓" if v.approved else "✗"
+        print(f"  {marker} {v.entry.raw}  —  {v.reason}", file=sys.stderr)
+    print(
+        f"\nFix: edit {path} per tools/privacy-llm/models.md.",
+        file=sys.stderr,
+    )
+    return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/privacy-llm/checker/src/checker/check.py
+++ b/tools/privacy-llm/checker/src/checker/check.py
@@ -73,7 +73,7 @@ def _approve_by_default_rules(entry: LLMEntry) -> Verdict | None:
     if entry.url is not None:
         host = host_of(entry.url)
         if host is None:
-            return Verdict(entry, False, f"unparseable URL host in {entry.url!r}")
+            return Verdict(entry, False, f"unparsable URL host in {entry.url!r}")
         if host in _LOCAL_HOSTS:
             return Verdict(entry, True, f"local-only inference at {host} (default-approved)")
         if host.endswith(".apache.org") or host == "apache.org":

--- a/tools/privacy-llm/checker/src/checker/config.py
+++ b/tools/privacy-llm/checker/src/checker/config.py
@@ -236,7 +236,7 @@ def parse_config(path: pathlib.Path) -> ParsedConfig:
 
 
 def host_of(url: str) -> str | None:
-    """Lowercase host of ``url``, or ``None`` if unparseable."""
+    """Lowercase host of ``url``, or ``None`` if unparsable."""
     try:
         parsed = urllib.parse.urlparse(url)
     except ValueError:

--- a/tools/privacy-llm/checker/src/checker/config.py
+++ b/tools/privacy-llm/checker/src/checker/config.py
@@ -1,0 +1,246 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""Parse ``<project-config>/privacy-llm.md`` into structured records.
+
+The parser is deliberately permissive about whitespace and comment
+placement — adopters customise the file by hand and the framework
+should not reject minor formatting variations. It IS strict about
+the structural anchors (`## Currently configured LLM stack`,
+`## Approved third-party endpoints (opt-in)`) — those are the
+contract surfaces the gate-check relies on, and a typo there is
+worth surfacing.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import os
+import pathlib
+import re
+import urllib.parse
+
+# Section-heading anchors the parser keys off. Matching is
+# case-insensitive on the heading text but the leading `## ` is
+# required.
+_HEADING_LLM_STACK = "currently configured llm stack"
+_HEADING_OPT_IN = "approved third-party endpoints (opt-in)"
+
+# Default lookup path when no `--config` / env var is supplied.
+DEFAULT_CONFIG_FILENAME = "privacy-llm.md"
+ENV_CONFIG_PATH = "PRIVACY_LLM_CONFIG"
+
+# The standard adopter location: <repo-root>/<project-config>/
+# privacy-llm.md. The framework's <project-config> placeholder
+# resolves at adoption time to either `.apache-steward/` (the
+# committed adopter-config dir under the tracker) or
+# `.apache-steward-overrides/` (the override dir). The checker
+# tries both, in that order.
+DEFAULT_CONFIG_DIRS = (".apache-steward", ".apache-steward-overrides")
+
+
+@dataclasses.dataclass(frozen=True)
+class LLMEntry:
+    """One row from the *Currently configured LLM stack* section.
+
+    ``raw`` is the verbatim bullet text (post-`- ` strip) for use in
+    error messages. ``url`` is the parsed URL when present (matched
+    against the *first* http(s) URL in the bullet); for entries that
+    only name a provider without a URL (e.g. ``Claude Code``) it is
+    ``None``.
+    """
+
+    raw: str
+    url: str | None
+
+
+@dataclasses.dataclass(frozen=True)
+class OptInEntry:
+    """One opt-in third-party endpoint declaration.
+
+    ``name`` is the top-level bullet text. ``data_residency`` and
+    ``approved_by`` are the values from the matching sub-bullets if
+    present; ``None`` if absent. The gate-check considers the entry
+    valid only when both sub-bullets carry non-placeholder values.
+    """
+
+    name: str
+    data_residency: str | None
+    approved_by: str | None
+
+
+@dataclasses.dataclass(frozen=True)
+class ParsedConfig:
+    """The parser's output."""
+
+    path: pathlib.Path
+    llm_stack: list[LLMEntry]
+    opt_in: list[OptInEntry]
+
+
+def locate_config_path(explicit: str | None = None) -> pathlib.Path:
+    """Resolve the config path: ``--config`` → env → default lookup.
+
+    Default lookup walks the standard adopter locations relative to
+    the current working directory. Returns the first existing file;
+    raises :class:`FileNotFoundError` if none exists, with the list
+    of paths tried.
+    """
+    if explicit:
+        return pathlib.Path(explicit).expanduser()
+    if env_path := os.environ.get(ENV_CONFIG_PATH):
+        return pathlib.Path(env_path).expanduser()
+    cwd = pathlib.Path.cwd()
+    candidates = [cwd / d / DEFAULT_CONFIG_FILENAME for d in DEFAULT_CONFIG_DIRS]
+    for c in candidates:
+        if c.is_file():
+            return c
+    tried = ", ".join(str(c) for c in candidates)
+    raise FileNotFoundError(
+        f"No privacy-llm config found. Tried: {tried}. Set ${ENV_CONFIG_PATH} or pass --config <path>."
+    )
+
+
+def _strip_html_comments(text: str) -> str:
+    """Drop HTML-comment blocks. Adopters often leave the template's
+    instructional comments in place; the parser should treat the
+    bullet structure as ground truth."""
+    return re.sub(r"<!--.*?-->", "", text, flags=re.DOTALL)
+
+
+def _section(lines: list[str], heading_lc: str) -> list[str]:
+    """Return the lines under the named ``## <heading>`` until the
+    next ``## `` heading (or end of file). Returns ``[]`` if the
+    section is not present."""
+    out: list[str] = []
+    in_section = False
+    for line in lines:
+        stripped = line.strip()
+        if stripped.startswith("## "):
+            current = stripped[3:].strip().lower()
+            if current == heading_lc:
+                in_section = True
+                continue
+            if in_section:
+                # Hit the next H2 — stop.
+                break
+        if in_section:
+            out.append(line)
+    return out
+
+
+def _parse_llm_stack(section_lines: list[str]) -> list[LLMEntry]:
+    """Each bullet in the section becomes one ``LLMEntry``."""
+    entries: list[LLMEntry] = []
+    for raw_line in section_lines:
+        line = raw_line.rstrip()
+        m = re.match(r"\s*-\s+(.+)$", line)
+        if not m:
+            continue
+        text = m.group(1).strip()
+        if not text or text.startswith("#"):
+            continue
+        # Skip the literal placeholder/example bullet from the template.
+        if text.startswith("(none") or text.startswith("(default"):
+            continue
+        url = _first_url(text)
+        entries.append(LLMEntry(raw=text, url=url))
+    return entries
+
+
+def _parse_opt_in(section_lines: list[str]) -> list[OptInEntry]:
+    """Top-level ``- <name>`` bullets become entries; their indented
+    sub-bullets supply *Data-residency contract* and *Approved-by*."""
+    entries: list[OptInEntry] = []
+    current_name: str | None = None
+    data_residency: str | None = None
+    approved_by: str | None = None
+
+    def flush() -> None:
+        nonlocal current_name, data_residency, approved_by
+        if current_name is not None:
+            entries.append(
+                OptInEntry(
+                    name=current_name,
+                    data_residency=data_residency,
+                    approved_by=approved_by,
+                )
+            )
+        current_name = None
+        data_residency = None
+        approved_by = None
+
+    for raw_line in section_lines:
+        line = raw_line.rstrip()
+        # Top-level bullet: zero or one leading space, then `- `.
+        m_top = re.match(r"^-\s+(.+)$", line)
+        if m_top:
+            flush()
+            text = m_top.group(1).strip()
+            if text.startswith("(none") or text.startswith("(default"):
+                continue
+            current_name = text
+            continue
+        # Sub-bullet: 2+ spaces then `- `.
+        m_sub = re.match(r"^\s{2,}-\s+(.+)$", line)
+        if m_sub and current_name is not None:
+            sub_text = m_sub.group(1).strip()
+            lc = sub_text.lower()
+            if lc.startswith("data-residency contract"):
+                data_residency = sub_text.split(":", 1)[1].strip() if ":" in sub_text else ""
+            elif lc.startswith("approved-by"):
+                approved_by = sub_text.split(":", 1)[1].strip() if ":" in sub_text else ""
+    flush()
+    return entries
+
+
+def _first_url(text: str) -> str | None:
+    """Return the first http(s) URL in ``text``, or ``None``.
+
+    The regex is intentionally simple — adopter configs name URLs
+    in clear unambiguous form. We do not try to extract URLs from
+    inside markdown link syntax; if the adopter writes
+    ``[label](URL)`` we still match the bare URL.
+    """
+    m = re.search(r"https?://[^\s)>]+", text)
+    if m is None:
+        return None
+    return m.group(0).rstrip(".,;:")
+
+
+def parse_config(path: pathlib.Path) -> ParsedConfig:
+    """Parse the file at ``path`` into a :class:`ParsedConfig`."""
+    raw = path.read_text(encoding="utf-8")
+    raw = _strip_html_comments(raw)
+    lines = raw.splitlines()
+    llm_stack_section = _section(lines, _HEADING_LLM_STACK)
+    opt_in_section = _section(lines, _HEADING_OPT_IN)
+    return ParsedConfig(
+        path=path,
+        llm_stack=_parse_llm_stack(llm_stack_section),
+        opt_in=_parse_opt_in(opt_in_section),
+    )
+
+
+def host_of(url: str) -> str | None:
+    """Lowercase host of ``url``, or ``None`` if unparseable."""
+    try:
+        parsed = urllib.parse.urlparse(url)
+    except ValueError:
+        return None
+    if not parsed.hostname:
+        return None
+    return parsed.hostname.lower()

--- a/tools/privacy-llm/checker/tests/__init__.py
+++ b/tools/privacy-llm/checker/tests/__init__.py
@@ -1,0 +1,16 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.

--- a/tools/privacy-llm/checker/tests/test_check.py
+++ b/tools/privacy-llm/checker/tests/test_check.py
@@ -76,7 +76,12 @@ def test_apache_org_is_approved():
         )
     )
     assert v.approved is True
-    assert "apache.org" in v.reason
+    # Match the verdict's exact phrasing rather than a bare "apache.org"
+    # substring — the latter trips CodeQL's incomplete-URL-sanitization
+    # rule (false positive here; v.reason is a human message, not a URL
+    # being validated). Asserting on the production-code phrasing also
+    # locks down the user-facing reason text against accidental drift.
+    assert "*.apache.org-hosted" in v.reason
 
 
 def test_subdomain_apache_org_is_approved():

--- a/tools/privacy-llm/checker/tests/test_check.py
+++ b/tools/privacy-llm/checker/tests/test_check.py
@@ -1,0 +1,280 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""Tests for ``checker.check`` — gate-check verdict logic + CLI."""
+
+from __future__ import annotations
+
+import io
+import pathlib
+import textwrap
+
+from checker import check
+from checker.config import LLMEntry, OptInEntry, ParsedConfig, parse_config
+
+
+def _write(path: pathlib.Path, body: str) -> pathlib.Path:
+    path.write_text(textwrap.dedent(body))
+    return path
+
+
+def _cfg(stack: list[LLMEntry], opt_in: list[OptInEntry] | None = None) -> ParsedConfig:
+    return ParsedConfig(path=pathlib.Path("/dev/null"), llm_stack=stack, opt_in=opt_in or [])
+
+
+def _run(monkeypatch, argv: list[str]) -> tuple[int, str, str]:
+    stdout = io.StringIO()
+    stderr = io.StringIO()
+    monkeypatch.setattr("sys.stdout", stdout)
+    monkeypatch.setattr("sys.stderr", stderr)
+    rc = check.main(argv)
+    return rc, stdout.getvalue(), stderr.getvalue()
+
+
+# -- default-approval rules --------------------------------------------
+
+
+def test_claude_code_is_approved_by_default():
+    [v] = check.check_stack(_cfg([LLMEntry(raw="Claude Code (the agent running …)", url=None)]))
+    assert v.approved is True
+    assert "Claude Code" in v.reason
+
+
+def test_claude_code_match_is_case_insensitive():
+    [v] = check.check_stack(_cfg([LLMEntry(raw="claude CODE itself", url=None)]))
+    assert v.approved is True
+
+
+def test_localhost_is_approved():
+    for host in ("http://127.0.0.1:11434/", "http://localhost:8000/v1/", "http://[::1]:8080/"):
+        [v] = check.check_stack(_cfg([LLMEntry(raw=f"Local at {host}", url=host)]))
+        assert v.approved is True, f"expected {host} to be approved, got {v.reason}"
+
+
+def test_apache_org_is_approved():
+    [v] = check.check_stack(
+        _cfg(
+            [
+                LLMEntry(
+                    raw="ASF inference at https://inference.apache.org/v1/",
+                    url="https://inference.apache.org/v1/",
+                )
+            ]
+        )
+    )
+    assert v.approved is True
+    assert "apache.org" in v.reason
+
+
+def test_subdomain_apache_org_is_approved():
+    [v] = check.check_stack(
+        _cfg(
+            [
+                LLMEntry(
+                    raw="ASF infra at https://llm.airflow.apache.org/", url="https://llm.airflow.apache.org/"
+                )
+            ]
+        )
+    )
+    assert v.approved is True
+
+
+def test_apache_org_lookalike_is_not_approved():
+    """``apache.org-attacker.example.com`` must NOT match the apache.org rule."""
+    [v] = check.check_stack(
+        _cfg(
+            [
+                LLMEntry(
+                    raw="Imposter at https://apache.org.evil.example/", url="https://apache.org.evil.example/"
+                )
+            ]
+        )
+    )
+    assert v.approved is False
+
+
+# -- opt-in matching --------------------------------------------------
+
+
+def test_opt_in_full_entry_approves_match():
+    stack = [LLMEntry(raw="AWS Bedrock at https://bedrock.eu.example/", url="https://bedrock.eu.example/")]
+    opt_in = [
+        OptInEntry(
+            name="AWS Bedrock — eu-central-1",
+            data_residency="AWS DPA + Bedrock no-training",
+            approved_by="ABC 2026-04-01",
+        )
+    ]
+    [v] = check.check_stack(_cfg(stack, opt_in))
+    assert v.approved is True
+    assert "AWS Bedrock" in v.reason
+
+
+def test_opt_in_missing_data_residency_rejects():
+    stack = [
+        LLMEntry(
+            raw="Anthropic API direct at https://api.anthropic.com/v1/", url="https://api.anthropic.com/v1/"
+        )
+    ]
+    opt_in = [OptInEntry(name="Anthropic API direct", data_residency=None, approved_by="ABC 2026-04-01")]
+    [v] = check.check_stack(_cfg(stack, opt_in))
+    assert v.approved is False
+    assert "Data-residency" in v.reason
+
+
+def test_opt_in_missing_approved_by_rejects():
+    stack = [
+        LLMEntry(
+            raw="Anthropic API direct at https://api.anthropic.com/v1/", url="https://api.anthropic.com/v1/"
+        )
+    ]
+    opt_in = [OptInEntry(name="Anthropic API direct", data_residency="ZDR + no-training", approved_by=None)]
+    [v] = check.check_stack(_cfg(stack, opt_in))
+    assert v.approved is False
+    assert "Approved-by" in v.reason
+
+
+def test_opt_in_placeholder_approved_by_rejects():
+    stack = [
+        LLMEntry(
+            raw="Anthropic API direct at https://api.anthropic.com/v1/", url="https://api.anthropic.com/v1/"
+        )
+    ]
+    opt_in = [
+        OptInEntry(
+            name="Anthropic API direct",
+            data_residency="ZDR + no-training",
+            approved_by="<PMC-member-initials> <YYYY-MM-DD>",
+        )
+    ]
+    [v] = check.check_stack(_cfg(stack, opt_in))
+    assert v.approved is False
+    assert "placeholder" in v.reason.lower()
+
+
+def test_no_default_approval_no_opt_in_rejects():
+    stack = [LLMEntry(raw="Some random LLM at https://random.example/", url="https://random.example/")]
+    [v] = check.check_stack(_cfg(stack))
+    assert v.approved is False
+    assert "no default-approval rule matches" in v.reason
+
+
+# -- CLI exit codes ---------------------------------------------------
+
+
+def test_cli_exit_0_on_all_approved(tmp_path: pathlib.Path, monkeypatch):
+    cfg = _write(
+        tmp_path / "p.md",
+        """\
+        ## Currently configured LLM stack
+
+        - Claude Code
+
+        ## Approved third-party endpoints (opt-in)
+        """,
+    )
+    rc, out, err = _run(monkeypatch, ["--config", str(cfg)])
+    assert rc == 0
+    assert "approved" in out.lower()
+
+
+def test_cli_exit_0_quiet_emits_no_stdout(tmp_path: pathlib.Path, monkeypatch):
+    cfg = _write(
+        tmp_path / "p.md",
+        """\
+        ## Currently configured LLM stack
+        - Claude Code
+
+        ## Approved third-party endpoints (opt-in)
+        """,
+    )
+    rc, out, err = _run(monkeypatch, ["--config", str(cfg), "--quiet"])
+    assert rc == 0
+    assert out == ""
+
+
+def test_cli_exit_1_on_unapproved_entry(tmp_path: pathlib.Path, monkeypatch):
+    cfg = _write(
+        tmp_path / "p.md",
+        """\
+        ## Currently configured LLM stack
+
+        - Claude Code
+        - Some random LLM at https://random.example/
+
+        ## Approved third-party endpoints (opt-in)
+        """,
+    )
+    rc, out, err = _run(monkeypatch, ["--config", str(cfg)])
+    assert rc == 1
+    assert "not approved" in err.lower()
+    assert "random.example" in err
+
+
+def test_cli_exit_1_on_empty_stack(tmp_path: pathlib.Path, monkeypatch):
+    cfg = _write(
+        tmp_path / "p.md",
+        """\
+        ## Currently configured LLM stack
+
+        ## Approved third-party endpoints (opt-in)
+        """,
+    )
+    rc, out, err = _run(monkeypatch, ["--config", str(cfg)])
+    assert rc == 1
+    assert "empty" in err.lower()
+
+
+def test_cli_exit_2_on_missing_config(tmp_path: pathlib.Path, monkeypatch):
+    monkeypatch.delenv("PRIVACY_LLM_CONFIG", raising=False)
+    monkeypatch.chdir(tmp_path)
+    rc, out, err = _run(monkeypatch, [])
+    assert rc == 2
+    assert "no privacy-llm config" in err.lower()
+
+
+def test_cli_reads_private_list_flag_in_banner(tmp_path: pathlib.Path, monkeypatch):
+    cfg = _write(
+        tmp_path / "p.md",
+        """\
+        ## Currently configured LLM stack
+        - Claude Code
+
+        ## Approved third-party endpoints (opt-in)
+        """,
+    )
+    rc, out, err = _run(monkeypatch, ["--config", str(cfg), "--reads-private-list"])
+    assert rc == 0
+    assert "private-list" in out
+
+
+# -- end-to-end against the framework's template ------------------------
+
+
+def test_framework_template_is_approved_by_default(tmp_path: pathlib.Path, monkeypatch):
+    """The shipped projects/_template/privacy-llm.md must pass the
+    check out of the box (Claude Code only, no opt-in entries) — it
+    is the starting state for every fresh adopter."""
+    template = pathlib.Path(__file__).resolve().parents[3] / "projects" / "_template" / "privacy-llm.md"
+    if not template.exists():
+        # Tests sometimes run from a stripped checkout without the
+        # template; skip rather than fail.
+        return
+    parsed = parse_config(template)
+    verdicts = check.check_stack(parsed)
+    assert verdicts, "template should declare at least Claude Code in its stack"
+    bad = [v for v in verdicts if not v.approved]
+    assert not bad, f"unapproved entries in shipped template: {bad}"

--- a/tools/privacy-llm/checker/tests/test_config.py
+++ b/tools/privacy-llm/checker/tests/test_config.py
@@ -1,0 +1,251 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""Tests for ``checker.config`` — markdown parsing of privacy-llm.md."""
+
+from __future__ import annotations
+
+import pathlib
+import textwrap
+
+import pytest
+
+from checker.config import (
+    DEFAULT_CONFIG_DIRS,
+    DEFAULT_CONFIG_FILENAME,
+    host_of,
+    locate_config_path,
+    parse_config,
+)
+
+
+def _write(path: pathlib.Path, body: str) -> pathlib.Path:
+    path.write_text(textwrap.dedent(body))
+    return path
+
+
+# -- locate_config_path ---------------------------------------------------
+
+
+def test_locate_explicit_wins(tmp_path: pathlib.Path, monkeypatch):
+    monkeypatch.setenv("PRIVACY_LLM_CONFIG", "/should-not-be-used")
+    explicit = tmp_path / "explicit.md"
+    explicit.write_text("# stub")
+    assert locate_config_path(str(explicit)) == explicit
+
+
+def test_locate_env_used_when_no_explicit(tmp_path: pathlib.Path, monkeypatch):
+    env_path = tmp_path / "from-env.md"
+    monkeypatch.setenv("PRIVACY_LLM_CONFIG", str(env_path))
+    assert locate_config_path(None) == env_path
+
+
+def test_locate_default_first_existing(tmp_path: pathlib.Path, monkeypatch):
+    monkeypatch.delenv("PRIVACY_LLM_CONFIG", raising=False)
+    monkeypatch.chdir(tmp_path)
+    cfg_dir = tmp_path / DEFAULT_CONFIG_DIRS[0]
+    cfg_dir.mkdir()
+    cfg = cfg_dir / DEFAULT_CONFIG_FILENAME
+    cfg.write_text("# stub")
+    assert locate_config_path(None) == cfg
+
+
+def test_locate_default_falls_back_to_overrides(tmp_path: pathlib.Path, monkeypatch):
+    monkeypatch.delenv("PRIVACY_LLM_CONFIG", raising=False)
+    monkeypatch.chdir(tmp_path)
+    cfg_dir = tmp_path / DEFAULT_CONFIG_DIRS[1]
+    cfg_dir.mkdir()
+    cfg = cfg_dir / DEFAULT_CONFIG_FILENAME
+    cfg.write_text("# stub")
+    assert locate_config_path(None) == cfg
+
+
+def test_locate_raises_when_nothing_found(tmp_path: pathlib.Path, monkeypatch):
+    monkeypatch.delenv("PRIVACY_LLM_CONFIG", raising=False)
+    monkeypatch.chdir(tmp_path)
+    with pytest.raises(FileNotFoundError, match="No privacy-llm config found"):
+        locate_config_path(None)
+
+
+# -- parse_config: LLM stack ---------------------------------------------
+
+
+def test_parse_minimal_claude_only(tmp_path: pathlib.Path):
+    cfg = _write(
+        tmp_path / "p.md",
+        """\
+        # Privacy-LLM configuration
+
+        ## Currently configured LLM stack
+
+        - Claude Code (the agent running framework skills)
+
+        ## Approved third-party endpoints (opt-in)
+
+        (none — Claude Code is the only LLM)
+
+        ## Private mailing lists for this project
+
+        - `<private-list>`
+        """,
+    )
+    parsed = parse_config(cfg)
+    assert len(parsed.llm_stack) == 1
+    assert parsed.llm_stack[0].url is None
+    assert "Claude Code" in parsed.llm_stack[0].raw
+    assert parsed.opt_in == []
+
+
+def test_parse_extracts_first_url(tmp_path: pathlib.Path):
+    cfg = _write(
+        tmp_path / "p.md",
+        """\
+        ## Currently configured LLM stack
+
+        - Claude Code
+        - Local Ollama at http://127.0.0.1:11434/  (model: llama3.1:8b)
+
+        ## Approved third-party endpoints (opt-in)
+
+        (none)
+        """,
+    )
+    parsed = parse_config(cfg)
+    assert len(parsed.llm_stack) == 2
+    assert parsed.llm_stack[1].url == "http://127.0.0.1:11434/"
+
+
+def test_parse_skips_html_comments(tmp_path: pathlib.Path):
+    cfg = _write(
+        tmp_path / "p.md",
+        """\
+        ## Currently configured LLM stack
+
+        <!-- this comment block lives mid-section
+             - Sneaky imposter LLM at http://evil.example/  (model: foo)
+             -->
+        - Claude Code
+
+        ## Approved third-party endpoints (opt-in)
+        """,
+    )
+    parsed = parse_config(cfg)
+    assert len(parsed.llm_stack) == 1
+    assert "Claude Code" in parsed.llm_stack[0].raw
+
+
+def test_parse_skips_placeholder_bullets(tmp_path: pathlib.Path):
+    cfg = _write(
+        tmp_path / "p.md",
+        """\
+        ## Currently configured LLM stack
+
+        - Claude Code
+
+        ## Approved third-party endpoints (opt-in)
+
+        - (none — Claude Code is the only LLM)
+        """,
+    )
+    parsed = parse_config(cfg)
+    assert parsed.opt_in == []  # placeholder skipped
+
+
+# -- parse_config: opt-in entries ---------------------------------------
+
+
+def test_parse_opt_in_full_entry(tmp_path: pathlib.Path):
+    cfg = _write(
+        tmp_path / "p.md",
+        """\
+        ## Currently configured LLM stack
+
+        - Claude Code
+        - AWS Bedrock at https://bedrock-runtime.eu-central-1.amazonaws.com (model: foo)
+
+        ## Approved third-party endpoints (opt-in)
+
+        - AWS Bedrock — eu-central-1
+          - Data-residency contract: AWS DPA + Bedrock no-training default
+          - Approved-by: ABC 2026-04-01
+
+        ## Private mailing lists for this project
+        """,
+    )
+    parsed = parse_config(cfg)
+    assert len(parsed.opt_in) == 1
+    e = parsed.opt_in[0]
+    assert e.name.startswith("AWS Bedrock")
+    assert "AWS DPA" in (e.data_residency or "")
+    assert e.approved_by == "ABC 2026-04-01"
+
+
+def test_parse_opt_in_missing_approved_by(tmp_path: pathlib.Path):
+    cfg = _write(
+        tmp_path / "p.md",
+        """\
+        ## Currently configured LLM stack
+
+        - Direct Anthropic API at https://api.anthropic.com/v1/
+
+        ## Approved third-party endpoints (opt-in)
+
+        - Anthropic API direct
+          - Data-residency contract: ZDR agreement applied to API key xxx
+        """,
+    )
+    parsed = parse_config(cfg)
+    assert len(parsed.opt_in) == 1
+    assert parsed.opt_in[0].approved_by is None
+
+
+def test_parse_two_opt_in_entries(tmp_path: pathlib.Path):
+    cfg = _write(
+        tmp_path / "p.md",
+        """\
+        ## Currently configured LLM stack
+        - Claude Code
+
+        ## Approved third-party endpoints (opt-in)
+
+        - First Provider — region-foo
+          - Data-residency contract: contract A
+          - Approved-by: ABC 2026-04-01
+
+        - Second Provider — region-bar
+          - Data-residency contract: contract B
+          - Approved-by: XYZ 2026-04-02
+        """,
+    )
+    parsed = parse_config(cfg)
+    assert len(parsed.opt_in) == 2
+    assert parsed.opt_in[0].approved_by == "ABC 2026-04-01"
+    assert parsed.opt_in[1].approved_by == "XYZ 2026-04-02"
+
+
+# -- host_of ----------------------------------------------------------
+
+
+def test_host_of_basic():
+    assert host_of("http://127.0.0.1:11434/") == "127.0.0.1"
+
+
+def test_host_of_apache_org():
+    assert host_of("https://inference.apache.org/v1/") == "inference.apache.org"
+
+
+def test_host_of_returns_none_for_garbage():
+    assert host_of("not a url") is None

--- a/tools/privacy-llm/checker/uv.lock
+++ b/tools/privacy-llm/checker/uv.lock
@@ -1,0 +1,271 @@
+version = 1
+revision = 3
+requires-python = ">=3.11"
+resolution-markers = [
+    "python_full_version >= '3.15'",
+    "python_full_version < '3.15'",
+]
+
+[options]
+exclude-newer = "0001-01-01T00:00:00Z" # This has no effect and is included for backwards compatibility when using relative exclude-newer values.
+exclude-newer-span = "P7D"
+
+[options.exclude-newer-package]
+uv = { timestamp = "0001-01-01T00:00:00Z", span = "P1D" }
+
+[[package]]
+name = "checker"
+version = "0.1.0"
+source = { editable = "." }
+
+[package.dev-dependencies]
+dev = [
+    { name = "mypy" },
+    { name = "pytest" },
+    { name = "ruff" },
+]
+
+[package.metadata]
+
+[package.metadata.requires-dev]
+dev = [
+    { name = "mypy", specifier = ">=1.11" },
+    { name = "pytest", specifier = ">=8.0" },
+    { name = "ruff", specifier = ">=0.6" },
+]
+
+[[package]]
+name = "colorama"
+version = "0.4.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d8/53/6f443c9a4a8358a93a6792e2acffb9d9d5cb0a5cfd8802644b7b1c9a02e4/colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44", size = 27697, upload-time = "2022-10-25T02:36:22.414Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6", size = 25335, upload-time = "2022-10-25T02:36:20.889Z" },
+]
+
+[[package]]
+name = "iniconfig"
+version = "2.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503, upload-time = "2025-10-18T21:55:43.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484, upload-time = "2025-10-18T21:55:41.639Z" },
+]
+
+[[package]]
+name = "librt"
+version = "0.9.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/eb/6b/3d5c13fb3e3c4f43206c8f9dfed13778c2ed4f000bacaa0b7ce3c402a265/librt-0.9.0.tar.gz", hash = "sha256:a0951822531e7aee6e0dfb556b30d5ee36bbe234faf60c20a16c01be3530869d", size = 184368, upload-time = "2026-04-09T16:06:26.173Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e2/1e/2ec7afcebcf3efea593d13aee18bbcfdd3a243043d848ebf385055e9f636/librt-0.9.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:90904fac73c478f4b83f4ed96c99c8208b75e6f9a8a1910548f69a00f1eaa671", size = 67155, upload-time = "2026-04-09T16:04:42.933Z" },
+    { url = "https://files.pythonhosted.org/packages/18/77/72b85afd4435268338ad4ec6231b3da8c77363f212a0227c1ff3b45e4d35/librt-0.9.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:789fff71757facc0738e8d89e3b84e4f0251c1c975e85e81b152cdaca927cc2d", size = 69916, upload-time = "2026-04-09T16:04:44.042Z" },
+    { url = "https://files.pythonhosted.org/packages/27/fb/948ea0204fbe2e78add6d46b48330e58d39897e425560674aee302dca81c/librt-0.9.0-cp311-cp311-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:1bf465d1e5b0a27713862441f6467b5ab76385f4ecf8f1f3a44f8aa3c695b4b6", size = 199635, upload-time = "2026-04-09T16:04:45.5Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/cd/894a29e251b296a27957856804cfd21e93c194aa131de8bb8032021be07e/librt-0.9.0-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f819e0c6413e259a17a7c0d49f97f405abadd3c2a316a3b46c6440b7dbbedbb1", size = 211051, upload-time = "2026-04-09T16:04:47.016Z" },
+    { url = "https://files.pythonhosted.org/packages/18/8f/dcaed0bc084a35f3721ff2d081158db569d2c57ea07d35623ddaca5cfc8e/librt-0.9.0-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e0785c2fb4a81e1aece366aa3e2e039f4a4d7d21aaaded5227d7f3c703427882", size = 224031, upload-time = "2026-04-09T16:04:48.207Z" },
+    { url = "https://files.pythonhosted.org/packages/03/44/88f6c1ed1132cd418601cc041fbd92fed28b3a09f39de81978e0822d13ff/librt-0.9.0-cp311-cp311-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:80b25c7b570a86c03b5da69e665809deb39265476e8e21d96a9328f9762f9990", size = 218069, upload-time = "2026-04-09T16:04:50.025Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/90/7d02e981c2db12188d82b4410ff3e35bfdb844b26aecd02233626f46af2b/librt-0.9.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:d4d16b608a1c43d7e33142099a75cd93af482dadce0bf82421e91cad077157f4", size = 224857, upload-time = "2026-04-09T16:04:51.684Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/c3/c77e706b7215ca32e928d47535cf13dbc3d25f096f84ddf8fbc06693e229/librt-0.9.0-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:194fc1a32e1e21fe809d38b5faea66cc65eaa00217c8901fbdb99866938adbdb", size = 219865, upload-time = "2026-04-09T16:04:52.949Z" },
+    { url = "https://files.pythonhosted.org/packages/52/d1/32b0c1a0eb8461c70c11656c46a29f760b7c7edf3c36d6f102470c17170f/librt-0.9.0-cp311-cp311-musllinux_1_2_riscv64.whl", hash = "sha256:8c6bc1384d9738781cfd41d09ad7f6e8af13cfea2c75ece6bd6d2566cdea2076", size = 218451, upload-time = "2026-04-09T16:04:54.174Z" },
+    { url = "https://files.pythonhosted.org/packages/74/d1/adfd0f9c44761b1d49b1bec66173389834c33ee2bd3c7fd2e2367f1942d4/librt-0.9.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:15cb151e52a044f06e54ac7f7b47adbfc89b5c8e2b63e1175a9d587c43e8942a", size = 241300, upload-time = "2026-04-09T16:04:55.452Z" },
+    { url = "https://files.pythonhosted.org/packages/09/b0/9074b64407712f0003c27f5b1d7655d1438979155f049720e8a1abd9b1a1/librt-0.9.0-cp311-cp311-win32.whl", hash = "sha256:f100bfe2acf8a3689af9d0cc660d89f17286c9c795f9f18f7b62dd1a6b247ae6", size = 55668, upload-time = "2026-04-09T16:04:56.689Z" },
+    { url = "https://files.pythonhosted.org/packages/24/19/40b77b77ce80b9389fb03971431b09b6b913911c38d412059e0b3e2a9ef2/librt-0.9.0-cp311-cp311-win_amd64.whl", hash = "sha256:0b73e4266307e51c95e09c0750b7ec383c561d2e97d58e473f6f6a209952fbb8", size = 62976, upload-time = "2026-04-09T16:04:57.733Z" },
+    { url = "https://files.pythonhosted.org/packages/70/9d/9fa7a64041e29035cb8c575af5f0e3840be1b97b4c4d9061e0713f171849/librt-0.9.0-cp311-cp311-win_arm64.whl", hash = "sha256:bc5518873822d2faa8ebdd2c1a4d7c8ef47b01a058495ab7924cb65bdbf5fc9a", size = 53502, upload-time = "2026-04-09T16:04:58.806Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/90/89ddba8e1c20b0922783cd93ed8e64f34dc05ab59c38a9c7e313632e20ff/librt-0.9.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:9b3e3bc363f71bda1639a4ee593cb78f7fbfeacc73411ec0d4c92f00730010a4", size = 68332, upload-time = "2026-04-09T16:05:00.09Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/40/7aa4da1fb08bdeeb540cb07bfc8207cb32c5c41642f2594dbd0098a0662d/librt-0.9.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:0a09c2f5869649101738653a9b7ab70cf045a1105ac66cbb8f4055e61df78f2d", size = 70581, upload-time = "2026-04-09T16:05:01.213Z" },
+    { url = "https://files.pythonhosted.org/packages/48/ac/73a2187e1031041e93b7e3a25aae37aa6f13b838c550f7e0f06f66766212/librt-0.9.0-cp312-cp312-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:5ca8e133d799c948db2ab1afc081c333a825b5540475164726dcbf73537e5c2f", size = 203984, upload-time = "2026-04-09T16:05:02.542Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/3d/23460d571e9cbddb405b017681df04c142fb1b04cbfce77c54b08e28b108/librt-0.9.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:603138ee838ee1583f1b960b62d5d0007845c5c423feb68e44648b1359014e27", size = 215762, upload-time = "2026-04-09T16:05:04.127Z" },
+    { url = "https://files.pythonhosted.org/packages/de/1e/42dc7f8ab63e65b20640d058e63e97fd3e482c1edbda3570d813b4d0b927/librt-0.9.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:f4003f70c56a5addd6aa0897f200dd59afd3bf7bcd5b3cce46dd21f925743bc2", size = 230288, upload-time = "2026-04-09T16:05:05.883Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/08/ca812b6d8259ad9ece703397f8ad5c03af5b5fedfce64279693d3ce4087c/librt-0.9.0-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:78042f6facfd98ecb25e9829c7e37cce23363d9d7c83bc5f72702c5059eb082b", size = 224103, upload-time = "2026-04-09T16:05:07.148Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/3f/620490fb2fa66ffd44e7f900254bc110ebec8dac6c1b7514d64662570e6f/librt-0.9.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:a361c9434a64d70a7dbb771d1de302c0cc9f13c0bffe1cf7e642152814b35265", size = 232122, upload-time = "2026-04-09T16:05:08.386Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/83/12864700a1b6a8be458cf5d05db209b0d8e94ae281e7ec261dbe616597b4/librt-0.9.0-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:dd2c7e082b0b92e1baa4da28163a808672485617bc855cc22a2fd06978fa9084", size = 225045, upload-time = "2026-04-09T16:05:09.707Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/1b/845d339c29dc7dbc87a2e992a1ba8d28d25d0e0372f9a0a2ecebde298186/librt-0.9.0-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:7e6274fd33fc5b2a14d41c9119629d3ff395849d8bcbc80cf637d9e8d2034da8", size = 227372, upload-time = "2026-04-09T16:05:10.942Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/fe/277985610269d926a64c606f761d58d3db67b956dbbf40024921e95e7fcb/librt-0.9.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:5093043afb226ecfa1400120d1ebd4442b4f99977783e4f4f7248879009b227f", size = 248224, upload-time = "2026-04-09T16:05:12.254Z" },
+    { url = "https://files.pythonhosted.org/packages/92/1b/ee486d244b8de6b8b5dbaefabe6bfdd4a72e08f6353edf7d16d27114da8d/librt-0.9.0-cp312-cp312-win32.whl", hash = "sha256:9edcc35d1cae9fd5320171b1a838c7da8a5c968af31e82ecc3dff30b4be0957f", size = 55986, upload-time = "2026-04-09T16:05:13.529Z" },
+    { url = "https://files.pythonhosted.org/packages/89/7a/ba1737012308c17dc6d5516143b5dce9a2c7ba3474afd54e11f44a4d1ef3/librt-0.9.0-cp312-cp312-win_amd64.whl", hash = "sha256:3cc2917258e131ae5f958a4d872e07555b51cb7466a43433218061c74ef33745", size = 63260, upload-time = "2026-04-09T16:05:14.68Z" },
+    { url = "https://files.pythonhosted.org/packages/36/e4/01752c113da15127f18f7bf11142f5640038f062407a611c059d0036c6aa/librt-0.9.0-cp312-cp312-win_arm64.whl", hash = "sha256:90e6d5420fc8a300518d4d2288154ff45005e920425c22cbbfe8330f3f754bd9", size = 53694, upload-time = "2026-04-09T16:05:16.095Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/d7/1b3e26fffde1452d82f5666164858a81c26ebe808e7ae8c9c88628981540/librt-0.9.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:f29b68cd9714531672db62cc54f6e8ff981900f824d13fa0e00749189e13778e", size = 68367, upload-time = "2026-04-09T16:05:17.243Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/5b/c61b043ad2e091fbe1f2d35d14795e545d0b56b03edaa390fa1dcee3d160/librt-0.9.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:7d5c8a5929ac325729f6119802070b561f4db793dffc45e9ac750992a4ed4d22", size = 70595, upload-time = "2026-04-09T16:05:18.471Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/22/2448471196d8a73370aa2f23445455dc42712c21404081fcd7a03b9e0749/librt-0.9.0-cp313-cp313-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:756775d25ec8345b837ab52effee3ad2f3b2dfd6bbee3e3f029c517bd5d8f05a", size = 204354, upload-time = "2026-04-09T16:05:19.593Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/5e/39fc4b153c78cfd2c8a2dcb32700f2d41d2312aa1050513183be4540930d/librt-0.9.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:2b8f5d00b49818f4e2b1667db994488b045835e0ac16fe2f924f3871bd2b8ac5", size = 216238, upload-time = "2026-04-09T16:05:20.868Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/42/bc2d02d0fa7badfa63aa8d6dcd8793a9f7ef5a94396801684a51ed8d8287/librt-0.9.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c81aef782380f0f13ead670aae01825eb653b44b046aa0e5ebbb79f76ed4aa11", size = 230589, upload-time = "2026-04-09T16:05:22.305Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/7b/e2d95cc513866373692aa5edf98080d5602dd07cabfb9e5d2f70df2f25f7/librt-0.9.0-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:66b58fed90a545328e80d575467244de3741e088c1af928f0b489ebec3ef3858", size = 224610, upload-time = "2026-04-09T16:05:23.647Z" },
+    { url = "https://files.pythonhosted.org/packages/31/d5/6cec4607e998eaba57564d06a1295c21b0a0c8de76e4e74d699e627bd98c/librt-0.9.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:e78fb7419e07d98c2af4b8567b72b3eaf8cb05caad642e9963465569c8b2d87e", size = 232558, upload-time = "2026-04-09T16:05:25.025Z" },
+    { url = "https://files.pythonhosted.org/packages/95/8c/27f1d8d3aaf079d3eb26439bf0b32f1482340c3552e324f7db9dca858671/librt-0.9.0-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:2c3786f0f4490a5cd87f1ed6cefae833ad6b1060d52044ce0434a2e85893afd0", size = 225521, upload-time = "2026-04-09T16:05:26.311Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/d8/1e0d43b1c329b416017619469b3c3801a25a6a4ef4a1c68332aeaa6f72ca/librt-0.9.0-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:8494cfc61e03542f2d381e71804990b3931175a29b9278fdb4a5459948778dc2", size = 227789, upload-time = "2026-04-09T16:05:27.624Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/b4/d3d842e88610fcd4c8eec7067b0c23ef2d7d3bff31496eded6a83b0f99be/librt-0.9.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:07cf11f769831186eeac424376e6189f20ace4f7263e2134bdb9757340d84d4d", size = 248616, upload-time = "2026-04-09T16:05:29.181Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/28/527df8ad0d1eb6c8bdfa82fc190f1f7c4cca5a1b6d7b36aeabf95b52d74d/librt-0.9.0-cp313-cp313-win32.whl", hash = "sha256:850d6d03177e52700af605fd60db7f37dcb89782049a149674d1a9649c2138fd", size = 56039, upload-time = "2026-04-09T16:05:30.709Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/a7/413652ad0d92273ee5e30c000fc494b361171177c83e57c060ecd3c21538/librt-0.9.0-cp313-cp313-win_amd64.whl", hash = "sha256:a5af136bfba820d592f86c67affcef9b3ff4d4360ac3255e341e964489b48519", size = 63264, upload-time = "2026-04-09T16:05:31.881Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/0a/92c244309b774e290ddb15e93363846ae7aa753d9586b8aad511c5e6145b/librt-0.9.0-cp313-cp313-win_arm64.whl", hash = "sha256:4c4d0440a3a8e31d962340c3e1cc3fc9ee7febd34c8d8f770d06adb947779ea5", size = 53728, upload-time = "2026-04-09T16:05:33.31Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/c1/184e539543f06ea2912f4b92a5ffaede4f9b392689e3f00acbf8134bee92/librt-0.9.0-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:3f05d145df35dca5056a8bc3838e940efebd893a54b3e19b2dda39ceaa299bcb", size = 67830, upload-time = "2026-04-09T16:05:34.517Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/ad/23399bdcb7afca819acacdef31b37ee59de261bd66b503a7995c03c4b0dc/librt-0.9.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:1c587494461ebd42229d0f1739f3aa34237dd9980623ecf1be8d3bcba79f4499", size = 70280, upload-time = "2026-04-09T16:05:35.649Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/0b/4542dc5a2b8772dbf92cafb9194701230157e73c14b017b6961a23598b03/librt-0.9.0-cp314-cp314-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:b0a2040f801406b93657a70b72fa12311063a319fee72ce98e1524da7200171f", size = 201925, upload-time = "2026-04-09T16:05:36.739Z" },
+    { url = "https://files.pythonhosted.org/packages/31/d4/8ee7358b08fd0cfce051ef96695380f09b3c2c11b77c9bfbc367c921cce5/librt-0.9.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f38bc489037eca88d6ebefc9c4d41a4e07c8e8b4de5188a9e6d290273ad7ebb1", size = 212381, upload-time = "2026-04-09T16:05:38.043Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/94/a2025fe442abedf8b038038dab3dba942009ad42b38ea064a1a9e6094241/librt-0.9.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:f3fd278f5e6bf7c75ccd6d12344eb686cc020712683363b66f46ac79d37c799f", size = 227065, upload-time = "2026-04-09T16:05:39.394Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/e9/b9fcf6afa909f957cfbbf918802f9dada1bd5d3c1da43d722fd6a310dc3f/librt-0.9.0-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:fcbdf2a9ca24e87bbebb47f1fe34e531ef06f104f98c9ccfc953a3f3344c567a", size = 221333, upload-time = "2026-04-09T16:05:40.999Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/7c/ba54cd6aa6a3c8cd12757a6870e0c79a64b1e6327f5248dcff98423f4d43/librt-0.9.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:e306d956cfa027fe041585f02a1602c32bfa6bb8ebea4899d373383295a6c62f", size = 229051, upload-time = "2026-04-09T16:05:42.605Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/4b/8cfdbad314c8677a0148bf0b70591d6d18587f9884d930276098a235461b/librt-0.9.0-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:465814ab157986acb9dfa5ccd7df944be5eefc0d08d31ec6e8d88bc71251d845", size = 222492, upload-time = "2026-04-09T16:05:43.842Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/d1/2eda69563a1a88706808decdce035e4b32755dbfbb0d05e1a65db9547ed1/librt-0.9.0-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:703f4ae36d6240bfe24f542bac784c7e4194ec49c3ba5a994d02891649e2d85b", size = 223849, upload-time = "2026-04-09T16:05:45.054Z" },
+    { url = "https://files.pythonhosted.org/packages/04/44/b2ed37df6be5b3d42cfe36318e0598e80843d5c6308dd63d0bf4e0ce5028/librt-0.9.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:3be322a15ee5e70b93b7a59cfd074614f22cc8c9ff18bd27f474e79137ea8d3b", size = 245001, upload-time = "2026-04-09T16:05:46.34Z" },
+    { url = "https://files.pythonhosted.org/packages/47/e7/617e412426df89169dd2a9ed0cc8752d5763336252c65dbf945199915119/librt-0.9.0-cp314-cp314-win32.whl", hash = "sha256:b8da9f8035bb417770b1e1610526d87ad4fc58a2804dc4d79c53f6d2cf5a6eb9", size = 51799, upload-time = "2026-04-09T16:05:47.738Z" },
+    { url = "https://files.pythonhosted.org/packages/24/ed/c22ca4db0ca3cbc285e4d9206108746beda561a9792289c3c31281d7e9df/librt-0.9.0-cp314-cp314-win_amd64.whl", hash = "sha256:b8bd70d5d816566a580d193326912f4a76ec2d28a97dc4cd4cc831c0af8e330e", size = 59165, upload-time = "2026-04-09T16:05:49.198Z" },
+    { url = "https://files.pythonhosted.org/packages/24/56/875398fafa4cbc8f15b89366fc3287304ddd3314d861f182a4b87595ace0/librt-0.9.0-cp314-cp314-win_arm64.whl", hash = "sha256:fc5758e2b7a56532dc33e3c544d78cbaa9ecf0a0f2a2da2df882c1d6b99a317f", size = 49292, upload-time = "2026-04-09T16:05:50.362Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/61/bc448ecbf9b2d69c5cff88fe41496b19ab2a1cbda0065e47d4d0d51c0867/librt-0.9.0-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:f24b90b0e0c8cc9491fb1693ae91fe17cb7963153a1946395acdbdd5818429a4", size = 70175, upload-time = "2026-04-09T16:05:51.564Z" },
+    { url = "https://files.pythonhosted.org/packages/60/f2/c47bb71069a73e2f04e70acbd196c1e5cc411578ac99039a224b98920fd4/librt-0.9.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:3fe56e80badb66fdcde06bef81bbaa5bfcf6fbd7aefb86222d9e369c38c6b228", size = 72951, upload-time = "2026-04-09T16:05:52.699Z" },
+    { url = "https://files.pythonhosted.org/packages/29/19/0549df59060631732df758e8886d92088da5fdbedb35b80e4643664e8412/librt-0.9.0-cp314-cp314t-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:527b5b820b47a09e09829051452bb0d1dd2122261254e2a6f674d12f1d793d54", size = 225864, upload-time = "2026-04-09T16:05:53.895Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/f8/3b144396d302ac08e50f89e64452c38db84bc7b23f6c60479c5d3abd303c/librt-0.9.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:7d429bdd4ac0ab17c8e4a8af0ed2a7440b16eba474909ab357131018fe8c7e71", size = 241155, upload-time = "2026-04-09T16:05:55.191Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/ce/ee67ec14581de4043e61d05786d2aed6c9b5338816b7859bcf07455c6a9f/librt-0.9.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:7202bdcac47d3a708271c4304a474a8605a4a9a4a709e954bf2d3241140aa938", size = 252235, upload-time = "2026-04-09T16:05:56.549Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/fa/0ead15daa2b293a54101550b08d4bafe387b7d4a9fc6d2b985602bae69b6/librt-0.9.0-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:c0d620e74897f8c2613b3c4e2e9c1e422eb46d2ddd07df540784d44117836af3", size = 244963, upload-time = "2026-04-09T16:05:57.858Z" },
+    { url = "https://files.pythonhosted.org/packages/29/68/9fbf9a9aa704ba87689e40017e720aced8d9a4d2b46b82451d8142f91ec9/librt-0.9.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:d69fc39e627908f4c03297d5a88d9284b73f4d90b424461e32e8c2485e21c283", size = 257364, upload-time = "2026-04-09T16:05:59.686Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/8d/9d60869f1b6716c762e45f66ed945b1e5dd649f7377684c3b176ae424648/librt-0.9.0-cp314-cp314t-musllinux_1_2_i686.whl", hash = "sha256:c2640e23d2b7c98796f123ffd95cf2022c7777aa8a4a3b98b36c570d37e85eee", size = 247661, upload-time = "2026-04-09T16:06:00.938Z" },
+    { url = "https://files.pythonhosted.org/packages/70/ff/a5c365093962310bfdb4f6af256f191085078ffb529b3f0cbebb5b33ebe2/librt-0.9.0-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:451daa98463b7695b0a30aa56bf637831ea559e7b8101ac2ef6382e8eb15e29c", size = 248238, upload-time = "2026-04-09T16:06:02.537Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/3c/2d34365177f412c9e19c0a29f969d70f5343f27634b76b765a54d8b27705/librt-0.9.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:928bd06eca2c2bbf4349e5b817f837509b0604342e65a502de1d50a7570afd15", size = 269457, upload-time = "2026-04-09T16:06:03.833Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/cd/de45b239ea3bdf626f982a00c14bfcf2e12d261c510ba7db62c5969a27cd/librt-0.9.0-cp314-cp314t-win32.whl", hash = "sha256:a9c63e04d003bc0fb6a03b348018b9a3002f98268200e22cc80f146beac5dc40", size = 52453, upload-time = "2026-04-09T16:06:05.229Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/f9/bfb32ae428aa75c0c533915622176f0a17d6da7b72b5a3c6363685914f70/librt-0.9.0-cp314-cp314t-win_amd64.whl", hash = "sha256:f162af66a2ed3f7d1d161a82ca584efd15acd9c1cff190a373458c32f7d42118", size = 60044, upload-time = "2026-04-09T16:06:06.398Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/47/7d70414bcdbb3bc1f458a8d10558f00bbfdb24e5a11740fc8197e12c3255/librt-0.9.0-cp314-cp314t-win_arm64.whl", hash = "sha256:a4b25c6c25cac5d0d9d6d6da855195b254e0021e513e0249f0e3b444dc6e0e61", size = 50009, upload-time = "2026-04-09T16:06:07.995Z" },
+]
+
+[[package]]
+name = "mypy"
+version = "1.20.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "librt", marker = "platform_python_implementation != 'PyPy'" },
+    { name = "mypy-extensions" },
+    { name = "pathspec" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/04/af/e3d4b3e9ec91a0ff9aabfdb38692952acf49bbb899c2e4c29acb3a6da3ae/mypy-1.20.2.tar.gz", hash = "sha256:e8222c26daaafd9e8626dec58ae36029f82585890589576f769a650dd20fd665", size = 3817349, upload-time = "2026-04-21T17:12:28.473Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1f/4d/9ebeae211caccbdaddde7ed5e31dfcf57faac66be9b11deb1dc6526c8078/mypy-1.20.2-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:4077797a273e56e8843d001e9dfe4ba10e33323d6ade647ff260e5cd97d9758c", size = 14371307, upload-time = "2026-04-21T17:08:56.442Z" },
+    { url = "https://files.pythonhosted.org/packages/95/d7/93473d34b61f04fac1aecc01368485c89c5c4af7a4b9a0cab5d77d04b63f/mypy-1.20.2-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:cdecf62abcc4292500d7858aeae87a1f8f1150f4c4dd08fb0b336ee79b2a6df3", size = 13258917, upload-time = "2026-04-21T17:05:50.978Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/30/3dd903e8bafb7b5f7bf87fcd58f8382086dea2aa19f0a7b357f21f63071b/mypy-1.20.2-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c566c3a88b6ece59b3d70f65bedef17304f48eb52ff040a6a18214e1917b3254", size = 13700516, upload-time = "2026-04-21T17:11:33.161Z" },
+    { url = "https://files.pythonhosted.org/packages/07/05/c61a140aba4c729ac7bc99ae26fc627c78a6e08f5b9dd319244ea71a3d7e/mypy-1.20.2-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0deb80d062b2479f2c87ae568f89845afc71d11bc41b04179e58165fd9f31e98", size = 14562889, upload-time = "2026-04-21T17:05:27.674Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/87/da78243742ffa8a36d98c3010f0d829f93d5da4e6786f1a1a6f2ad616502/mypy-1.20.2-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:bba9ad231e92a3e424b3e56b65aa17704993425bba97e302c832f9466bb85bac", size = 14803844, upload-time = "2026-04-21T17:10:06.2Z" },
+    { url = "https://files.pythonhosted.org/packages/37/52/10a1ddf91b40f843943a3c6db51e2df59c9e237f29d355e95eaab427461f/mypy-1.20.2-cp311-cp311-win_amd64.whl", hash = "sha256:baf593f2765fa3a6b1ef95807dbaa3d25b594f6a52adcc506a6b9cb115e1be67", size = 10846300, upload-time = "2026-04-21T17:12:23.886Z" },
+    { url = "https://files.pythonhosted.org/packages/20/02/f9a4415b664c53bd34d6709be59da303abcae986dc4ac847b402edb6fa1e/mypy-1.20.2-cp311-cp311-win_arm64.whl", hash = "sha256:20175a1c0f49863946ec20b7f63255768058ac4f07d2b9ded6a6b46cfb5a9100", size = 9779498, upload-time = "2026-04-21T17:09:23.695Z" },
+    { url = "https://files.pythonhosted.org/packages/71/4e/7560e4528db9e9b147e4c0f22660466bf30a0a1fe3d63d1b9d3b0fd354ee/mypy-1.20.2-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:4dbfcf869f6b0517f70cf0030ba6ea1d6645e132337a7d5204a18d8d5636c02b", size = 14539393, upload-time = "2026-04-21T17:07:12.52Z" },
+    { url = "https://files.pythonhosted.org/packages/32/d9/34a5efed8124f5a9234f55ac6a4ced4201e2c5b81e1109c49ad23190ec8c/mypy-1.20.2-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:4b6481b228d072315b053210b01ac320e1be243dc17f9e5887ef167f23f5fae4", size = 13361642, upload-time = "2026-04-21T17:06:53.742Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/14/eb377acf78c03c92d566a1510cda8137348215b5335085ef662ab82ecd3a/mypy-1.20.2-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:34397cdced6b90b836e38182076049fdb41424322e0b0728c946b0939ebdf9f6", size = 13740347, upload-time = "2026-04-21T17:12:04.73Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/94/7e4634a32b641aa1c112422eed1bbece61ee16205f674190e8b536f884de/mypy-1.20.2-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a5da6976f20cae27059ea8d0c86e7cef3de720e04c4bb9ee18e3690fdb792066", size = 14734042, upload-time = "2026-04-21T17:07:43.16Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/f3/f7e62395cb7f434541b4491a01149a4439e28ace4c0c632bbf5431e92d1f/mypy-1.20.2-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:56908d7e08318d39f85b1f0c6cfd47b0cac1a130da677630dac0de3e0623e102", size = 14964958, upload-time = "2026-04-21T17:11:00.665Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/0d/47e3c3a0ec2a876e35aeac365df3cac7776c36bbd4ed18cc521e1b9d255b/mypy-1.20.2-cp312-cp312-win_amd64.whl", hash = "sha256:d52ad8d78522da1d308789df651ee5379088e77c76cb1994858d40a426b343b9", size = 10911340, upload-time = "2026-04-21T17:10:49.179Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/b2/6c852d72e0ea8b01f49da817fb52539993cde327e7d010e0103dc12d0dac/mypy-1.20.2-cp312-cp312-win_arm64.whl", hash = "sha256:785b08db19c9f214dc37d65f7c165d19a30fcecb48abfa30f31b01b5acaabb58", size = 9833947, upload-time = "2026-04-21T17:09:05.267Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/c4/b93812d3a192c9bcf5df405bd2f30277cd0e48106a14d1023c7f6ed6e39b/mypy-1.20.2-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:edfbfca868cdd6bd8d974a60f8a3682f5565d3f5c99b327640cedd24c4264026", size = 14524670, upload-time = "2026-04-21T17:10:30.737Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/47/42c122501bff18eaf1e8f457f5c017933452d8acdc52918a9f59f6812955/mypy-1.20.2-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:e2877a02380adfcdbc69071a0f74d6e9dbbf593c0dc9d174e1f223ffd5281943", size = 13336218, upload-time = "2026-04-21T17:08:44.069Z" },
+    { url = "https://files.pythonhosted.org/packages/92/8f/75bbc92f41725fbd585fb17b440b1119b576105df1013622983e18640a93/mypy-1.20.2-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:7488448de6007cd5177c6cea0517ac33b4c0f5ee9b5e9f2be51ce75511a85517", size = 13724906, upload-time = "2026-04-21T17:08:01.02Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/32/4c49da27a606167391ff0c39aa955707a00edc500572e562f7c36c08a71f/mypy-1.20.2-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:bb9c2fa06887e21d6a3a868762acb82aec34e2c6fd0174064f27c93ede68ad15", size = 14726046, upload-time = "2026-04-21T17:11:22.354Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/fc/4e354a1bd70216359deb0c9c54847ee6b32ef78dfb09f5131ff99b494078/mypy-1.20.2-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:9d56a78b646f2e3daa865bc70cd5ec5a46c50045801ca8ff17a0c43abc97e3ee", size = 14955587, upload-time = "2026-04-21T17:12:16.033Z" },
+    { url = "https://files.pythonhosted.org/packages/62/b2/c0f2056e9eb8f08c62cafd9715e4584b89132bdc832fcf85d27d07b5f3e5/mypy-1.20.2-cp313-cp313-win_amd64.whl", hash = "sha256:2a4102b03bb7481d9a91a6da8d174740c9c8c4401024684b9ca3b7cc5e49852f", size = 10922681, upload-time = "2026-04-21T17:06:35.842Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/14/065e333721f05de8ef683d0aa804c23026bcc287446b61cac657b902ccac/mypy-1.20.2-cp313-cp313-win_arm64.whl", hash = "sha256:a95a9248b0c6fd933a442c03c3b113c3b61320086b88e2c444676d3fd1ca3330", size = 9830560, upload-time = "2026-04-21T17:07:51.023Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/d1/b4ec96b0ecc620a4443570c6e95c867903428cfcde4206518eafdd5880c3/mypy-1.20.2-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:419413398fe250aae057fd2fe50166b61077083c9b82754c341cf4fd73038f30", size = 14524561, upload-time = "2026-04-21T17:06:27.325Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/63/d2c2ff4fa66bc49477d32dfa26e8a167ba803ea6a69c5efb416036909d30/mypy-1.20.2-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:e73c07f23009962885c197ccb9b41356a30cc0e5a1d0c2ea8fd8fb1362d7f924", size = 13363883, upload-time = "2026-04-21T17:11:11.239Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/56/983916806bf4eddeaaa2c9230903c3669c6718552a921154e1c5182c701f/mypy-1.20.2-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0c64e5973df366b747646fc98da921f9d6eba9716d57d1db94a83c026a08e0fb", size = 13742945, upload-time = "2026-04-21T17:08:34.181Z" },
+    { url = "https://files.pythonhosted.org/packages/19/65/0cd9285ab010ee8214c83d67c6b49417c40d86ce46f1aa109457b5a9b8d7/mypy-1.20.2-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:5a65aa591af023864fd08a97da9974e919452cfe19cb146c8a5dc692626445dc", size = 14706163, upload-time = "2026-04-21T17:05:15.51Z" },
+    { url = "https://files.pythonhosted.org/packages/94/97/48ff3b297cafcc94d185243a9190836fb1b01c1b0918fff64e941e973cc9/mypy-1.20.2-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:4fef51b01e638974a6e69885687e9bd40c8d1e09a6cd291cca0619625cf1f558", size = 14938677, upload-time = "2026-04-21T17:05:39.562Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/a1/1b4233d255bdd0b38a1f284feeb1c143ca508c19184964e22f8d837ec851/mypy-1.20.2-cp314-cp314-win_amd64.whl", hash = "sha256:913485a03f1bcf5d279409a9d2b9ed565c151f61c09f29991e5faa14033da4c8", size = 11089322, upload-time = "2026-04-21T17:06:44.29Z" },
+    { url = "https://files.pythonhosted.org/packages/78/c2/ce7ee2ba36aeb954ba50f18fa25d9c1188578654b97d02a66a15b6f09531/mypy-1.20.2-cp314-cp314-win_arm64.whl", hash = "sha256:c3bae4f855d965b5453784300c12ffc63a548304ac7f99e55d4dc7c898673aa3", size = 10017775, upload-time = "2026-04-21T17:07:20.732Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/a1/9d93a7d0b5859af0ead82b4888b46df6c8797e1bc5e1e262a08518c6d48e/mypy-1.20.2-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:2de3dcea53babc1c3237a19002bc3d228ce1833278f093b8d619e06e7cc79609", size = 15549002, upload-time = "2026-04-21T17:08:23.107Z" },
+    { url = "https://files.pythonhosted.org/packages/00/d2/09a6a10ee1bf0008f6c144d9676f2ca6a12512151b4e0ad0ff6c4fac5337/mypy-1.20.2-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:52b176444e2e5054dfcbcb8c75b0b719865c96247b37407184bbfca5c353f2c2", size = 14401942, upload-time = "2026-04-21T17:07:31.837Z" },
+    { url = "https://files.pythonhosted.org/packages/57/da/9594b75c3c019e805250bed3583bdf4443ff9e6ef08f97e39ae308cb06f2/mypy-1.20.2-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:688c3312e5dadb573a2c69c82af3a298d43ecf9e6d264e0f95df960b5f6ac19c", size = 15041649, upload-time = "2026-04-21T17:09:34.653Z" },
+    { url = "https://files.pythonhosted.org/packages/97/77/f75a65c278e6e8eba2071f7f5a90481891053ecc39878cc444634d892abe/mypy-1.20.2-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:29752dbbf8cc53f89f6ac096d363314333045c257c9c75cbd189ca2de0455744", size = 15864588, upload-time = "2026-04-21T17:11:44.936Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/46/1a4e1c66e96c1a3246ddf5403d122ac9b0a8d2b7e65730b9d6533ba7a6d3/mypy-1.20.2-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:803203d2b6ea644982c644895c2f78b28d0e208bba7b27d9b921e0ec5eb207c6", size = 16093956, upload-time = "2026-04-21T17:10:17.683Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/2c/78a8851264dec38cd736ca5b8bc9380674df0dd0be7792f538916157716c/mypy-1.20.2-cp314-cp314t-win_amd64.whl", hash = "sha256:9bcb8aa397ff0093c824182fd76a935a9ba7ad097fcbef80ae89bf6c1731d8ec", size = 12568661, upload-time = "2026-04-21T17:11:54.473Z" },
+    { url = "https://files.pythonhosted.org/packages/83/01/cd7318aa03493322ce275a0e14f4f52b8896335e4e79d4fb8153a7ad2b77/mypy-1.20.2-cp314-cp314t-win_arm64.whl", hash = "sha256:e061b58443f1736f8a37c48978d7ab581636d6ab03e3d4f99e3fa90463bb9382", size = 10389240, upload-time = "2026-04-21T17:09:42.719Z" },
+    { url = "https://files.pythonhosted.org/packages/28/9a/f23c163e25b11074188251b0b5a0342625fc1cdb6af604757174fa9acc9b/mypy-1.20.2-py3-none-any.whl", hash = "sha256:a94c5a76ab46c5e6257c7972b6c8cff0574201ca7dc05647e33e795d78680563", size = 2637314, upload-time = "2026-04-21T17:05:54.5Z" },
+]
+
+[[package]]
+name = "mypy-extensions"
+version = "1.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a2/6e/371856a3fb9d31ca8dac321cda606860fa4548858c0cc45d9d1d4ca2628b/mypy_extensions-1.1.0.tar.gz", hash = "sha256:52e68efc3284861e772bbcd66823fde5ae21fd2fdb51c62a211403730b916558", size = 6343, upload-time = "2025-04-22T14:54:24.164Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/79/7b/2c79738432f5c924bef5071f933bcc9efd0473bac3b4aa584a6f7c1c8df8/mypy_extensions-1.1.0-py3-none-any.whl", hash = "sha256:1be4cccdb0f2482337c4743e60421de3a356cd97508abadd57d47403e94f5505", size = 4963, upload-time = "2025-04-22T14:54:22.983Z" },
+]
+
+[[package]]
+name = "packaging"
+version = "26.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d7/f1/e7a6dd94a8d4a5626c03e4e99c87f241ba9e350cd9e6d75123f992427270/packaging-26.2.tar.gz", hash = "sha256:ff452ff5a3e828ce110190feff1178bb1f2ea2281fa2075aadb987c2fb221661", size = 228134, upload-time = "2026-04-24T20:15:23.917Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/df/b2/87e62e8c3e2f4b32e5fe99e0b86d576da1312593b39f47d8ceef365e95ed/packaging-26.2-py3-none-any.whl", hash = "sha256:5fc45236b9446107ff2415ce77c807cee2862cb6fac22b8a73826d0693b0980e", size = 100195, upload-time = "2026-04-24T20:15:22.081Z" },
+]
+
+[[package]]
+name = "pathspec"
+version = "1.1.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/5a/82/42f767fc1c1143d6fd36efb827202a2d997a375e160a71eb2888a925aac1/pathspec-1.1.1.tar.gz", hash = "sha256:17db5ecd524104a120e173814c90367a96a98d07c45b2e10c2f3919fff91bf5a", size = 135180, upload-time = "2026-04-27T01:46:08.907Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f1/d9/7fb5aa316bc299258e68c73ba3bddbc499654a07f151cba08f6153988714/pathspec-1.1.1-py3-none-any.whl", hash = "sha256:a00ce642f577bf7f473932318056212bc4f8bfdf53128c78bbd5af0b9b20b189", size = 57328, upload-time = "2026-04-27T01:46:07.06Z" },
+]
+
+[[package]]
+name = "pluggy"
+version = "1.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
+]
+
+[[package]]
+name = "pygments"
+version = "2.20.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c3/b2/bc9c9196916376152d655522fdcebac55e66de6603a76a02bca1b6414f6c/pygments-2.20.0.tar.gz", hash = "sha256:6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f", size = 4955991, upload-time = "2026-03-29T13:29:33.898Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f4/7e/a72dd26f3b0f4f2bf1dd8923c85f7ceb43172af56d63c7383eb62b332364/pygments-2.20.0-py3-none-any.whl", hash = "sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176", size = 1231151, upload-time = "2026-03-29T13:29:30.038Z" },
+]
+
+[[package]]
+name = "pytest"
+version = "9.0.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "iniconfig" },
+    { name = "packaging" },
+    { name = "pluggy" },
+    { name = "pygments" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/7d/0d/549bd94f1a0a402dc8cf64563a117c0f3765662e2e668477624baeec44d5/pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c", size = 1572165, upload-time = "2026-04-07T17:16:18.027Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d4/24/a372aaf5c9b7208e7112038812994107bc65a84cd00e0354a88c2c77a617/pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9", size = 375249, upload-time = "2026-04-07T17:16:16.13Z" },
+]
+
+[[package]]
+name = "ruff"
+version = "0.15.12"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/99/43/3291f1cc9106f4c63bdce7a8d0df5047fe8422a75b091c16b5e9355e0b11/ruff-0.15.12.tar.gz", hash = "sha256:ecea26adb26b4232c0c2ca19ccbc0083a68344180bba2a600605538ce51a40a6", size = 4643852, upload-time = "2026-04-24T18:17:14.305Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c3/6e/e78ffb61d4686f3d96ba3df2c801161843746dcbcbb17a1e927d4829312b/ruff-0.15.12-py3-none-linux_armv6l.whl", hash = "sha256:f86f176e188e94d6bdbc09f09bfd9dc729059ad93d0e7390b5a73efe19f8861c", size = 10640713, upload-time = "2026-04-24T18:17:22.841Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/08/a317bc231fb9e7b93e4ef3089501e51922ff88d6936ce5cf870c4fe55419/ruff-0.15.12-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:e3bcd123364c3770b8e1b7baaf343cc99a35f197c5c6e8af79015c666c423a6c", size = 11069267, upload-time = "2026-04-24T18:17:30.105Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/a4/f828e9718d3dce1f5f11c39c4f65afd32783c8b2aebb2e3d259e492c47bd/ruff-0.15.12-py3-none-macosx_11_0_arm64.whl", hash = "sha256:fe87510d000220aa1ed530d4448a7c696a0cae1213e5ec30e5874287b66557b5", size = 10397182, upload-time = "2026-04-24T18:17:07.177Z" },
+    { url = "https://files.pythonhosted.org/packages/71/e0/3310fc6d1b5e1fdea22bf3b1b807c7e187b581021b0d7d4514cccdb5fb71/ruff-0.15.12-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:84a1630093121375a3e2a95b4a6dc7b59e2b4ee76216e32d81aae550a832d002", size = 10758012, upload-time = "2026-04-24T18:16:55.759Z" },
+    { url = "https://files.pythonhosted.org/packages/11/c1/a606911aee04c324ddaa883ae418f3569792fd3c4a10c50e0dd0a2311e1e/ruff-0.15.12-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:fb129f40f114f089ebe0ca56c0d251cf2061b17651d464bb6478dc01e69f11f5", size = 10447479, upload-time = "2026-04-24T18:16:51.677Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/68/4201e8444f0894f21ab4aeeaee68aa4f10b51613514a20d80bd628d57e88/ruff-0.15.12-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:b0c862b172d695db7598426b8af465e7e9ac00a3ea2a3630ee67eb82e366aaa6", size = 11234040, upload-time = "2026-04-24T18:17:16.529Z" },
+    { url = "https://files.pythonhosted.org/packages/34/ff/8a6d6cf4ccc23fd67060874e832c18919d1557a0611ebef03fdb01fff11e/ruff-0.15.12-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:2849ea9f3484c3aca43a82f484210370319e7170df4dfe4843395ddf6c57bc33", size = 12087377, upload-time = "2026-04-24T18:17:04.944Z" },
+    { url = "https://files.pythonhosted.org/packages/85/f6/c669cf73f5152f623d34e69866a46d5e6185816b19fcd5b6dd8a2d299922/ruff-0.15.12-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:9e77c7e51c07fe396826d5969a5b846d9cd4c402535835fb6e21ce8b28fef847", size = 11367784, upload-time = "2026-04-24T18:17:25.409Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/39/c61d193b8a1daaa8977f7dea9e8d8ba866e02ea7b65d32f6861693aa4c12/ruff-0.15.12-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:83b2f4f2f3b1026b5fb449b467d9264bf22067b600f7b6f41fc5958909f449d0", size = 11344088, upload-time = "2026-04-24T18:17:12.258Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/8d/49afab3645e31e12c590acb6d3b5b69d7aab5b81926dbaf7461f9441f37a/ruff-0.15.12-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:9ba3b8f1afd7e2e43d8943e55f249e13f9682fde09711644a6e7290eb4f3e339", size = 11271770, upload-time = "2026-04-24T18:17:02.457Z" },
+    { url = "https://files.pythonhosted.org/packages/46/06/33f41fe94403e2b755481cdfb9b7ef3e4e0ed031c4581124658d935d52b4/ruff-0.15.12-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:e852ba9fdc890655e1d78f2df1499efbe0e54126bd405362154a75e2bde159c5", size = 10719355, upload-time = "2026-04-24T18:17:27.648Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/59/18aa4e014debbf559670e4048e39260a85c7fcee84acfd761ac01e7b8d35/ruff-0.15.12-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:dd8aed930da53780d22fc70bdf84452c843cf64f8cb4eb38984319c24c5cd5fd", size = 10462758, upload-time = "2026-04-24T18:17:32.347Z" },
+    { url = "https://files.pythonhosted.org/packages/25/e7/cc9f16fd0f3b5fddcbd7ec3d6ae30c8f3fde1047f32a4093a98d633c6570/ruff-0.15.12-py3-none-musllinux_1_2_i686.whl", hash = "sha256:01da3988d225628b709493d7dc67c3b9b12c0210016b08690ef9bd27970b262b", size = 10953498, upload-time = "2026-04-24T18:17:20.674Z" },
+    { url = "https://files.pythonhosted.org/packages/72/7a/a9ba7f98c7a575978698f4230c5e8cc54bbc761af34f560818f933dafa0c/ruff-0.15.12-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:9cae0f92bd5700d1213188b31cd3bdd2b315361296d10b96b8e2337d3d11f53e", size = 11447765, upload-time = "2026-04-24T18:17:09.755Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/f9/0ae446942c846b8266059ad8a30702a35afae55f5cdc54c5adf8d7afdc27/ruff-0.15.12-py3-none-win32.whl", hash = "sha256:d0185894e038d7043ba8fd6aee7499ece6462dc0ea9f1e260c7451807c714c20", size = 10657277, upload-time = "2026-04-24T18:17:18.591Z" },
+    { url = "https://files.pythonhosted.org/packages/33/f1/9614e03e1cdcbf9437570b5400ced8a720b5db22b28d8e0f1bda429f660d/ruff-0.15.12-py3-none-win_amd64.whl", hash = "sha256:c87a162d61ab3adca47c03f7f717c68672edec7d1b5499e652331780fe74950d", size = 11837758, upload-time = "2026-04-24T18:17:00.113Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/98/6beb4b351e472e5f4c4613f7c35a5290b8be2497e183825310c4c3a3984b/ruff-0.15.12-py3-none-win_arm64.whl", hash = "sha256:a538f7a82d061cee7be55542aca1d86d1393d55d81d4fcc314370f4340930d4f", size = 11120821, upload-time = "2026-04-24T18:16:57.979Z" },
+]
+
+[[package]]
+name = "typing-extensions"
+version = "4.15.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/94/1a15dd82efb362ac84269196e94cf00f187f7ed21c242792a923cdb1c61f/typing_extensions-4.15.0.tar.gz", hash = "sha256:0cea48d173cc12fa28ecabc3b837ea3cf6f38c6d1136f85cbaaf598984861466", size = 109391, upload-time = "2025-08-25T13:49:26.313Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/18/67/36e9267722cc04a6b9f15c7f3441c2363321a3ea07da7ae0c0707beb2a9c/typing_extensions-4.15.0-py3-none-any.whl", hash = "sha256:f0fa19c6845758ab08074a0cfa8b7aecb71c999ca73d62883bc25cc018c4e548", size = 44614, upload-time = "2025-08-25T13:49:24.86Z" },
+]

--- a/tools/privacy-llm/models.md
+++ b/tools/privacy-llm/models.md
@@ -43,11 +43,13 @@ default-approved Claude Code instance and passes).
 | **Local-only inference** | The data never leaves the user's machine. No external party (cloud LLM operator, network operator, log aggregator) can observe it. | Ollama serving a local model, vLLM on the user's workstation, llama.cpp embedded in a CLI helper |
 | **Air-gapped on-prem** | Same rationale as local inference, scaled to a contributor's organisation. The model server runs on infra the adopter operationally controls and which has no path to a third-party LLM operator. | A PMC-hosted inference appliance on a private VLAN |
 
-Detection lives in the helper's `redactor/src/redactor/registry.py`
-(once PR-3 lands the gate-call wiring); for PR-1 the registry is
-the markdown contract here and the
+Detection lives in
+[`checker/src/checker/check.py`](checker/src/checker/check.py)
+(the `_approve_by_default_rules` function); the markdown contract
+here is the source-of-truth for what those rules implement, and
+the
 [`<project-config>/privacy-llm.md`](#adopter-config--project-configprivacy-llmmd)
-declaration shape.
+declaration shape is what the checker parses.
 
 ## The opt-in entries — adopter declares explicitly
 
@@ -148,22 +150,35 @@ re-uses the same source-of-truth so the two stay in sync.
 
 ## How skills call the gate
 
-Skills call the gate via a small Python helper that ships with
-the redactor sub-tool (in PR-3 — the gate-call wiring is
-deferred from PR-1 to keep the foundation diff focused). The
-contract for that helper, defined here for forward-compatibility:
+Skills call the gate via the `privacy-llm-check` console script
+in [`checker/`](checker/). Run it at Step 0 (pre-flight); a
+non-zero exit is a hard stop.
 
 ```bash
 # Returns exit code 0 if the active stack is fully approved,
-# non-zero with a stderr explanation if not. Skills run this at
-# Step 0 and bail on non-zero.
-uv run --project <framework>/tools/privacy-llm/redactor privacy-llm-check \
+# non-zero with a stderr explanation if not.
+uv run --project <framework>/tools/privacy-llm/checker privacy-llm-check \
   --reads-private-list                 # set when the skill may read <private-list>
 ```
 
-For `<security-list>`-only skills the gate-call is not required
-(the body classification permits Claude-Code-default LLMs by
-construction); the redactor (`pii-redact`) is required regardless.
+The checker auto-locates `<project-config>/privacy-llm.md`:
+explicit `--config` → `$PRIVACY_LLM_CONFIG` env var → standard
+adopter paths (`<cwd>/.apache-steward/privacy-llm.md`,
+`<cwd>/.apache-steward-overrides/privacy-llm.md`). On approval
+it prints a one-line banner per stack entry; on rejection it
+prints the failing entries to stderr and exits 1. Exit 2 means
+the config file could not be located or parsed.
+
+For `<security-list>`-only skills the gate-call is **also
+required** as a defence-in-depth measure: even though the body
+classification permits Claude-Code-default LLMs, running the
+check ensures the adopter's config is in a valid state (no
+unconfigured opt-in entries lurking in the active stack) before
+any private content flows. The redactor (`pii-redact`) is
+required for every `<security-list>` body read regardless; see
+[`pii.md`](pii.md) for the redaction contract and
+[`wiring.md`](wiring.md) for how the two mechanisms compose at
+the skill level.
 
 ## Why this list is provisional
 

--- a/tools/privacy-llm/tool.md
+++ b/tools/privacy-llm/tool.md
@@ -52,7 +52,8 @@ agent's context, and `privacy-llm` is what stops it from leaking.
 | Skill-wiring pattern | [`wiring.md`](wiring.md) | The canonical step-by-step pattern every `<security-list>`- or `<private-list>`-touching skill follows when applying the contract — Step 0 pre-flight, redact-after-fetch, reveal-before-send, plus edge cases. Skill `SKILL.md` files link here from their pre-flight section rather than copying the protocol. |
 | Per-project configuration | [`projects/_template/privacy-llm.md`](../../projects/_template/privacy-llm.md) | Template the adopter copies into `<project-config>/privacy-llm.md` to declare their LLM stack, private mailing-list set, collaborator source, and redaction-tuning knobs (collaborator exemption, enabled field types). Defaults are documented inline. |
 | Setup recipes | [`../../docs/setup/privacy-llm.md`](../../docs/setup/privacy-llm.md) | Copy-pasteable configurations for the supported variants — local inference, Apache-hosted endpoint, AWS Bedrock, opt-in third-party. Marked **provisional pending ASF Legal Affairs ratification** of an authoritative approved-model list. |
-| Reference Python helper | [`redactor/`](redactor/) | A small `uv` project exposing three console scripts — `pii-redact`, `pii-reveal`, `pii-list` — that skills shell out to so the redaction lifecycle is consistent across every consumer. |
+| Reference Python helper — redactor | [`redactor/`](redactor/) | A small `uv` project exposing three console scripts — `pii-redact`, `pii-reveal`, `pii-list` — that skills shell out to so the redaction lifecycle is consistent across every consumer. |
+| Reference Python helper — gate-check | [`checker/`](checker/) | A small `uv` project exposing one console script — `privacy-llm-check` — that parses `<project-config>/privacy-llm.md` and verifies every active-stack entry is approved per [`models.md`](models.md). Skills shell out to it at Step 0 (pre-flight). |
 
 ## Why this is its own tool
 

--- a/tools/privacy-llm/wiring.md
+++ b/tools/privacy-llm/wiring.md
@@ -79,18 +79,21 @@ Three rules govern the whole protocol:
 Add to the skill's existing Step 0 (pre-flight check) section:
 
 ```markdown
-- **Privacy-LLM contract.** Read
-  `<project-config>/privacy-llm.md` (or the framework's
-  template at
-  [`projects/_template/privacy-llm.md`](../../projects/_template/privacy-llm.md)
-  if the adopter has not yet customised it). Confirm:
+- **Privacy-LLM contract.** Run the gate-check via the
+  `privacy-llm-check` console script — it parses
+  `<project-config>/privacy-llm.md`, verifies every entry in the
+  *Currently configured LLM stack* is approved per
+  [`tools/privacy-llm/models.md`](../../tools/privacy-llm/models.md#the-pre-flight-check),
+  and exits non-zero on any unapproved entry.
 
-  - The configured LLM stack matches what is currently
-    active. If the skill may read `<private-list>` content
-    and the active LLM stack contains an entry not in the
-    approved-model registry per
-    [`tools/privacy-llm/models.md`](../../tools/privacy-llm/models.md#the-pre-flight-check),
-    stop and ask the user to wire an approved model first.
+      uv run --project <framework>/tools/privacy-llm/checker \
+        privacy-llm-check --reads-private-list
+
+  Pass `--reads-private-list` when the skill may read
+  `<private-list>` content; omit it for `<security-list>`-only
+  flows (the check itself is the same — the flag only controls
+  the printed banner). The skill also confirms:
+
   - `~/.config/apache-steward/` is writable (the redactor's
     mapping file lives there). If not, prompt the user to
     create it.
@@ -102,8 +105,9 @@ Add to the skill's existing Step 0 (pre-flight check) section:
 ```
 
 The pre-flight is read-only — no PII has been fetched yet. A
-failed pre-flight does not write to the mapping file or the
-tracker.
+failed pre-flight (gate-check exit non-zero, or any of the other
+checks above) does not write to the mapping file or the
+tracker; the skill stops and surfaces the failure to the user.
 
 ## Redact-after-fetch protocol
 


### PR DESCRIPTION
## Summary

PR-3 of the privacy-llm series. Lands the second mechanism from the original design (PR-1 foundation: #48; PR-2 skill-side redaction wiring: #50; this PR is the approved-LLM gate-check). The contracts in `models.md` and `wiring.md` were already shipped pointing at this command — now the command exists.

### What lands

- **`tools/privacy-llm/checker/`** (new) — stdlib-only Python sub-tool with one console script: `privacy-llm-check`. Parses `<project-config>/privacy-llm.md`, applies the approval rules from `tools/privacy-llm/models.md`:
  - **Default-approved**: Claude Code itself, `*.apache.org` endpoints, local-only inference (`localhost` / `127.0.0.1` / `::1`).
  - **Opt-in**: every other endpoint requires an entry under *Approved third-party endpoints (opt-in)* with non-empty `Data-residency contract` AND `Approved-by` lines (placeholder text like `<PMC-member-initials>` is rejected).
  - **Exit codes**: `0` all approved, `1` at least one unapproved, `2` config not locatable / parseable.

- **Pre-commit hooks** for the new sub-tool mirroring the redactor pattern.

- **Doc updates** — `models.md` / `wiring.md` / `tool.md` now reference the concrete `privacy-llm-check` invocation instead of the previous "PR-3 future" placeholders.

- **Skill wiring** — every Gmail-touching SKILL.md gets the explicit gate-check call in its Step 0 pre-flight: `security-issue-import`, `-sync`, `-invalidate`, `-cve-allocate`, `-import-from-md`. The `-sync` skill passes `--reads-private-list` because it may escalate to PMC-private foundation lists.

### Why the gate-call is required even for `<security-list>`-only skills

Defence-in-depth. Even though `<security-list>` content is permitted to flow through the Claude-Code-default LLM, running the check at Step 0 ensures the adopter's config is in a sane state — no half-configured opt-in entries, no LLMs in the active stack that the adopter forgot to approve. This mirrors the framework's posture elsewhere (`prek install` is mandatory before every commit even when most commits don't need most hooks).

## Test plan

- [x] `pytest` (checker) — 33/33 pass, including a fixture test that the shipped `projects/_template/privacy-llm.md` parses + approves out of the box.
- [x] `prek run --all-files` — clean (every existing hook + the four new checker hooks).
- [x] `ruff check / format / mypy` — all clean.
- [ ] Walk through the `privacy-llm-check` invocation in one of the wired skills (e.g. `security-issue-import` Step 0) end-to-end against a real adopter config, confirm the failure path produces a useful stderr message.
- [ ] `gh pr` against this PR's CI to confirm the new pre-commit hooks fire correctly in the prek workflow.