### PR TITLE
fix(secure-agent-setup): allow tool-cache writes in sandbox

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -9,12 +9,16 @@
         "~/.gitconfig",
         "~/.config/git/",
         "~/.config/gh/",
-        "~/.cache/uv/",
+        "~/.cache/",
         "~/.local/share/uv/",
         "~/.local/bin/",
         "~/.config/apache-steward/",
         "~/.gnupg/",
         "/run/user/*/gnupg/"
+      ],
+      "allowWrite": [
+        "~/.cache/",
+        "~/.local/share/uv/"
       ]
     },
     "network": {

--- a/docs/setup/secure-agent-setup.md
+++ b/docs/setup/secure-agent-setup.md
@@ -340,12 +340,16 @@ below, annotated.
         "~/.gitconfig",               // git's user.name / user.email
         "~/.config/git/",             // git's per-host config
         "~/.config/gh/",              // gh CLI auth (token in hosts.yml)
-        "~/.cache/uv/",               // uv's HTTP cache
+        "~/.cache/",                  // dev tool caches (uv HTTP cache, prek logs, ruff/mypy caches)
         "~/.local/share/uv/",         // uv's tool venvs (prek, etc.)
         "~/.local/bin/",              // uv-installed tool entry points
         "~/.config/apache-steward/",  // Gmail OAuth refresh token (oauth-draft tool)
         "~/.gnupg/",                  // gpg keys (commit signing)
         "/run/user/*/gnupg/"          // gpg-agent socket dir (ssh-via-gpg-agent commit signing)
+      ],
+      "allowWrite": [
+        "~/.cache/",                  // uv lock files, prek log + state, ruff/mypy caches
+        "~/.local/share/uv/"          // uv's tool venvs (prek installs new hook envs here)
       ]
     },
     "network": {
@@ -848,7 +852,14 @@ sub-section that follows.
      domains you don't actually use, add any project-specific hosts.
    - The `sandbox.filesystem.allowRead` list — same: drop the
      dotfiles your project doesn't need, add any project-specific
-     paths the host requires.
+     paths the host requires. If you use Claude Code's `--worktree`
+     agent isolation, sibling agent worktrees live next to the active
+     one (e.g. `~/code/<project>/.claude/worktrees/agent-*/`), and
+     `git` operations on a worktree follow its `.git` file up to the
+     main repo's `.git/` directory. Both require read access to the
+     parent path that contains all worktrees and the main repo —
+     adopters who keep their checkout at, say, `~/code/<project>/`
+     should add that directory to `allowRead`.
    - The `permissions.ask` list — add any project-specific
      write-side commands you want to confirm explicitly (e.g. a
      custom release-publishing CLI).


### PR DESCRIPTION
## Summary

- `sandbox.filesystem.allowWrite` is added with `~/.cache/` and
  `~/.local/share/uv/`. Without write access to these paths, common
  dev-loop tools fail under the sandbox: `uv` cannot open
  `~/.cache/uv/sdists-v9/.git`, `prek` cannot write `~/.cache/prek/prek.log`,
  and `ruff`/`mypy` cannot maintain their on-disk caches.
- `sandbox.filesystem.allowRead` is broadened from `~/.cache/uv/` to
  `~/.cache/` so the read side covers the same dev-tool caches that
  the new write entry covers.
- Adopter-setup docs gain a note about the `--worktree` agent-isolation
  case: sibling agent worktrees and the main repo's `.git/` need read
  access to the parent path that contains them, which is
  project-specific (e.g. adopters whose checkout sits at
  `~/code/<project>/` should add that directory to `allowRead`).

## Test plan

- [x] `prek run --files .claude/settings.json docs/setup/secure-agent-setup.md`
      — all relevant hooks (markdownlint, typos, TOC, EOF/whitespace
      checks) pass.
- [x] In a live Airflow contributor session, the same change applied
      to `~/.claude/settings.json` unblocked `uv run`, `prek run`, and
      `git` operations on agent worktrees that previously failed with
      `Operation not permitted` on `~/.cache/uv/sdists-v9/.git` and
      `~/.cache/prek/prek.log`.
- [ ] CI: `prek run --all-files` and `zizmor` (auto-run on PR).

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Opus 4.7 (1M context)

Generated-by: Claude Opus 4.7 (1M context) following the framework's
agent-authored-fixes pattern.