### PR TITLE
docs(mission): add Russell Spitzer to PMC roster

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -77,6 +77,7 @@ github:
     - jbonofre           # Jean-Baptiste Onofré (Incubator PMC, Polaris PMC)
     - paulk-asert        # Paul King (Groovy PMC, Grails PMC, Incubator PMC)
     - rusackas           # Evan Rusackas (Superset PMC)
+    - russellspitzer     # Russell Spitzer (Incubator PMC, Polaris PMC, Iceberg PMC)
 
   # Disable the GitHub Copilot automatic-code-review ruleset on the
   # default branch. The framework's review workflow is human-driven

--- a/MISSION.md
+++ b/MISSION.md
@@ -169,6 +169,7 @@ ASF members for the roster:
 - Jean-Baptiste Onofré — Incubator PMC, Polaris PMC, …
 - Paul King — Groovy PMC, Grails PMC, Incubator PMC
 - Evan Rusackas — Superset PMC
+- Russell Spitzer — Incubator PMC, Polaris PMC, Iceberg PMC
 
 The named PMC roster will accompany the resolution at the time of vote.
 


### PR DESCRIPTION
## Summary
- Add Russell Spitzer (Incubator PMC, Polaris PMC, Iceberg PMC) to the
  initial PMC roster in `MISSION.md`.
- Mirror in `.asf.yaml` under the non-Airflow-committer collaborators
  block so he has GitHub triage rights from day one. The active
  collaborators list is now at 10 — the ASF Infra cap noted in the
  file's header comment.

## Test plan
- [ ] Visual review of the two-line diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)