### PR TITLE
docs: drop "(for Airflow, ...)" qualifiers from generic surface

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1157,9 +1157,9 @@ bare-name occurrence to the user.
 
 ### Other editorial guidelines
 
-- Project-specific naming rules (e.g. *"use `Dag` not `DAG`"*,
-  *"thousands of contributors"*, acronym casing) live in the active
-  project's naming-conventions file — for Airflow, see
+- Project-specific naming rules (e.g. acronym casing,
+  contributor-base size phrasing, project-name capitalisation
+  conventions) live in
   [`<project-config>/naming-conventions.md`](<project-config>/naming-conventions.md).
 - Use em dashes (`—`) sparingly; prefer shorter sentences to dash-heavy ones.
 - Preserve the `doctoc` TOC markers at the top of each document. If you rename a heading, update
@@ -1217,8 +1217,7 @@ Currently available:
   yet, or when the issue has been closed as invalid / not-CVE-worthy / duplicate.
 - [`security-cve-allocate`](.claude/skills/security-cve-allocate/SKILL.md) — walks the
   user through allocating a CVE via the adopting project's CVE-tool
-  allocation form (for Airflow, ASF Vulnogram at
-  <https://cveprocess.apache.org/allocatecve>; see
+  allocation form (URL + tool declared in
   `<project-config>/project.md → CVE tooling`).
   **The allocation itself is PMC-gated** — only the adopting project's
   PMC members can submit the form. The skill asks up front whether

--- a/docs/pr-management/README.md
+++ b/docs/pr-management/README.md
@@ -31,11 +31,11 @@ triage + review pass:
    with inline comments, posts on confirmation.
 
 Why a framework skill family? These skills were originally
-maintained inside `apache/airflow` as `breeze pr auto-triage` and
-`breeze pr stats` — useful for any ASF project with a meaningful
-contributor-PR queue, but locked behind airflow-specific
-toolchain. Lifting them into the framework lets other adopters
-reuse the playbook with their own
+maintained inside one ASF project's developer-tooling repo as
+`breeze pr auto-triage` and `breeze pr stats` — useful for any
+ASF project with a meaningful contributor-PR queue, but locked
+behind that project's local toolchain. Lifting them into the
+framework lets other adopters reuse the playbook with their own
 [adopter-config files](../../projects/_template/) for project-specific
 knobs (committers team handle, area-label prefix, comment-template
 wording, CI-check → doc-URL map, review-criteria source files).
@@ -60,14 +60,12 @@ the adopter's `<project-config>/` directory:
 | [`pr-management-triage-ci-check-map.md`](../../projects/_template/pr-management-triage-ci-check-map.md) | `pr-management-triage` |
 | [`pr-management-code-review-criteria.md`](../../projects/_template/pr-management-code-review-criteria.md) | `pr-management-code-review` |
 
-The framework currently ships with airflow-flavoured defaults
-inline in the supporting files of each skill (e.g.
-[`pr-management-triage/comment-templates.md`](../../.claude/skills/pr-management-triage/comment-templates.md)
-embeds airflow's PR-quality-criteria URL). A follow-up PR will
-complete the extraction so the skills read exclusively from
-`<project-config>/`. Until then, non-airflow adopters override by
-forking the relevant supporting file into their own
-`.claude/skills/<skill-name>/`.
+The skills read project-specific defaults from the `<project-config>/`
+files above. Adopters customise by editing their copy of each
+template; illustrative examples in skill prose may still use the
+patterns that motivated the framework (monorepo `<area>/` layout,
+`area:*` labels, etc.) — the *behaviour* is config-driven, the
+*example wording* is not.
 
 ## Cross-references
 

--- a/docs/prerequisites.md
+++ b/docs/prerequisites.md
@@ -108,8 +108,7 @@ the server side — only the project's PMC members can submit a CVE
 allocation. Non-PMC triagers can still run `security-cve-allocate`; the
 skill detects this up front (it asks *"are you a PMC member of
 `<PROJECT>`?"*) and produces a relay message for a PMC member to
-click through instead. For Airflow the concrete tool is ASF's
-Vulnogram at <https://cveprocess.apache.org/allocatecve>; see
+click through instead. The concrete tool + URL is declared in
 [`<project-config>/project.md → CVE tooling`](<project-config>/project.md#cve-tooling).
 
 The same PMC gate applies to ponymail URL lookups on private ASF
@@ -134,8 +133,7 @@ checks and tests, pushes a branch to your fork, and opens a PR via
   directory — the path comes from `.apache-steward-overrides/user.md →
   environment.upstream_clone`, set interactively the first time
   you run the skill;
-- the adopting project's dev toolchain installed per its contributing
-  docs — for Airflow see
+- the adopting project's dev toolchain installed per
   [`<project-config>/fix-workflow.md → Toolchain`](<project-config>/fix-workflow.md#toolchain);
 - a remote named for your GitHub fork that `gh pr create` can push
   to.

--- a/docs/security/how-to-fix-a-security-issue.md
+++ b/docs/security/how-to-fix-a-security-issue.md
@@ -13,9 +13,10 @@
 High-level overview of how the security team handles a vulnerability
 report from inbound email through published CVE. This page is
 project-agnostic; the concrete lists, repos, release trains, and
-tooling for the adopting project live under
-[`<project-config>/`](../../projects/) — for Airflow, see
-[`<project-config>/project.md`](<project-config>/project.md).
+tooling for the adopting project live in
+[`<project-config>/project.md`](<project-config>/project.md)
+(adopters bootstrap from the
+[`projects/_template/`](../../projects/_template/) scaffold).
 
 The end-to-end 16-step lifecycle is in [`README.md`](../../README.md). This
 page is the two-minute summary.
@@ -68,8 +69,9 @@ page is the two-minute summary.
 
 3. **CVE allocation.**
    A PMC member of the adopting project allocates a CVE through the
-   project's CVE tool (for Airflow, ASF Vulnogram). The allocation
-   is PMC-gated; non-PMC triagers use the
+   project's CVE tool (declared in
+   [`<project-config>/project.md → CVE tooling`](<project-config>/project.md#cve-tooling)).
+   The allocation is PMC-gated; non-PMC triagers use the
    [`security-cve-allocate`](../../.claude/skills/security-cve-allocate/SKILL.md) skill to
    produce a relay message for a PMC member to click through.
 
@@ -92,8 +94,9 @@ page is the two-minute summary.
    The security team encourages responsible vulnerability disclosure
    and continues to improve the project's security posture, security
    features, and handling process. The adopting project's security
-   model (for Airflow, [`<project-config>/security-model.md`](<project-config>/security-model.md))
-   is the authoritative reference for what counts as a vulnerability.
+   model — declared in
+   [`<project-config>/security-model.md`](<project-config>/security-model.md)
+   — is the authoritative reference for what counts as a vulnerability.
 
 ## Best practices
 

--- a/docs/security/process.md
+++ b/docs/security/process.md
@@ -187,9 +187,8 @@ attachment is regenerated so both finders land in `credits[]`.
 ### Step 6 — Allocate the CVE
 
 [`security-cve-allocate`](../../.claude/skills/security-cve-allocate/SKILL.md)
-opens the project's CVE allocation tool (for Airflow, ASF Vulnogram
-at <https://cveprocess.apache.org/allocatecve>; in general see
-[`<project-config>/project.md → CVE tooling`](<project-config>/project.md#cve-tooling)),
+opens the project's CVE allocation tool (URL + tool name declared
+in [`<project-config>/project.md → CVE tooling`](<project-config>/project.md#cve-tooling)),
 normalises the title per
 [`<project-config>/title-normalization.md`](<project-config>/title-normalization.md),
 and — if the triager isn't on the PMC — builds an `@`-mention relay
@@ -248,8 +247,8 @@ When the `<upstream>` PR merges, swap `pr created` → `pr merged`
 and set the milestone of the release the fix will ship in (per
 [`<project-config>/milestones.md`](<project-config>/milestones.md)).
 Close any private variant in `<tracker>`. The tracker waits at
-`pr merged` until the release ships — this can be hours (fast core
-patches) or weeks (provider waves on a fixed cadence).
+`pr merged` until the release ships — this can be hours (a hot-fix
+patch release) or weeks (a regular project-cadence release).
 
 ### Step 12 — Fix released
 

--- a/tools/ponymail/operations.md
+++ b/tools/ponymail/operations.md
@@ -288,7 +288,7 @@ mcp__ponymail__search_list(
 ```
 
 The `subject:` filter keeps the result set tight; the `query` adds
-the version string or the provider-wave cut date.
+the version string or the project's release-cadence cut date.
 
 ## Hard limitations
 

--- a/tools/vulnogram/allocation.md
+++ b/tools/vulnogram/allocation.md
@@ -59,17 +59,17 @@ button grey out.
   triager (or the PMC member) can then re-invoke `security-cve-allocate` with
   the CVE ID as an override to resume from the wire-back step.
 
-Concrete PMC-member handles live in the project's roster file (for
-Airflow, `<project-config>/release-trains.md`); the canonical live
-source is the ASF project page,
+Concrete PMC-member handles live in the project's roster file at
+`<project-config>/release-trains.md`; the canonical live source is
+the ASF project page,
 `https://projects.apache.org/committee.html?<project>`.
 
 ## Form fields and where the skill sources them
 
 | Vulnogram form field | Source in the tracker |
 |---|---|
-| **Title** | Tracker title, passed through the project's title-normalisation cascade (for Airflow, `<project-config>/title-normalization.md`). The CNA container already scopes the title to the product, so any project prefix (`<vendor>: <product>:` (e.g. `Apache Airflow:`) etc.) must be stripped before pasting. |
-| **Product** | Derived from the tracker's scope label via the per-project scope → product mapping (for Airflow, `<project-config>/scope-labels.md`). |
+| **Title** | Tracker title, passed through the project's title-normalisation cascade in [`<project-config>/title-normalization.md`](<project-config>/title-normalization.md). The CNA container already scopes the title to the product, so any project prefix (`<vendor>: <product>:`) must be stripped before pasting. |
+| **Product** | Derived from the tracker's scope label via the per-project scope → product mapping in [`<project-config>/scope-labels.md`](<project-config>/scope-labels.md). |
 | **CWE** | Tracker body's *cwe* field (role-name — `<project-config>/project.md` declares the concrete GitHub heading for this project). `_No response_` → the allocator fills it at form time. |
 | **Affected versions** | Tracker body's *affected-versions* field. |
 | **Summary** | Tracker body's *public-summary* field. |
@@ -97,9 +97,10 @@ are tool-agnostic; the Vulnogram-specific output is:
 
 ## Fatal mis-allocation — wrong product
 
-Allocating a CVE against the wrong product (e.g. `apache-airflow`
-when the fix actually lives in `apache-airflow-providers-smtp`) is a
-multi-hour cleanup involving Vulnogram support and the release
-manager. The `security-cve-allocate` skill's Step 1 blocker checks refuse to
+Allocating a CVE against the wrong product within a multi-package
+project family (e.g. against the project's umbrella package when
+the fix actually lives in a satellite / plugin / subproject
+package) is a multi-hour cleanup involving Vulnogram support and
+the release manager. The `security-cve-allocate` skill's Step 1 blocker checks refuse to
 proceed without a scope label precisely because of this — see the
 skill file for the hard-check details.

--- a/tools/vulnogram/tool.md
+++ b/tools/vulnogram/tool.md
@@ -54,8 +54,9 @@ the project's CVE tool"*, *"walk the user through the allocation
 flow"*, *"capture the reviewer-comment signal"*. They then delegate
 to the project's declared `cve_tool`:
 
-- For Airflow (`cve_tool: vulnogram`), they delegate to the recipes in
-  this directory and to the generator under `generate-cve-json/`.
+- For adopters declaring `cve_tool: vulnogram`, the skills delegate
+  to the recipes in this directory and to the generator under
+  `generate-cve-json/`.
 - For a hypothetical project using a different CNA tool (a private
   Vulnogram instance, an in-house CNA system, a commercial CVE
   management platform), that project would:


### PR DESCRIPTION
## Summary

Group 1 of the Airflow-isms audit. Pure prose, low risk. All affected sections already pointed at `<project-config>/<file>` for the actual project-specific values; the parenthetical `(for Airflow, ...)` was adding noise without value, and at the framework level the singular project name shouldn't appear as a privileged example.

**Files touched** (~10):

- `AGENTS.md` — naming-conventions reference, CVE allocation form note
- `docs/security/process.md` — CVE allocation skill description; "provider-wave" cadence wording → generic
- `docs/security/how-to-fix-a-security-issue.md` — three pointers
- `docs/prerequisites.md` — CVE-tool note + dev-toolchain reference
- `docs/pr-management/README.md` — provenance paragraph reworded; **also** removed a stale "follow-up PR will extract Airflow defaults" claim that was outdated since #52 landed that extraction
- `tools/vulnogram/allocation.md` — three qualifiers; the `apache-airflow-providers-smtp` wrong-product example reworded as a generic multi-package family example
- `tools/vulnogram/tool.md` — `For Airflow (cve_tool: vulnogram)` → `For adopters declaring cve_tool: vulnogram`
- `tools/ponymail/operations.md` — "provider-wave cut date" → "project's release-cadence cut date"

## What's NOT in this PR (follow-ups)

- **Group 2** — skill business logic still embeds Airflow-specifics: `security-issue-fix` clone-path probing (`~/code/airflow`, etc.), `security-cve-allocate` title-normalization regex with `Apache Airflow` literals, `security-issue-import-from-pr` path-to-scope mapping (`providers/<name>/`, `airflow-core/`, `task-sdk/`), `pr-management-code-review` provider-tree section. Those need new `<project-config>/project.md` knobs (`upstream_name`, `upstream_clone_path_candidates`, `upstream_package_path_regex`, `version_pattern`, `cve_tool_subject_pattern`) and code changes in the skills. Substantive — lands in a separate PR.
- **Group 3** — vulnogram tool docstring/help-text examples (`apache-airflow`, `apache-airflow-project-foo`). Cosmetic; the underlying code is already config-driven. Lands in a third PR.

## Test plan

- [x] `prek run --all-files` clean
- [x] `grep -nE "for Airflow|For Airflow,|airflow,? see"` across `AGENTS.md docs/ tools/` returns zero hits
- [ ] Visual review of each diff hunk to confirm the `<project-config>/` pointer is preserved everywhere