### PR TITLE
Add skill-validate prek hook for `.claude/skills/**`

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -269,3 +269,14 @@ repos:
         entry: uv run --directory tools/sandbox-lint pytest
         files: ^(tools/sandbox-lint/(src|tests|pyproject\.toml|expected\.json)|\.claude/settings\.json)
         pass_filenames: false
+
+  # Validate `.claude/skills/**` via the `skill-validate` CLI. Re-fires
+  # on validator-source changes so rule updates get re-applied.
+  - repo: local
+    hooks:
+      - id: skill-validate
+        name: skill-validate (.claude/skills/**)
+        language: system
+        entry: uv run --directory tools/skill-validator skill-validate
+        files: ^(\.claude/skills/.*\.md|tools/skill-validator/(src|pyproject\.toml))
+        pass_filenames: false

--- a/tools/skill-validator/uv.lock
+++ b/tools/skill-validator/uv.lock
@@ -10,9 +10,6 @@ resolution-markers = [
 exclude-newer = "0001-01-01T00:00:00Z" # This has no effect and is included for backwards compatibility when using relative exclude-newer values.
 exclude-newer-span = "P7D"
 
-[options.exclude-newer-package]
-uv = { timestamp = "0001-01-01T00:00:00Z", span = "P1D" }
-
 [[package]]
 name = "colorama"
 version = "0.4.6"


### PR DESCRIPTION
## Summary

- Wires `tools/skill-validator` into `.pre-commit-config.yaml` so every
  skill under `.claude/skills/**` is validated on each commit (locally
  when `prek install` is configured, and unconditionally in CI via the
  existing `.github/workflows/pre-commit.yml` runner).
- Re-runs validation whenever a skill `.md` file or the validator's own
  source changes, so updated rules are automatically re-applied across
  all skills.

## What `skill-validate` checks

- **Frontmatter** (`SKILL.md` only): required keys (`name`,
  `description`, `license`), `license` ∈ {`Apache-2.0`}, `mode` ∈
  {`A`, `B`, `C`} when present.
- **Internal links**: cross-file targets exist and `#anchor`s resolve
  to real headings (same-file and cross-file).
- **Placeholder convention**: uses the same forbidden-pattern and
  allowlist definitions as `tools/dev/check-placeholders.sh`.