### PR TITLE
fix(security): close gh permission gaps in settings.json

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -63,7 +63,9 @@
       "Bash(docker login *)",
       "Bash(npm publish *)",
       "Bash(pip install --upgrade *)",
-      "Bash(uv self update *)"
+      "Bash(uv self update *)",
+      "Bash(gh auth token*)",
+      "Bash(gh auth refresh*)"
     ],
     "ask": [
       "Bash(git push *)",
@@ -85,11 +87,14 @@
       "Bash(gh repo edit *)",
       "Bash(gh repo delete *)",
       "Bash(gh api * --method *)",
+      "Bash(gh api --method *)",
       "Bash(gh api * --input *)",
+      "Bash(gh api --input *)",
       "Bash(gh secret *)",
       "Bash(gh ssh-key *)",
       "Bash(gh release upload *)",
-      "Bash(gh release delete *)"
+      "Bash(gh release delete *)",
+      "Bash(gh workflow run *)"
     ]
   }
 }


### PR DESCRIPTION
Split from #88 per review.

`gh auth token` and `gh auth refresh` are added to `permissions.deny`. `gh auth token` prints the GitHub token to stdout with no prompt, so any injection that reaches Bash can capture it and exfil via the already-allowlisted `api.github.com`. No skill in the repo needs either command.

`gh workflow run *` is added to `permissions.ask` so an injected agent can't trigger arbitrary upstream workflows without a confirmation prompt.

Flag-first variants `gh api --method *` and `gh api --input *` are added alongside the existing `gh api * --method *` / `gh api * --input *` patterns. With the flag before the endpoint path the existing patterns may not match, depending on whether the glob `*` matches the empty string.