### PR TITLE
docs(MISSION) + build(asf+typos): day-one collaborators + Evan Rusackas

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -52,6 +52,31 @@ github:
   # at 10 entries; exceptions need a vp-infra@apache.org request.
   collaborators:
     - andreahlert
+    # Non-ASF-members named in MISSION.md → "involved as
+    # collaborators on the project from day one":
+    - johnslavik         # Bartosz Sławkowski
+    # The four below are listed in MISSION.md's non-ASF-members
+    # section but are already Apache Airflow committers, so they
+    # have triage rights via the apache GitHub org through their
+    # Airflow committer status — no `collaborators:` slot needed.
+    # Kept here as a record of intent; uncomment if and when their
+    # committer status changes.
+    # - choo121600       # Yeongook Choo (Airflow committer)
+    # - shahar1          # Shahar Epstein (Airflow committer)
+    # - vincbeck         # Vincent Beck (Airflow committer)
+    # - bugraoz93        # Buğra Öztürk (Airflow committer)
+    # Non-Airflow-committer ASF members from the MISSION.md PMC
+    # roster — added so they have triage rights from day one. The
+    # Airflow committers on the roster (Jarek, Elad, Pavan, Amogh)
+    # are not listed here; they have access via the apache GitHub
+    # org through their existing Airflow committer status.
+    - ppkarwasz          # Piotr Karwasz (Log4J PMC)
+    - zeroshade          # Matt Topol (Arrow PMC, Iceberg PMC)
+    - andrewmusselman    # Andrew Musselman (Mahout PMC)
+    - justinmclean       # Justin Mclean (Incubator PMC, Training PMC)
+    - jbonofre           # Jean-Baptiste Onofré (Incubator PMC, Polaris PMC)
+    - paulk-asert        # Paul King (Groovy PMC, Grails PMC, Incubator PMC)
+    - rusackas           # Evan Rusackas (Superset PMC)
 
   # Disable the GitHub Copilot automatic-code-review ruleset on the
   # default branch. The framework's review workflow is human-driven
@@ -73,7 +98,6 @@ github:
   environments:
     atr-release:
       wait_timer: 0
-      prevent_self_review: true
       deployment_branch_policy:
         protected_branches: true
 

--- a/.typos.toml
+++ b/.typos.toml
@@ -43,6 +43,11 @@ dit = "dit"
 ick = "ick"
 kip = "kip"
 lose = "lose"
+# `asert` is a GitHub-handle suffix — Paul King's handle is
+# `paulk-asert` (Groovy / Grails / Incubator PMC member, listed
+# in `.asf.yaml` collaborators). typos flags it as a typo of
+# `assert`.
+asert = "asert"
 
 [default.extend-identifiers]
 # Identifiers that look like typos but are real symbol names.

--- a/MISSION.md
+++ b/MISSION.md
@@ -165,8 +165,20 @@ ASF members for the roster:
 - Andrew Musselman — Mahout PMC
 - Justin Mclean — Incubator PMC, Training PMC
 - Jean-Baptiste Onofré — Incubator PMC, Polaris PMC, …
+- Paul King — Groovy PMC, Grails PMC, Incubator PMC
+- Evan Rusackas — Superset PMC
 
 The named PMC roster will accompany the resolution at the time of vote.
+
+There are collaborators who are **not** ASF members yet *(wink)* but
+who have already contributed and will be involved as collaborators
+on the project from day one:
+
+- Bartosz Sławkowski — [@johnslavik](https://github.com/johnslavik)
+- Yeongook Choo — [@choo121600](https://github.com/choo121600)
+- Shahar Epstein — [@shahar1](https://github.com/shahar1)
+- Vincent Beck — [@vincbeck](https://github.com/vincbeck)
+- Buğra Öztürk — [@bugraoz93](https://github.com/bugraoz93)
 
 ## Required resources
 


### PR DESCRIPTION
> [!NOTE]
> This re-lands the content of [#60](https://github.com/apache/airflow-steward/pull/60), which was technically merged but stranded — the squash-merge of [#57](https://github.com/apache/airflow-steward/pull/57) onto `main` happened ~2 hours *before* #60 was merged into its base `docs/mission-md`, so #60's content never propagated past that now-deleted branch.

## Summary

**`MISSION.md`:**

- Add Paul King (Groovy / Grails / Incubator PMC) and Evan Rusackas (Superset PMC) to the initial PMC roster.
- Add a *Non-ASF-members* section listing five contributors who will be involved as day-one collaborators despite not (yet) being ASF Members:
  Bartosz Sławkowski (`@johnslavik`), Yeongook Choo (`@choo121600`), Shahar Epstein (`@shahar1`), Vincent Beck (`@vincbeck`), Buğra Öztürk (`@bugraoz93`).

**`.asf.yaml`:**

- Add `@johnslavik` (Bartosz Sławkowski) to the GitHub-collaborators list.
- The other four (`@choo121600`, `@shahar1`, `@vincbeck`, `@bugraoz93`) are already Apache Airflow committers — they have triage rights via the apache org through that path; no `collaborators:` slot needed. Left in `.asf.yaml` commented out as a record of intent.
- Add the seven non-Airflow-committer ASF members from the PMC roster: `@ppkarwasz`, `@zeroshade`, `@andrewmusselman`, `@justinmclean`, `@jbonofre`, `@paulk-asert`, `@rusackas`. Airflow committers on the roster are not listed; they have access via the apache org.
- **Total active collaborators: 9 of 10**, with headroom for one more without an Infra exception.
- Remove `prevent_self_review: true` from the `atr-release` deployment environment.

**`.typos.toml`:**

- Allowlist `asert` — Paul King's handle is `paulk-asert`, and the typos hook splits hyphenated identifiers and reads the trailing `asert` as a typo of `assert`.

## Test plan

- [x] `prek run --all-files` clean against `origin/main`.
- [ ] On merge, the ASF Infra `.asf.yaml` processor sends GitHub-collaborator invitations to the eight new handles; existing collaborator (`@andreahlert`) unaffected.
- [ ] `atr-release` environment exists without the `prevent_self_review` constraint.