### PR TITLE
fix(skills): add `license: Apache-2.0` frontmatter to 13 skills

### DIFF
--- a/.claude/skills/pr-management-stats/SKILL.md
+++ b/.claude/skills/pr-management-stats/SKILL.md
@@ -11,6 +11,7 @@ when_to_use: |
   variation on "give me the maintainer view of the backlog". Good as a daily
   health check, before or after a triage sweep, or as an input to a planning
   session.
+license: Apache-2.0
 ---
 
 <!-- SPDX-License-Identifier: Apache-2.0

--- a/.claude/skills/security-cve-allocate/SKILL.md
+++ b/.claude/skills/security-cve-allocate/SKILL.md
@@ -22,6 +22,7 @@ when_to_use: |
   report is valid (process step 6). Not appropriate before the
   valid/invalid decision has been landed, nor for trackers that
   already carry a CVE ID in their *CVE tool link* body field.
+license: Apache-2.0
 ---
 
 <!-- Placeholder convention (see AGENTS.md#placeholder-convention-used-in-skill-files):

--- a/.claude/skills/security-issue-deduplicate/SKILL.md
+++ b/.claude/skills/security-issue-deduplicate/SKILL.md
@@ -17,6 +17,7 @@ when_to_use: |
   ID collision) between a new report and an existing tracker. Also
   appropriate as a periodic cleanup action when a triager spots two
   open trackers describing the same bug from different angles.
+license: Apache-2.0
 ---
 
 <!-- Placeholder convention (see AGENTS.md#placeholder-convention-used-in-skill-files):

--- a/.claude/skills/security-issue-fix/SKILL.md
+++ b/.claude/skills/security-issue-fix/SKILL.md
@@ -23,6 +23,7 @@ when_to_use: |
   valid vulnerabilities, or for changes that require private
   code-review in `<tracker>` itself (the private-PR fallback
   in process step 9 of README.md).
+license: Apache-2.0
 ---
 
 <!-- Placeholder convention (see AGENTS.md#placeholder-convention-used-in-skill-files):

--- a/.claude/skills/security-issue-import-from-md/SKILL.md
+++ b/.claude/skills/security-issue-import-from-md/SKILL.md
@@ -22,6 +22,7 @@ when_to_use: |
   inbound report is best handled through the Gmail path
   (`security-issue-import`) or when there is a public PR to anchor
   the import on (`security-issue-import-from-pr`).
+license: Apache-2.0
 ---
 
 <!-- Placeholder convention (see AGENTS.md#placeholder-convention-used-in-skill-files):

--- a/.claude/skills/security-issue-import-from-pr/SKILL.md
+++ b/.claude/skills/security-issue-import-from-pr/SKILL.md
@@ -20,6 +20,7 @@ when_to_use: |
   security relevance has already been agreed informally; this skill
   does not host a validity discussion. For reports that arrive on
   `<security-list>`, use `security-issue-import`.
+license: Apache-2.0
 ---
 
 <!-- Placeholder convention (see AGENTS.md#placeholder-convention-used-in-skill-files):

--- a/.claude/skills/security-issue-import/SKILL.md
+++ b/.claude/skills/security-issue-import/SKILL.md
@@ -20,6 +20,7 @@ when_to_use: |
   no-op when every recent thread is already tracked or already
   answered-and-closed on-thread. Use `import last 30d` / `import all`
   (= 90d) for a wider backlog sweep when genuinely warranted.
+license: Apache-2.0
 ---
 
 <!-- Placeholder convention (see AGENTS.md#placeholder-convention-used-in-skill-files):

--- a/.claude/skills/security-issue-invalidate/SKILL.md
+++ b/.claude/skills/security-issue-invalidate/SKILL.md
@@ -21,6 +21,7 @@ when_to_use: |
   the advisory has already shipped (closing as invalid then is a
   retraction with public consequences and needs explicit team
   escalation).
+license: Apache-2.0
 ---
 
 <!-- Placeholder convention (see AGENTS.md#placeholder-convention-used-in-skill-files):

--- a/.claude/skills/security-issue-sync/SKILL.md
+++ b/.claude/skills/security-issue-sync/SKILL.md
@@ -15,6 +15,7 @@ when_to_use: |
   through issue NNN". Also appropriate as part of a recurring triage sweep
   where the team member wants to reconcile a batch of open issues with the
   current state of the world.
+license: Apache-2.0
 ---
 
 <!-- Placeholder convention (see AGENTS.md#placeholder-convention-used-in-skill-files):

--- a/.claude/skills/setup-isolated-setup-install/SKILL.md
+++ b/.claude/skills/setup-isolated-setup-install/SKILL.md
@@ -24,6 +24,7 @@ when_to_use: |
   `setup-isolated-setup-verify` (to confirm completeness) or
   `setup-isolated-setup-update` (to refresh against the framework's
   latest) instead.
+license: Apache-2.0
 ---
 
 <!-- Placeholder convention (see AGENTS.md#placeholder-convention-used-in-skill-files):

--- a/.claude/skills/setup-isolated-setup-update/SKILL.md
+++ b/.claude/skills/setup-isolated-setup-update/SKILL.md
@@ -19,6 +19,7 @@ when_to_use: |
   blocked Bash call now appears to succeed. Recommended cadence
   per the doc: once per Claude Code upgrade or once a month,
   whichever comes first. Cheap to re-run; never destructive.
+license: Apache-2.0
 ---
 
 <!-- Placeholder convention (see AGENTS.md#placeholder-convention-used-in-skill-files):

--- a/.claude/skills/setup-isolated-setup-verify/SKILL.md
+++ b/.claude/skills/setup-isolated-setup-verify/SKILL.md
@@ -19,6 +19,7 @@ when_to_use: |
   time a previously-blocked Bash call appears to have succeeded
   (the "did a denial silently turn into an allow?" canary). Cheap
   to re-run; never destructive.
+license: Apache-2.0
 ---
 
 <!-- Placeholder convention (see AGENTS.md#placeholder-convention-used-in-skill-files):

--- a/.claude/skills/setup-shared-config-sync/SKILL.md
+++ b/.claude/skills/setup-shared-config-sync/SKILL.md
@@ -22,6 +22,7 @@ when_to_use: |
   drift on a script that the user keeps in `~/.claude-config/` and
   the user wants the framework's update propagated to every
   machine the sync repo is checked out on.
+license: Apache-2.0
 ---
 
 <!-- Placeholder convention (see AGENTS.md#placeholder-convention-used-in-skill-files):


### PR DESCRIPTION
## Summary

`skill-validator` requires every SKILL.md to declare `license` in its frontmatter, but 13 skills predate the requirement and were never backfilled. Running the validator locally on `main` surfaces them all:

```
$ skill-validate | grep "missing required frontmatter key: 'license'"
.claude/skills/pr-management-stats/SKILL.md:1: missing required frontmatter key: 'license'
.claude/skills/security-cve-allocate/SKILL.md:1: missing required frontmatter key: 'license'
... 11 more ...
```

All 13 skills are already Apache-2.0 (the SPDX header at the top of every file under `.claude/skills/` says so), so this is a mechanical one-value fill, no decisions needed:

- `pr-management-stats`
- `security-cve-allocate`
- `security-issue-{deduplicate,fix,import,import-from-md,import-from-pr,invalidate,sync}`
- `setup-isolated-setup-{install,update,verify}`
- `setup-shared-config-sync`

## What this does not fix

The remaining `skill-validator` violations on `main` are not mechanical:

- 13 broken links to deleted `code-review.instructions.md`. Decision needed: restore the file or update references.
- 3 broken `providers/AGENTS.md` links (apache/airflow-specific paths leaked into framework-generic skills).
- 4 unsubstituted `<...>` placeholders in `pr-management-triage/comment-templates.md` (adopter-config convention vs. literal substitution).
- Anchor mismatches from a slugify bug; #65 fixes most of them.

Each is a separate scoped follow-up. After all of them, `skill-validator` can be wired into prek + CI without burning the build.