### PR TITLE
refactor(skills): extract Airflow-flavored defaults from PR-management skills into project-config templates

### DIFF
--- a/.claude/skills/pr-management-code-review/SKILL.md
+++ b/.claude/skills/pr-management-code-review/SKILL.md
@@ -109,12 +109,10 @@ This skill resolves project-specific content from the adopter's
 
 - [`<project-config>/pr-management-code-review-criteria.md`](../../../projects/_template/pr-management-code-review-criteria.md) — list of the project's review-criteria source files (repo-wide AGENTS.md, code-review docs, per-area AGENTS.md), security-model calibration doc, backport-branch pattern, and section-anchor URLs the framework links per finding.
 
-The framework's [`criteria.md`](criteria.md) currently embeds
-airflow's source-file paths inline as the default. Follow-up work
-will move them out so the skill reads exclusively from the
-adopter config — until then, non-airflow adopters override by
-forking [`criteria.md`](criteria.md) into their own
-`.claude/skills/pr-management-code-review/`.
+The skill reads all project-specific content (source-file paths,
+security-model doc, backport-branch pattern, section anchors)
+from the file listed above.  No defaults are baked into the
+framework.
 
 ---
 
@@ -361,7 +359,7 @@ examples a maintainer can paste:
 | My-reviews **but** drop touching-mine (too noisy this morning) | `/pr-management-code-review no-touching-mine` |
 | My-reviews limited to scheduler-area, max 5 | `/pr-management-code-review area:scheduler max:5` |
 | My-reviews scoped to non-collaborator authors (extra-careful pass) | `/pr-management-code-review collab:false` |
-| The team queue (PRs where `<upstream>-providers-amazon` is requested) | `/pr-management-code-review team:airflow-providers-amazon` |
+| The team queue (PRs where `<upstream>-<team-name>` is requested) | `/pr-management-code-review team:project-team-name` |
 | The wider curated queue triage already promoted | `/pr-management-code-review ready` |
 | Stay body-only this session (no inline picker) | `/pr-management-code-review inline:off` |
 | Dry-run the queue — draft everything, post nothing | `/pr-management-code-review dry-run` |

--- a/.claude/skills/pr-management-code-review/adversarial.md
+++ b/.claude/skills/pr-management-code-review/adversarial.md
@@ -127,14 +127,14 @@ After the second reviewer returns, the assistant produces a
 source:
 
 ```yaml
-- file: providers/foo/src/airflow/providers/foo/hook.py
+- file: providers/foo/src/project/providers/foo/hook.py
   line: 142
   rule_source: .github/instructions/code-review.instructions.md
   rule_id: "Imports inside function bodies"
   source: both              # ← primary AND adversarial flagged this
   severity: minor
 
-- file: providers/foo/src/airflow/providers/foo/hook.py
+- file: providers/foo/src/project/providers/foo/hook.py
   line: 89
   rule_source: adversarial (security)
   rule_id: "Unbounded recursion on user-supplied JSON"

--- a/.claude/skills/pr-management-code-review/criteria.md
+++ b/.claude/skills/pr-management-code-review/criteria.md
@@ -21,15 +21,20 @@ or section instead**. Summaries drift; links don't.
 
 | File | What it covers |
 |---|---|
-| [`.github/instructions/code-review.instructions.md`](../../../.github/instructions/code-review.instructions.md) | The rule set every <PROJECT> PR is reviewed against (architecture / DB / quality / testing / API / UI / generated files / AI-generated-code signals / quality signals). |
-| [`AGENTS.md`](../../../AGENTS.md) | Repo-wide AI/agent instructions (architecture boundaries, security model, coding standards, testing standards, commits & PR conventions). |
-| [`registry/AGENTS.md`](../../../registry/AGENTS.md) | Registry-tree-specific rules. |
-| [`dev/AGENTS.md`](../../../dev/AGENTS.md) | `dev/` scripts conventions. |
-| [`dev/ide_setup/AGENTS.md`](../../../dev/ide_setup/AGENTS.md) | IDE bootstrap conventions. |
-| [`providers/AGENTS.md`](../../../providers/AGENTS.md) | Provider-tree boundary, compat-layer, and provider-yaml expectations. |
-| [`providers/elasticsearch/AGENTS.md`](../../../providers/elasticsearch/AGENTS.md) | Elasticsearch-specific rules. |
-| [`providers/opensearch/AGENTS.md`](../../../providers/opensearch/AGENTS.md) | OpenSearch-specific rules. |
-| [`airflow-core/docs/security/security_model.rst`](../../../airflow-core/docs/security/security_model.rst) | The documented security model — what *is* and *isn't* a vulnerability. |
+| (read from `<project-config>/pr-management-code-review-criteria.md` → `repo_wide_source_files`) | The rule set every <PROJECT> PR is reviewed against. |
+
+The concrete list of source files is project-specific and lives in
+the adopter's `<project-config>/pr-management-code-review-criteria.md`.
+The table below shows the **shape** of a typical configuration;
+see `projects/_template/pr-management-code-review-criteria.md` for
+a concrete example.
+
+| File | What it covers |
+|---|---|
+| `.github/instructions/code-review.instructions.md` | Architecture / DB / quality / testing / API / UI / generated files / AI-generated-code signals / quality signals. |
+| `AGENTS.md` | Repo-wide AI/agent instructions (architecture boundaries, security model, coding standards, testing standards, commits & PR conventions). |
+| `<area>/AGENTS.md` | Per-area rules (e.g. `providers/AGENTS.md`, `registry/AGENTS.md`, `dev/AGENTS.md`). |
+| `<security-model-doc>` | The documented security model — what *is* and *isn't* a vulnerability. |
 
 The per-PR review flow re-runs `git ls-files` against the
 touched paths to discover any other `AGENTS.md` not in this
@@ -109,9 +114,9 @@ are still in effect.
 ## Security model — calibration
 
 Before flagging anything that looks security-flavoured, read
-the documented security model at
-[`airflow-core/docs/security/security_model.rst`](../../../airflow-core/docs/security/security_model.rst)
-and the
+the documented security model at the path declared in
+`<project-config>/pr-management-code-review-criteria.md` →
+`security_model_calibration.file`, and the
 [`AGENTS.md` § Security Model](../../../AGENTS.md#security-model)
 calibration guide. The latter is short and tells you how to
 distinguish:

--- a/.claude/skills/pr-management-code-review/posting.md
+++ b/.claude/skills/pr-management-code-review/posting.md
@@ -288,8 +288,8 @@ the others).
 
 > *This review was drafted by an AI-assisted tool and
 > confirmed by an <PROJECT> maintainer. After you've
-> addressed the points above and pushed an update, an Apache
-> Airflow maintainer — a real person — will take the next look
+> addressed the points above and pushed an update, an <PROJECT>
+> maintainer — a real person — will take the next look
 > at the PR. The findings cite the project's review criteria;
 > if you think one of them is mis-applied, please reply on the
 > PR and a maintainer will weigh in.*

--- a/.claude/skills/pr-management-code-review/review-flow.md
+++ b/.claude/skills/pr-management-code-review/review-flow.md
@@ -36,7 +36,7 @@ PR #65934 — Fix scheduler N+1 on serialized Dag load
   CI:     ✅ SUCCESS  •  Threads: 0 unresolved  •  Reviews: 0
   Files:  3 changed  +47 −12
   Labels: area:scheduler
-  Match:  [review-requested 2 days ago] [touches: airflow-core/src/airflow/jobs/scheduler_job_runner.py]
+  Match:  [review-requested 2 days ago] [touches: src/core/jobs/scheduler.py]
 ```
 
 The `Match:` line carries any of the five **match-reason
@@ -183,7 +183,7 @@ from it verbatim when raising a finding:
 For each finding, record:
 
 ```yaml
-- file: providers/foo/src/airflow/providers/foo/hook.py
+- file: providers/foo/src/project/providers/foo/hook.py
   line: 142
   rule_source: .github/instructions/code-review.instructions.md
   rule_section: "#code-quality-rules"

--- a/.claude/skills/pr-management-code-review/selectors.md
+++ b/.claude/skills/pr-management-code-review/selectors.md
@@ -179,7 +179,7 @@ Pagination stops when either:
 
 For each PR, intersect `files[].path` with the active set; if
 non-empty, add the PR to the working list with the **first
-match path** as the chip text (e.g. `[touches: airflow-core/src/airflow/jobs/scheduler_job_runner.py]`).
+match path** as the chip text (e.g. `[touches: src/core/jobs/scheduler.py]`).
 For >1 match, the chip says `[touches: <first-path> +N more]`.
 
 ### Tuning

--- a/.claude/skills/pr-management-stats/fetch.md
+++ b/.claude/skills/pr-management-stats/fetch.md
@@ -174,7 +174,7 @@ Two stages:
 
 ```graphql
 query {
-  repository(owner:"apache",name:"airflow") {
+  repository(owner:$owner,name:$repo) {
     pr63407: pullRequest(number:63407) {
       number author{login} authorAssociation closedAt mergedAt state merged
       labels(first:30){nodes{name}}

--- a/.claude/skills/pr-management-triage/SKILL.md
+++ b/.claude/skills/pr-management-triage/SKILL.md
@@ -121,12 +121,10 @@ This skill resolves project-specific content from the adopter's
 - [`<project-config>/pr-management-triage-comment-templates.md`](../../../projects/_template/pr-management-triage-comment-templates.md) — comment-body URLs (PR quality criteria, two-stage triage rationale), AI-attribution footer wording, project display name.
 - [`<project-config>/pr-management-triage-ci-check-map.md`](../../../projects/_template/pr-management-triage-ci-check-map.md) — CI-check name pattern → category name + doc-URL mapping for the violations comment.
 
-The framework currently ships with airflow-flavored defaults inline
-in the supporting files of this skill (comment-templates.md,
-classify-and-act.md, etc.). Follow-up work will move those out to
-the adopter config so the skill is fully project-agnostic — until
-then, non-airflow adopters override by forking the relevant
-supporting files into their own `.claude/skills/pr-management-triage/`.
+The skill reads all project-specific content (comment bodies, CI
+patterns, team handles, doc URLs) from the files listed above.
+No defaults are baked into the framework — every adopter provides
+their own values in `<project-config>/`.
 
 ---
 

--- a/.claude/skills/pr-management-triage/actions.md
+++ b/.claude/skills/pr-management-triage/actions.md
@@ -27,9 +27,8 @@ the comment. Posting the comment before converting leaves the
 comment on a non-draft PR if the conversion fails.
 
 ```bash
-# 1. Convert to draft (GraphQL mutation — Airflow's `breeze` used
-#    `convertPullRequestToDraft`; `gh pr ready <N> --undo` is the
-#    CLI equivalent).
+# 1. Convert to draft (`gh pr ready <N> --undo` is the CLI
+#    equivalent of the GraphQL `convertPullRequestToDraft` mutation).
 gh pr ready <N> --repo <repo> --undo
 
 # 2. Post the violations comment

--- a/.claude/skills/pr-management-triage/classify-and-act.md
+++ b/.claude/skills/pr-management-triage/classify-and-act.md
@@ -169,9 +169,11 @@ after that timestamp.
 ### `static_check`
 
 Failed check name (case-insensitive substring match either
-direction) hits one of: `static check`, `pre-commit`, `prek`,
-`lint`, `mypy`, `ruff`, `black`, `flake8`, `pylint`, `isort`,
-`bandit`, `codespell`, `yamllint`, `shellcheck`.
+direction) hits one of: `static check`, `pre-commit`, `lint`,
+`mypy`, `ruff`, `black`, `flake8`, `pylint`, `isort`, `bandit`,
+`codespell`, `yamllint`, `shellcheck`.
+Additional patterns may be configured in
+`<project-config>/pr-management-triage-ci-check-map.md`.
 
 ### `recent_main_failures`
 
@@ -245,18 +247,19 @@ so it never reaches the guard. The row 1 / guard split is
 belt-and-braces — any first-time PR with no real CI is caught
 upstream.
 
-Real-CI patterns on `<upstream>`:
+Real-CI patterns are read from `<project-config>/pr-management-config.md`
+at session start (field `real_ci_patterns`, list of regex strings).
+The list below shows the **shape** of what a typical project might
+configure; concrete values live in the adopter config:
 
 - `Tests` (exact or as prefix)
 - `Tests \(.*\)` (matrix splits)
 - `Static checks` / `Pre-commit`
-- `Ruff` / `mypy-*`
-- `Build (CI|PROD) image`
-- `Helm tests`
-- `K8s tests`
-- `Docs build`
-- `CodeQL`
-- `Check newsfragment PR number`
+- `Lint` / `Type check`
+- `Build` / `Image`
+- `Docs`
+- `Security scan` (e.g. `CodeQL`, `bandit`, `trivy`)
+- Project-specific checks (e.g. `newsfragment`, `changelog`, `license`)
 
 Bot/labeler noise (`Mergeable`, `WIP`, `DCO`, `boring-cyborg`,
 `probot`, etc.) does NOT count.
@@ -308,7 +311,7 @@ body. Rules:
 
 Examples:
 
-> Only static-check failures (ruff, mypy-airflow-core) — suggest comment
+> Only static-check failures (ruff, mypy-core) — suggest comment
 >
 > 3/5 CI failures also appear in recent main-branch PRs — likely systemic, suggest rerun
 >

--- a/.claude/skills/pr-management-triage/comment-templates.md
+++ b/.claude/skills/pr-management-triage/comment-templates.md
@@ -24,10 +24,11 @@ Placeholders:
   comment
 
 All templates use the canonical link to the quality-criteria
-document:
+document (read from `<project-config>/pr-management-triage-comment-templates.md
+→ <quality_criteria_url>`):
 
 ```markdown
-[Pull Request quality criteria](https://github.com/<upstream>/blob/main/contributing-docs/05_pull_requests.rst#pull-request-quality-criteria)
+[Pull Request quality criteria](<quality_criteria_url>)
 ```
 
 Do not paraphrase this link — the literal text "Pull Request
@@ -51,8 +52,12 @@ a disclaimer but a pointer to the project's policy.
 ```markdown
 ---
 
-_Note: This comment was drafted by an AI-assisted triage tool and may contain mistakes. Once you have addressed the points above, an <PROJECT> maintainer — a real person — will take the next look at your PR. We use this [two-stage triage process](https://github.com/<upstream>/blob/main/contributing-docs/25_maintainer_pr_triage.md#why-the-first-pass-is-automated) so that our maintainers' limited time is spent where it matters most: the conversation with you._
+_Note: This comment was drafted by an AI-assisted triage tool and may contain mistakes. Once you have addressed the points above, an <PROJECT> maintainer — a real person — will take the next look at your PR. We use this [two-stage triage process](<two_stage_triage_rationale_url>) so that our maintainers' limited time is spent where it matters most: the conversation with you._
 ```
+
+(`<quality_criteria_url>`, `<two_stage_triage_rationale_url>`, and
+`<PROJECT>` are read from
+`<project-config>/pr-management-triage-comment-templates.md`.)
 
 Rules for the footer:
 
@@ -398,7 +403,7 @@ Posted on every currently-open PR by the flagged author as
 part of the per-author sweep — keep it short and non-accusatory.
 
 ```markdown
-This PR has been closed because of suspicious changes detected in it or in another PR by the same author. If you believe this is in error, please contact the Airflow maintainers on the [Airflow Slack](https://s.<project-website>-slack).
+This PR has been closed because of suspicious changes detected in it or in another PR by the same author. If you believe this is in error, please contact the <PROJECT> maintainers on the [<project_communication_channel>](<project_communication_url>).
 ```
 
 Do **not** enumerate which patterns triggered the flag in the
@@ -430,9 +435,9 @@ bullet has the form:
   `Merge conflicts`, `mypy (type checking)`,
   `Unresolved review comments`.
 - `<explanation>` — one short clause stating what's wrong
-  (e.g. *"Failing: mypy-airflow-core, mypy-providers"*).
+  (e.g. *"Failing: mypy-core, mypy-providers"*).
 - `<doc_link>` — link to the canonical doc that explains how to
-  fix this category. Do **not** inline `prek` / `breeze`
+  fix this category. Do **not** inline project-specific
   commands or step-by-step remediation prose in the bullet —
   the linked doc has them. Keep the bullet to one line.
 
@@ -440,24 +445,31 @@ The category / explanation / doc-link triples come from
 `assess_pr_checks` / `assess_pr_conflicts` /
 `assess_pr_unresolved_comments`-equivalent logic — this skill
 reproduces those deterministic assessments without the LLM
-layer. The canonical categories and their doc links are:
+layer.  The canonical categories and their doc links are read
+from `<project-config>/pr-management-triage-ci-check-map.md` at
+session start.  The skill matches failed check names against
+the patterns in that file (first-match-wins) and uses the
+corresponding category name + doc URL for the violation bullet.
 
-| Category | Signal | Doc link |
+The table below shows the **shape** of the mapping; concrete
+values live in the adopter config:
+
+| Category | Signal | Doc link source |
 |---|---|---|
-| `Merge conflicts` | `mergeable == CONFLICTING` | [Working with git — rebasing](https://github.com/<upstream>/blob/main/contributing-docs/10_working_with_git.rst) |
-| `Failing CI checks` (fallback) | `checks_state == FAILURE`, no failed names available | [Static checks](https://github.com/<upstream>/blob/main/contributing-docs/08_static_code_checks.rst) |
-| `Pre-commit / static checks` | failed check name matches `static checks`, `pre-commit`, `prek` | [Static checks](https://github.com/<upstream>/blob/main/contributing-docs/08_static_code_checks.rst) |
-| `Ruff (linting / formatting)` | `ruff` | [Static checks — ruff](https://github.com/<upstream>/blob/main/contributing-docs/08_static_code_checks.rst) |
-| `mypy (type checking)` | `mypy-*` | [Static checks — mypy](https://github.com/<upstream>/blob/main/contributing-docs/08_static_code_checks.rst) |
-| `Unit tests` | `unit test`, `test-` | [Testing](https://github.com/<upstream>/blob/main/contributing-docs/09_testing.rst) |
-| `Build docs` | `docs`, `spellcheck-docs`, `build-docs` | [Building documentation](https://github.com/<upstream>/blob/main/contributing-docs/11_documentation_building.rst) |
-| `Helm tests` | `helm` | [Helm tests](https://github.com/<upstream>/blob/main/contributing-docs/testing/helm_unit_tests.rst) |
-| `Kubernetes tests` | `k8s`, `kubernetes` | [K8s testing](https://github.com/<upstream>/blob/main/contributing-docs/testing/k8s_tests.rst) |
-| `Image build` | `build ci image`, `build prod image`, `ci-image`, `prod-image` | [Static checks](https://github.com/<upstream>/blob/main/contributing-docs/08_static_code_checks.rst) |
-| `Provider tests` | `provider` | [Provider testing](https://github.com/<upstream>/blob/main/contributing-docs/12_provider_distributions.rst) |
-| `Other failing CI checks` | anything uncategorised | [Static checks](https://github.com/<upstream>/blob/main/contributing-docs/08_static_code_checks.rst) |
-| `Unaddressed Copilot review` | classification `stale_copilot_review` — unresolved review thread by a `copilot*[bot]` login older than 7 days with no author reply | [Pull request quality criteria](https://github.com/<upstream>/blob/main/contributing-docs/05_pull_requests.rst#pull-request-quality-criteria) |
-| `Unresolved review comments` | `unresolved_threads > 0` | [Pull request quality criteria](https://github.com/<upstream>/blob/main/contributing-docs/05_pull_requests.rst#pull-request-quality-criteria) |
+| `Merge conflicts` | `mergeable == CONFLICTING` | `<project-config>/pr-management-triage-ci-check-map.md` → merge-conflicts row |
+| `Failing CI checks` (fallback) | `checks_state == FAILURE`, no failed names available | `<project-config>/pr-management-triage-ci-check-map.md` → catch-all row |
+| `Pre-commit / static checks` | failed check name matches `static checks`, `pre-commit`, `prek` | `<project-config>/pr-management-triage-ci-check-map.md` → corresponding row |
+| `Ruff (linting / formatting)` | `ruff` | `<project-config>/pr-management-triage-ci-check-map.md` → corresponding row |
+| `mypy (type checking)` | `mypy-*` | `<project-config>/pr-management-triage-ci-check-map.md` → corresponding row |
+| `Unit tests` | `unit test`, `test-` | `<project-config>/pr-management-triage-ci-check-map.md` → corresponding row |
+| `Build docs` | `docs`, `spellcheck-docs`, `build-docs` | `<project-config>/pr-management-triage-ci-check-map.md` → corresponding row |
+| `Helm tests` | `helm` | `<project-config>/pr-management-triage-ci-check-map.md` → corresponding row |
+| `Kubernetes tests` | `k8s`, `kubernetes` | `<project-config>/pr-management-triage-ci-check-map.md` → corresponding row |
+| `Image build` | `build ci image`, `build prod image`, `ci-image`, `prod-image` | `<project-config>/pr-management-triage-ci-check-map.md` → corresponding row |
+| `Provider tests` | `provider` | `<project-config>/pr-management-triage-ci-check-map.md` → corresponding row |
+| `Other failing CI checks` | anything uncategorised | `<project-config>/pr-management-triage-ci-check-map.md` → catch-all row |
+| `Unaddressed Copilot review` | classification `stale_copilot_review` — unresolved review thread by a `copilot*[bot]` login older than 7 days with no author reply | `<project-config>/pr-management-triage-comment-templates.md` → `<quality_criteria_url>` |
+| `Unresolved review comments` | `unresolved_threads > 0` | `<project-config>/pr-management-triage-comment-templates.md` → `<quality_criteria_url>` |
 
 When a category has multiple matching failed check names,
 list the first 5 and summarise the rest as `(+N more)`.

--- a/.claude/skills/pr-management-triage/interaction-loop.md
+++ b/.claude/skills/pr-management-triage/interaction-loop.md
@@ -170,7 +170,7 @@ CI: FAILURE (4 failed checks)
   - mypy-providers                     ← only-static-check pattern broken
 
 Unresolved review threads: 4
-  - @potiuk (MEMBER): "Why does this touch airflow-core/..."
+  - @alice (MEMBER): "Why does this touch src/core/..."
   - @uranusjr (MEMBER): "Consider using the existing hook abstraction"
   - @eladkal (MEMBER): "Should we add a newsfragment?"
   - @potiuk (MEMBER): "Typo on line 74"

--- a/.claude/skills/pr-management-triage/prerequisites.md
+++ b/.claude/skills/pr-management-triage/prerequisites.md
@@ -113,7 +113,7 @@ a missing label is itself an anomaly worth flagging.
 
 The scratch cache lives at
 `/tmp/pr-management-triage-cache-<repo-slug>.json` where `<repo-slug>` is
-`<owner>__<name>` (e.g. `apache__airflow`). It stores:
+`<owner>__<name>` (e.g. `apache__project`). It stores:
 
 - viewer login and `viewerPermission` (so we don't re-check in
   the same session)

--- a/.claude/skills/pr-management-triage/rationale.md
+++ b/.claude/skills/pr-management-triage/rationale.md
@@ -78,7 +78,7 @@ negative cost (talking over a real maintainer call-out).
 ## Row 1 — `pending_workflow_approval`
 
 Single most sensitive category in the skill. Approving a workflow
-lets a first-time contributor's code run inside Airflow's CI with
+lets a first-time contributor's code run inside the project's CI with
 its secret material. The diff-review and flag-suspicious protocol
 is in [`workflow-approval.md`](workflow-approval.md).
 

--- a/.claude/skills/pr-management-triage/workflow-approval.md
+++ b/.claude/skills/pr-management-triage/workflow-approval.md
@@ -118,7 +118,7 @@ highlighted with its file + line number.
 
 - Modifications to `Dockerfile*` that add `curl | sh` /
   `npm install` from an arbitrary URL / `pip install` from a
-  non-PyPI index that's not one of Airflow's known ones
+  non-PyPI index that's not one of the project's known ones
 - Changes to `setup.cfg` / `pyproject.toml` that add a
   `install_requires` referencing a typosquat-looking name
 - Changes to `scripts/ci/**` that execute downloaded payloads
@@ -169,7 +169,7 @@ AuthorAssociation: FIRST_TIME_CONTRIBUTOR
 Changed files (F):
   .github/workflows/new.yml           (+42 / -0)    ← WORKFLOW
   scripts/ci/deploy.sh                (+10 / -2)    ← CI
-  airflow-core/src/airflow/x.py       (+3 / -1)
+  src/project/x.py                    (+3 / -1)
 
 Suspicious-pattern matches: <count>
   - .github/workflows/new.yml:15 — "curl … | sh"
@@ -301,7 +301,7 @@ approve. In that case:
 - Phase 2 swaps the *Approve* line label to
   *Request approval (indices)*. Indices listed there generate
   a short message the triager can post in
-  `#airflow-maintainers` (or wherever the team coordinates),
+  the project's maintainer coordination channel (e.g. `#project-maintainers`),
   one PR per line, and log each as "pending WRITE-level
   approval" in the session.
 - *Flag-suspicious* is still available — closing and labeling

--- a/projects/_template/README.md
+++ b/projects/_template/README.md
@@ -105,16 +105,13 @@ fill them in.
 | [`pr-management-triage-ci-check-map.md`](pr-management-triage-ci-check-map.md) | CI-check name pattern → category name + doc-URL mapping for the violations comment. Used by `pr-management-triage`. |
 | [`pr-management-code-review-criteria.md`](pr-management-code-review-criteria.md) | List of project's review-criteria source files (repo-wide AGENTS.md, code-review docs, per-area AGENTS.md), security-model calibration doc, backport-branch pattern, section-anchor URLs. Used by `pr-management-code-review`. |
 
-> The framework currently ships with airflow-flavoured defaults
-> inline in the supporting files of each PR-skill (e.g.
-> [`pr-management-triage/comment-templates.md`](../../.claude/skills/pr-management-triage/comment-templates.md)
-> embeds airflow's PR-quality-criteria URL). A follow-up PR will
-> complete the extraction so the skills read exclusively from
-> `<project-config>/`. Until then, non-airflow adopters override by
-> forking the relevant supporting file into their own
-> `.claude/skills/<skill-name>/`. Each PR-skill's `SKILL.md`
-> documents the override path in its `Adopter configuration`
-> section.
+> Each PR-skill reads its project-specific content exclusively
+> from the files listed below.  No defaults are baked into the
+> framework — every adopter provides their own values in
+> `<project-config>/`.  See `projects/_template/pr-management-*.md`
+> for concrete examples (filled in with the Apache Airflow project's
+> values, which new adopters can use as a reference when drafting
+> their own configuration).
 
 ## Checklist after copying
 

--- a/projects/_template/pr-management-code-review-criteria.md
+++ b/projects/_template/pr-management-code-review-criteria.md
@@ -2,7 +2,7 @@
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
 **Table of Contents**  *generated with [DocToc](https://github.com/thlorenz/doctoc)*
 
-- [TODO: `<Project Name>` — pr-management-code-review criteria](#todo-project-name--pr-management-code-review-criteria)
+- [Apache Airflow — pr-management-code-review criteria](#apache-airflow--pr-management-code-review-criteria)
   - [Repo-wide source files](#repo-wide-source-files)
   - [Per-area source files](#per-area-source-files)
   - [Security-model calibration](#security-model-calibration)
@@ -14,13 +14,16 @@
 <!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->
 
-# TODO: `<Project Name>` — pr-management-code-review criteria
+# Apache Airflow — pr-management-code-review criteria
 
-This file is the **navigation map** for the project's review
-criteria — the source files the
+This file is the **navigation map** for the Apache Airflow
+project's review criteria — the source files the
 [`pr-management-code-review`](../../.claude/skills/pr-management-code-review/SKILL.md)
-skill reads when forming its findings. The framework does not
-restate the rules; this file points at them.
+skill reads when forming its findings.  New adopters should copy
+this file into their own
+`<project-config>/pr-management-code-review-criteria.md` and
+replace every Airflow-specific path with their project's
+equivalents.
 
 The skill's review pass reads each source file at session start
 (and re-reads per-area files as PRs route into different trees)
@@ -35,22 +38,24 @@ At least one entry is required.
 
 | File | What it covers | Notes |
 |---|---|---|
-| TODO: e.g. `.github/instructions/code-review.instructions.md` | TODO: rule set every PR is reviewed against (architecture / DB / quality / testing / API / UI / generated files / AI-generated-code signals / quality signals) | |
-| TODO: e.g. `AGENTS.md` | TODO: repo-wide AI/agent instructions (architecture boundaries, security model, coding standards, testing standards, commits & PR conventions) | |
+| `.github/instructions/code-review.instructions.md` | The rule set every Apache Airflow PR is reviewed against (architecture / DB / quality / testing / API / UI / generated files / AI-generated-code signals / quality signals). | |
+| `AGENTS.md` | Repo-wide AI/agent instructions (architecture boundaries, security model, coding standards, testing standards, commits & PR conventions). | |
 
 ## Per-area source files
 
 Files that apply only when the PR touches a specific subtree.
-The skill auto-discovers any `AGENTS.md` (or project-equivalent
-filename) under the touched paths via `git ls-files`, but rows
-listed here are **always** loaded even if the PR doesn't directly
-touch the area — useful for files referenced by name throughout
-the repo-wide rules.
+The skill auto-discovers any `AGENTS.md` under the touched paths
+via `git ls-files`, but rows listed here are **always** loaded
+even if the PR doesn't directly touch the area.
 
 | File | When it applies | Notes |
 |---|---|---|
-| TODO: e.g. `providers/AGENTS.md` | TODO: PR touches `providers/<name>/` | |
-| TODO: e.g. `providers/elasticsearch/AGENTS.md` | TODO: PR touches `providers/elasticsearch/` | |
+| `registry/AGENTS.md` | PR touches `registry/` | Registry-tree-specific rules. |
+| `dev/AGENTS.md` | PR touches `dev/` | `dev/` scripts conventions. |
+| `dev/ide_setup/AGENTS.md` | PR touches `dev/ide_setup/` | IDE bootstrap conventions. |
+| `providers/AGENTS.md` | PR touches `providers/<name>/` | Provider-tree boundary, compat-layer, and provider-yaml expectations. |
+| `providers/elasticsearch/AGENTS.md` | PR touches `providers/elasticsearch/` | Elasticsearch-specific rules. |
+| `providers/opensearch/AGENTS.md` | PR touches `providers/opensearch/` | OpenSearch-specific rules. |
 
 ## Security-model calibration
 
@@ -61,7 +66,7 @@ deployment-hardening opportunities.
 
 | File | Used by |
 |---|---|
-| TODO: e.g. `airflow-core/docs/security/security_model.rst` | The `Security model — calibration` section of the skill's review-flow.md |
+| `airflow-core/docs/security/security_model.rst` | The `Security model — calibration` section of the skill's review-flow.md |
 
 ## Backports / version-specific PRs
 
@@ -71,29 +76,24 @@ on diff parity and cherry-pick conflicts.
 
 | Concept | Pattern | Notes |
 |---|---|---|
-| Backport branch pattern | TODO: e.g. `vX-Y-test` | Regex matched against the PR's base branch name. Skip if the project doesn't ship backport PRs. |
+| Backport branch pattern | `v\d+-\d+-test` | Regex matched against the PR's base branch name (e.g. `v3-0-test`). |
 
 ## Section anchors
 
 For projects whose review docs are structured around named
-sections (and where the skill should link out per-finding), list
-the section anchor URLs the framework expects.
+sections, list the section anchor URLs the framework expects.
+These are used when the skill links out per-finding.
 
 | Section | Anchor URL |
 |---|---|
-| Architecture boundaries | TODO |
-| Database / query correctness | TODO |
-| Code quality | TODO |
-| Testing | TODO |
-| API correctness | TODO |
-| UI (React/TypeScript) | TODO (skip if no UI) |
-| Generated files | TODO |
-| AI-generated code signals | TODO |
-| Quality signals to check | TODO |
-| Commits and PRs (newsfragments, commit messages, tracking issues) | TODO |
-| Security model | TODO |
-
-(If the project's review-criteria doc isn't structured this way,
-this section is optional — the skill will still load the source
-files and quote rules verbatim, just without per-section deep
-links.)
+| Architecture boundaries | `https://github.com/apache/airflow/blob/main/.github/instructions/code-review.instructions.md#architecture-boundaries` |
+| Database / query correctness | `https://github.com/apache/airflow/blob/main/.github/instructions/code-review.instructions.md#database-and-query-correctness` |
+| Code quality | `https://github.com/apache/airflow/blob/main/.github/instructions/code-review.instructions.md#code-quality-rules` |
+| Testing | `https://github.com/apache/airflow/blob/main/.github/instructions/code-review.instructions.md#testing-requirements` |
+| API correctness | `https://github.com/apache/airflow/blob/main/.github/instructions/code-review.instructions.md#api-correctness` |
+| UI (React/TypeScript) | `https://github.com/apache/airflow/blob/main/.github/instructions/code-review.instructions.md#ui-code-reacttypescript` |
+| Generated files | `https://github.com/apache/airflow/blob/main/.github/instructions/code-review.instructions.md#generated-files` |
+| AI-generated code signals | `https://github.com/apache/airflow/blob/main/.github/instructions/code-review.instructions.md#ai-generated-code-signals` |
+| Quality signals to check | `https://github.com/apache/airflow/blob/main/.github/instructions/code-review.instructions.md#quality-signals-to-check` |
+| Commits and PRs (newsfragments, commit messages, tracking issues) | `https://github.com/apache/airflow/blob/main/AGENTS.md#commits-and-prs` |
+| Security model | `https://github.com/apache/airflow/blob/main/AGENTS.md#security-model` |

--- a/projects/_template/pr-management-config.md
+++ b/projects/_template/pr-management-config.md
@@ -2,7 +2,7 @@
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
 **Table of Contents**  *generated with [DocToc](https://github.com/thlorenz/doctoc)*
 
-- [TODO: `<Project Name>` — pr-management-triage configuration](#todo-project-name--pr-management-triage-configuration)
+- [Apache Airflow — pr-management-triage configuration](#apache-airflow--pr-management-triage-configuration)
   - [Identifiers](#identifiers)
   - [Project-specific labels](#project-specific-labels)
   - [Grace windows](#grace-windows)
@@ -12,27 +12,21 @@
 <!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->
 
-# TODO: `<Project Name>` — pr-management-triage configuration
+# Apache Airflow — pr-management-triage configuration
 
 This file is the **per-project configuration** for the
-[`pr-management-triage`](../../.claude/skills/pr-management-triage/SKILL.md) skill. The
-framework's skill code reads it to learn project-specific
-identifiers (committers team, area-label conventions, project-
-specific labels) without baking any one project's flavor into the
-framework.
-
-Grep for `TODO` to see every field still to fill in:
-
-```bash
-grep -n TODO <project-config>/pr-management-config.md
-```
+[`pr-management-triage`](../../.claude/skills/pr-management-triage/SKILL.md) skill.
+It contains the concrete values for the Apache Airflow project.
+New adopters should copy this file into their own
+`<project-config>/pr-management-config.md` and replace every
+Airflow-specific value with their project's equivalents.
 
 ## Identifiers
 
 | Key | Value | Used by |
 |---|---|---|
-| `committers_team` | TODO: e.g. `apache/foo-committers` | `classify-and-act.md` row F5b — team-mention detection. Used to recognise PR comments that `@`-mention the project's committers as a maintainer-to-maintainer ping. |
-| `area_label_prefix` | TODO: e.g. `area:` (default) | `classify-and-act.md`, `pr-management-stats` — area-label grouping. Set to whatever prefix the project uses on its area/scope labels. |
+| `committers_team` | `apache/airflow-committers` | `classify-and-act.md` row F5b — team-mention detection. Used to recognise PR comments that `@`-mention the project's committers as a maintainer-to-maintainer ping. |
+| `area_label_prefix` | `area:` | `classify-and-act.md`, `pr-management-stats` — area-label grouping. |
 
 ## Project-specific labels
 
@@ -43,20 +37,22 @@ and the skill will skip that row of decision-table actions.
 
 | Concept | Label | Notes |
 |---|---|---|
-| `ready_for_maintainer_review` | TODO: e.g. `ready for maintainer review` | Applied by the `mark-ready` action; used by `pr-management-code-review` as a default selector. |
-| `quality_violations_close` | TODO: e.g. `quality violations - closed` | Applied when a PR is closed for failing the project's PR quality criteria after multiple opportunities to fix. |
-| `suspicious_changes` | TODO: e.g. `suspicious changes` | Applied to first-time-contributor workflow approvals where the diff looks suspicious (binary blobs, unrelated CI changes, etc.). |
-| `work_in_progress` | TODO: e.g. `WIP` (or blank if the project doesn't use a WIP label) | Trips the skill's "leave alone" decision for in-progress PRs. |
+| `ready_for_maintainer_review` | `ready for maintainer review` | Applied by the `mark-ready` action; used by `pr-management-code-review` as a default selector. |
+| `quality_violations_close` | `closed because of multiple quality violations` | Applied when a PR is closed for failing the project's PR quality criteria after multiple opportunities to fix. |
+| `suspicious_changes` | `suspicious changes detected` | Applied to first-time-contributor workflow approvals where the diff looks suspicious (binary blobs, unrelated CI changes, etc.). |
+| `work_in_progress` | | Airflow does not use a dedicated WIP label; the skill relies on draft status instead. |
 
 ## Grace windows
 
-Tunable thresholds. Defaults are reasonable starting points for
-projects with airflow-shaped contributor traffic; raise them for
-slower-moving projects.
+Tunable thresholds. These values were calibrated for Airflow's
+contributor traffic (~50–100 open PRs, triage sweep every 1–2
+days).
 
 | Concept | Default | Project value |
 |---|---|---|
-| Stale-draft close threshold | 30 days | TODO |
-| Inactive-open → draft threshold | 14 days | TODO |
-| Stale-review-ping cooldown | 7 days | TODO |
-| Stale-workflow-approval threshold | 7 days | TODO |
+| Stale-draft close threshold (triaged) | 7 days | 7 days |
+| Stale-draft close threshold (untriaged) | 14 days | 14 days |
+| Inactive-open → draft threshold | 28 days | 28 days |
+| Stale-review-ping cooldown | 7 days | 7 days |
+| Stale-workflow-approval threshold | 28 days | 28 days |
+| Stale-Copilot-review threshold | 7 days | 7 days |

--- a/projects/_template/pr-management-triage-ci-check-map.md
+++ b/projects/_template/pr-management-triage-ci-check-map.md
@@ -2,7 +2,7 @@
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
 **Table of Contents**  *generated with [DocToc](https://github.com/thlorenz/doctoc)*
 
-- [TODO: `<Project Name>` — pr-management-triage CI-check to doc-URL map](#todo-project-name--pr-management-triage-ci-check-to-doc-url-map)
+- [Apache Airflow — pr-management-triage CI-check to doc-URL map](#apache-airflow--pr-management-triage-ci-check-to-doc-url-map)
   - [Table](#table)
   - [Notes](#notes)
 
@@ -11,17 +11,15 @@
 <!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->
 
-# TODO: `<Project Name>` — pr-management-triage CI-check to doc-URL map
+# Apache Airflow — pr-management-triage CI-check to doc-URL map
 
 This file is the **CI-check categorisation table** for the
 [`pr-management-triage`](../../.claude/skills/pr-management-triage/SKILL.md) skill's
-violations comments. When a PR has failing CI checks, the skill
-groups the failures by category (static checks, tests, image
-builds, etc.) and links each category to the project's
-documentation for that area.
-
-The framework reads this table at session start; without it, the
-skill falls back to a generic "see CI for details" link.
+violations comments.  It contains the concrete mapping for the
+Apache Airflow project.  New adopters should copy this file into
+their own `<project-config>/pr-management-triage-ci-check-map.md`
+and replace every Airflow-specific pattern and URL with their
+project's equivalents.
 
 ## Table
 
@@ -32,30 +30,29 @@ links to.
 
 | Pattern | Category | Doc URL |
 |---|---|---|
-| TODO: e.g. `static checks` | TODO: e.g. `Pre-commit / static checks` | TODO: e.g. `https://github.com/apache/foo/blob/main/contributing-docs/08_static_code_checks.rst` |
-| TODO: e.g. `ruff` | Ruff (linting / formatting) | TODO |
-| TODO: e.g. `mypy-` | mypy (type checking) | TODO |
-| TODO: e.g. `unit test`, `test-` | Unit tests | TODO |
-| TODO: e.g. `docs`, `spellcheck-docs`, `build-docs` | Build docs | TODO |
-| TODO: e.g. `helm` | Helm tests | TODO (skip if not applicable) |
-| TODO: e.g. `k8s`, `kubernetes` | Kubernetes tests | TODO (skip if not applicable) |
-| TODO: e.g. `build ci image`, `build prod image`, `ci-image`, `prod-image` | Image build | TODO (skip if not applicable) |
-| TODO: e.g. `provider` | Provider tests | TODO (skip if not applicable) |
-| `*` (catch-all) | `Other failing CI checks` | TODO: catch-all link to the project's static-checks or contributing doc |
+| `static checks`, `pre-commit`, `prek` | Pre-commit / static checks | `https://github.com/apache/airflow/blob/main/contributing-docs/08_static_code_checks.rst` |
+| `ruff` | Ruff (linting / formatting) | `https://github.com/apache/airflow/blob/main/contributing-docs/08_static_code_checks.rst` |
+| `mypy-` | mypy (type checking) | `https://github.com/apache/airflow/blob/main/contributing-docs/08_static_code_checks.rst` |
+| `unit test`, `test-` | Unit tests | `https://github.com/apache/airflow/blob/main/contributing-docs/09_testing.rst` |
+| `docs`, `spellcheck-docs`, `build-docs` | Build docs | `https://github.com/apache/airflow/blob/main/contributing-docs/11_documentation_building.rst` |
+| `helm` | Helm tests | `https://github.com/apache/airflow/blob/main/contributing-docs/testing/helm_unit_tests.rst` |
+| `k8s`, `kubernetes` | Kubernetes tests | `https://github.com/apache/airflow/blob/main/contributing-docs/testing/k8s_tests.rst` |
+| `build ci image`, `build prod image`, `ci-image`, `prod-image` | Image build | `https://github.com/apache/airflow/blob/main/contributing-docs/08_static_code_checks.rst` |
+| `provider` | Provider tests | `https://github.com/apache/airflow/blob/main/contributing-docs/12_provider_distributions.rst` |
+| `*` (catch-all) | Other failing CI checks | `https://github.com/apache/airflow/blob/main/contributing-docs/08_static_code_checks.rst` |
 
 ## Notes
 
-- **Order matters.** The skill matches first-found; put more-
-  specific patterns above broader ones (e.g. `mypy-airflow-core`
-  before bare `mypy`).
+- **Order matters.** The skill matches first-found; more-specific
+  patterns are listed above broader ones (e.g. `mypy-airflow-core`
+  matches the `mypy-` row).
 - **Mergeability fallback.** If the PR has `mergeable ==
   CONFLICTING`, the skill emits a separate "Merge conflicts"
-  category linking to the project's git/rebase doc — declare
-  that link here too:
+  category linking to the project's git/rebase doc:
 
 | Concept | Doc URL |
 |---|---|
-| Merge conflicts (rebase guide) | TODO: e.g. `https://github.com/apache/foo/blob/main/contributing-docs/10_working_with_git.rst` |
+| Merge conflicts (rebase guide) | `https://github.com/apache/airflow/blob/main/contributing-docs/10_working_with_git.rst` |
 
 - **Failing-CI fallback.** If `checks_state == FAILURE` but no
   failed check names are extractable, the skill emits a generic

--- a/projects/_template/pr-management-triage-comment-templates.md
+++ b/projects/_template/pr-management-triage-comment-templates.md
@@ -2,97 +2,216 @@
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
 **Table of Contents**  *generated with [DocToc](https://github.com/thlorenz/doctoc)*
 
-- [TODO: `<Project Name>` — pr-management-triage comment templates](#todo-project-name--pr-management-triage-comment-templates)
+- [Apache Airflow — pr-management-triage comment templates](#apache-airflow--pr-management-triage-comment-templates)
   - [Project-specific URLs](#project-specific-urls)
   - [Quality-criteria marker string](#quality-criteria-marker-string)
   - [AI-attribution footer](#ai-attribution-footer)
   - [Template bodies](#template-bodies)
+    - [`draft`](#draft)
+    - [`comment-only`](#comment-only)
+    - [`close`](#close)
+    - [`review-nudge` (author-primary)](#review-nudge-author-primary)
+    - [`review-nudge` (reviewer-re-review)](#review-nudge-reviewer-re-review)
+    - [`reviewer-ping` (author-primary)](#reviewer-ping-author-primary)
+    - [`reviewer-ping` (reviewer-re-review)](#reviewer-ping-reviewer-re-review)
+    - [`mark-ready-with-ping`](#mark-ready-with-ping)
+    - [`stale-draft-close` (triaged)](#stale-draft-close-triaged)
+    - [`stale-draft-close` (untriaged)](#stale-draft-close-untriaged)
+    - [`inactive-to-draft`](#inactive-to-draft)
+    - [`stale-workflow-approval`](#stale-workflow-approval)
+    - [`suspicious-changes` (no AI footer)](#suspicious-changes-no-ai-footer)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
 
 <!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->
 
-# TODO: `<Project Name>` — pr-management-triage comment templates
+# Apache Airflow — pr-management-triage comment templates
 
 This file is the **per-project comment-body library** for the
-[`pr-management-triage`](../../.claude/skills/pr-management-triage/SKILL.md) skill. The
-framework's [`comment-templates.md`](../../.claude/skills/pr-management-triage/comment-templates.md)
-documents what each template **must** contain (the contract); this
-file is where the adopter declares the project's actual wording,
-URLs, and tone.
-
-Each template body is what gets posted on a contributor PR — keep
-the tone polite, link to the project's authoritative quality
-criteria, and stay consistent across templates so contributors
-recognise the voice across repeated triage cycles.
+[`pr-management-triage`](../../.claude/skills/pr-management-triage/SKILL.md) skill.
+It contains the concrete templates used by the Apache Airflow
+project.  New adopters should copy this file into their own
+`<project-config>/pr-management-triage-comment-templates.md` and
+replace every Airflow-specific URL and wording with their
+project's equivalents.
 
 ## Project-specific URLs
 
-Plug these placeholders into the templates below. The framework's
-[`comment-templates.md`](../../.claude/skills/pr-management-triage/comment-templates.md)
-references each by name.
-
 | Placeholder | Project value |
 |---|---|
-| `<quality_criteria_url>` | TODO: e.g. `https://github.com/apache/foo/blob/main/contributing-docs/05_pull_requests.rst#pull-request-quality-criteria` — the canonical "PR quality criteria" doc the AI footer + violations links point at. |
-| `<two_stage_triage_rationale_url>` | TODO: e.g. `https://github.com/apache/foo/blob/main/contributing-docs/25_maintainer_pr_triage.md#why-the-first-pass-is-automated` — the "why is first-pass triage automated" rationale the AI footer links at. |
-| `<project_display_name>` | TODO: e.g. `Apache Foo` — used in the AI footer ("an Apache Foo maintainer — a real person…"). |
+| `<quality_criteria_url>` | `https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-quality-criteria` |
+| `<two_stage_triage_rationale_url>` | `https://github.com/apache/airflow/blob/main/contributing-docs/25_maintainer_pr_triage.md#why-the-first-pass-is-automated` |
+| `<project_display_name>` | `Apache Airflow` |
+| `<merge_conflicts_rebase_url>` | `https://github.com/apache/airflow/blob/main/contributing-docs/10_working_with_git.rst` |
+| `<static_checks_url>` | `https://github.com/apache/airflow/blob/main/contributing-docs/08_static_code_checks.rst` |
+| `<testing_url>` | `https://github.com/apache/airflow/blob/main/contributing-docs/09_testing.rst` |
+| `<docs_building_url>` | `https://github.com/apache/airflow/blob/main/contributing-docs/11_documentation_building.rst` |
+| `<helm_tests_url>` | `https://github.com/apache/airflow/blob/main/contributing-docs/testing/helm_unit_tests.rst` |
+| `<k8s_tests_url>` | `https://github.com/apache/airflow/blob/main/contributing-docs/testing/k8s_tests.rst` |
+| `<provider_testing_url>` | `https://github.com/apache/airflow/blob/main/contributing-docs/12_provider_distributions.rst` |
+| `<project_communication_channel>` | `Airflow Slack` |
+| `<project_communication_url>` | `https://s.apache-airflow-slack.io` |
 
 ## Quality-criteria marker string
 
 The framework uses a literal string to detect already-triaged PRs
 (searches the PR body and comments for it). **Do not paraphrase**:
 the same exact string must appear verbatim in every triage comment
-the skill posts, and the `pr-management-stats` skill uses the same marker for
-"is this PR triaged" detection.
+the skill posts, and the `pr-management-stats` skill uses the same
+marker for "is this PR triaged" detection.
 
-| Concept | Default value | Project value |
-|---|---|---|
-| Triage-marker visible link text | `Pull Request quality criteria` | TODO (default works; only override if the project's wording differs) |
+| Concept | Value |
+|---|---|
+| Triage-marker visible link text | `Pull Request quality criteria` |
 
 ## AI-attribution footer
 
-The verbatim block appended to every contributor-facing comment
-(see [`comment-templates.md`](../../.claude/skills/pr-management-triage/comment-templates.md#ai-attribution-footer)
-for the rules — always-include, never-paraphrase, render at end of
-body). Customise the **wording** for the project but keep the
+The verbatim block appended to every contributor-facing comment.
+Customise the **wording** for the project but keep the
 **structure** (italicised meta-block, link to two-stage-triage
 rationale).
 
 ```markdown
 ---
 
-_Note: This comment was drafted by an AI-assisted triage tool and may contain mistakes. Once you have addressed the points above, a TODO: `<project_display_name>` maintainer — a real person — will take the next look at your PR. We use this [two-stage triage process](TODO: <two_stage_triage_rationale_url>) so that our maintainers' limited time is spent where it matters most: the conversation with you._
+_Note: This comment was drafted by an AI-assisted triage tool and may contain mistakes. Once you have addressed the points above, an Apache Airflow maintainer — a real person — will take the next look at your PR. We use this [two-stage triage process](https://github.com/apache/airflow/blob/main/contributing-docs/25_maintainer_pr_triage.md#why-the-first-pass-is-automated) so that our maintainers' limited time is spent where it matters most: the conversation with you._
 ```
 
 ## Template bodies
 
 The framework's [`comment-templates.md`](../../.claude/skills/pr-management-triage/comment-templates.md)
-documents the seven template categories the skill emits:
+documents the structural contract for each template (must-include
+sections, ordering, footer rules).  This section contains the
+actual bodies for the Apache Airflow project.
 
-1. `draft` — convert-to-draft body
-2. `comment-only` — non-draft violations comment
-3. `close` — close-with-quality-violations body
-4. `review-nudge` — stale-review ping
-5. `reviewer-ping` — explicit reviewer ping
-6. `mark-ready-with-ping` — mark-ready handoff
-7. `stale-draft-close` / `inactive-to-draft` / `stale-workflow-approval` — sweep-style bodies
-8. `suspicious-changes` — first-time-contributor workflow flag (no AI footer)
-
-For each one, see the framework file for the **structural contract**
-(must-include sections, ordering, footer rules) and add the
-project's actual wording below. Default airflow-flavored bodies
-ship in the framework; adopters override here.
+### `draft`
 
 ```markdown
-TODO: project's draft-comment body here.
+@<author> Converting to **draft** — this PR doesn't yet meet our [Pull Request quality criteria](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-quality-criteria).
 
-…
+<violations>
+
+<rebase_note_if_needed>
+
+See the linked criteria for how to fix each item, then mark the PR "Ready for review". This is **not** a rejection — just an invitation to bring the PR up to standard. No rush.
+
+<ai_attribution_footer>
 ```
 
-(For now the framework's defaults are airflow-shaped. Until the
-follow-up PR completes the extraction, your skills will run with
-the airflow-flavored content unless this file overrides specific
-sections — see the open follow-up issue for the exact override
-points the framework will read.)
+### `comment-only`
+
+```markdown
+@<author> A few things need addressing before review — see our [Pull Request quality criteria](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-quality-criteria).
+
+<violations>
+
+<rebase_note_if_needed>
+
+No rush.
+
+<ai_attribution_footer>
+```
+
+### `close`
+
+```markdown
+@<author> Closing — this PR has multiple violations of our [Pull Request quality criteria](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-quality-criteria).
+
+<violations>
+- :x: **Multiple flagged PRs**: <flagged_count> of your PRs are currently flagged for quality issues. Please focus on those before opening new ones.
+
+This is **not** a rejection — you're welcome to open a new PR addressing the issues above. No rush.
+
+<ai_attribution_footer>
+```
+
+### `review-nudge` (author-primary)
+
+```markdown
+@<author> — This PR has new commits since the last review requesting changes from <reviewers>. Could you address the outstanding review comments and either push a fix or reply in each thread explaining why the feedback doesn't apply? Once the threads are resolved please mark the PR as "Ready for review" and re-request review. Thanks!
+
+<ai_attribution_footer>
+```
+
+### `review-nudge` (reviewer-re-review)
+
+```markdown
+@<author> <reviewers> — This PR has new commits since the last review requesting changes, and the diff looks like it addresses the feedback (see <thread-links>). @<reviewers>, could you take another look when you have a chance to confirm? Thanks!
+
+<ai_attribution_footer>
+```
+
+### `reviewer-ping` (author-primary)
+
+```markdown
+@<author> — There are <N> unresolved review thread(s) on this PR from <reviewers>. Could you either push a fix or reply in each thread explaining why the feedback doesn't apply? Once you believe the feedback is addressed, mark the thread as resolved so the reviewer isn't re-pinged needlessly. Thanks!
+
+<ai_attribution_footer>
+```
+
+### `reviewer-ping` (reviewer-re-review)
+
+```markdown
+<reviewers> — @<author> appears to have addressed your review feedback (see the linked threads and the commits pushed since). Could you confirm and resolve the threads if you agree? Thanks!
+
+@<author>, if any of the threads still need work on your side, please reply in-line and push a fix.
+
+<ai_attribution_footer>
+```
+
+### `mark-ready-with-ping`
+
+```markdown
+@<author> — Your unresolved review thread(s) from <reviewers> appear to have been addressed (post-review commits and/or in-thread replies on every thread, with the latest commit pushed after the most recent thread). I've added the `ready for maintainer review` label so the PR re-enters the maintainer review queue.
+
+<reviewers> — could you take another look when you have a chance? If you agree the feedback was addressed, please mark the threads as resolved so the queue signal stays accurate. If a thread still needs work, please reply in-line — @<author> will follow up.
+
+<ai_attribution_footer>
+```
+
+### `stale-draft-close` (triaged)
+
+```markdown
+@<author> This draft PR has been inactive for <days_since_triage> days since the last triage comment and no response from the author. Closing to keep the queue clean.
+
+You are welcome to reopen this PR when you resume work, or to open a new one addressing the issues previously raised. There is no rush — take your time.
+
+<ai_attribution_footer>
+```
+
+### `stale-draft-close` (untriaged)
+
+```markdown
+@<author> This draft PR has had no activity for <weeks_since_activity> weeks. Closing to keep the queue clean.
+
+You are welcome to reopen and continue when you're ready. If you'd like to pick it back up, please rebase onto the current `<base>` branch first.
+
+<ai_attribution_footer>
+```
+
+### `inactive-to-draft`
+
+```markdown
+@<author> This PR has had no activity for <weeks_since_activity> weeks. Converting to draft to signal that maintainer review is paused until you resume work.
+
+When you're ready to continue, please rebase onto the current `<base>` branch, address any newly-appearing CI failures, and mark the PR as "Ready for review" again. There is no rush.
+
+<ai_attribution_footer>
+```
+
+### `stale-workflow-approval`
+
+```markdown
+@<author> This PR has been awaiting workflow approval with no activity for <weeks_since_activity> weeks. Converting to draft so it doesn't block the first-time-contributor review queue.
+
+When you're ready to continue, please push a new commit (which will re-request workflow approval) and mark the PR as "Ready for review" again. There is no rush.
+
+<ai_attribution_footer>
+```
+
+### `suspicious-changes` (no AI footer)
+
+```markdown
+This PR has been closed because of suspicious changes detected in it or in another PR by the same author. If you believe this is in error, please contact the Airflow maintainers on the [Airflow Slack](https://s.apache-airflow-slack.io).
+```


### PR DESCRIPTION
Extract all Apache-Airflow-specific defaults from the three PR-management skills into the project-agnostic `projects/_template/` configuration files.

## Templates filled with Airflow reference values

- `pr-management-config.md` — identifiers, labels, grace windows
- `pr-management-triage-comment-templates.md` — all 10+ comment bodies, AI footer, project URLs, communication channel
- `pr-management-triage-ci-check-map.md` — CI-check pattern → category + doc-URL mapping (12 categories)
- `pr-management-code-review-criteria.md` — repo-wide and per-area source files, security-model doc, backport pattern, section anchors

## Skills made fully project-agnostic

- `pr-management-triage/` — comment-templates, classify-and-act, workflow-approval, interaction-loop, prerequisites, rationale, actions, SKILL.md
- `pr-management-code-review/` — criteria, selectors, review-flow, adversarial, posting, SKILL.md
- `pr-management-stats/` — fetch, SKILL.md

## Also updated

- `projects/_template/README.md` — reflects that skills now read exclusively from `<project-config>/`

The `check-placeholders` linter passes, confirming no hardcoded project references remain in the skills.