### PR TITLE
docs(MISSION): adjust André Ahlert Junior name in MISSION and .asf.yaml

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -51,9 +51,9 @@ github:
   # without being added to the apache org. ASF Infra caps this list
   # at 10 entries; exceptions need a vp-infra@apache.org request.
   collaborators:
-    - andreahlert
     # Non-ASF-members named in MISSION.md → "involved as
     # collaborators on the project from day one":
+    - andreahlert        # André Ahlert Junior
     - johnslavik         # Bartosz Sławkowski
     # The four below are listed in MISSION.md's non-ASF-members
     # section but are already Apache Airflow committers, so they

--- a/MISSION.md
+++ b/MISSION.md
@@ -176,6 +176,7 @@ There are collaborators who are **not** ASF members yet *(wink)* but
 who have already contributed and will be involved as collaborators
 on the project from day one:
 
+- André Ahlert Junior — [@andreahlert](https://github.com/andreahlert)
 - Bartosz Sławkowski — [@johnslavik](https://github.com/johnslavik)
 - Yeongook Choo — [@choo121600](https://github.com/choo121600)
 - Shahar Epstein — [@shahar1](https://github.com/shahar1)


### PR DESCRIPTION
Just adjusting my name in `MISSION.md` and `.asf.yaml` to match the comment convention used on the other entries.