### PR TITLE
Add .claude/settings.local.json to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 logs
 .build
 .claude/worktrees/
+.claude/settings.local.json
 
 # Python
 __pycache__/


### PR DESCRIPTION
Some of our skills stay loaded even while developing this project itself, which can unnecessarily increase context usage during development.

To make local development lighter, this PR adds `settings.local.json` to `.gitignore` so contributors can locally disable loading most skills while working on the repository.

If you are experiencing the same issue, you can add the following configuration to `settings.local.json`:

```json
{
  "$schema": "https://json.schemastore.org/claude-code-settings.json",
  "skillOverrides": {
    "pr-management-code-review": "off",
    "pr-management-mentor": "off",
    "pr-management-stats": "off",
    "pr-management-triage": "off",
    "security-cve-allocate": "off",
    "security-issue-deduplicate": "off",
    "security-issue-fix": "off",
    "security-issue-import": "off",
    "security-issue-import-from-md": "off",
    "security-issue-import-from-pr": "off",
    "security-issue-invalidate": "off",
    "security-issue-sync": "off",
    "setup-isolated-setup-install": "off",
    "setup-isolated-setup-update": "off",
    "setup-isolated-setup-verify": "off",
    "setup-override-upstream": "off",
    "setup-shared-config-sync": "off",
    "setup-steward": "off",
    "write-skill": "on"
  }
}
```

## Before

<img width="745" height="305" alt="image" src="https://github.com/user-attachments/assets/354a192a-0f19-4ee0-89f3-4aa9350ff5c1" />

<img width="478" height="496" alt="image" src="https://github.com/user-attachments/assets/c853d653-d2c4-4902-a1a5-0a8e45493563" />



## After
<img width="724" height="295" alt="image" src="https://github.com/user-attachments/assets/e8a1ea74-b26b-4213-959e-05f0662c95d9" />

<img width="398" height="187" alt="image" src="https://github.com/user-attachments/assets/d279758d-c494-4a00-aa8c-cd2945fad720" />
