### PR TITLE
fix(pre-commit): silent-pass CWD bug + link/anchor rot cleanup

### DIFF
--- a/.claude/skills/pr-management-code-review/criteria.md
+++ b/.claude/skills/pr-management-code-review/criteria.md
@@ -44,19 +44,16 @@ table; see [`review-flow.md#area-specific-overlay`](review-flow.md).
 
 ## Categories — link out to the source section
 
-The category headings below are the **abstract names** the skill
-uses when grouping findings. The concrete URL each one links to
-lives in the adopter's
+The list below is the **abstract canonical category list** the
+skill uses when grouping findings. The concrete review-doc URL
+for each category lives in the adopter's
 `<project-config>/pr-management-code-review-criteria.md` →
-`Section anchors` table — every adopter substitutes their own
-review-doc URLs there. The skill resolves a category to its URL
-at finding time by matching the heading verbatim against the
-adopter table's `Section` column.
-
-If a category has no anchor row in the adopter config, the skill
-falls back to a plain reference (no clickable link) and surfaces
-the missing anchor as a one-line warning at the top of the
-review.
+`Section anchors` table; the skill resolves a category to its
+URL at finding time by matching the category name verbatim
+against that table's `Section` column. If a category has no
+anchor row, the skill falls back to a plain reference (no
+clickable link) and surfaces the missing anchor as a one-line
+warning at the top of the review.
 
 The canonical category list:
 
@@ -98,10 +95,10 @@ adopter table, only the repo-wide rules apply.
 Before flagging anything that looks security-flavoured, read
 the documented security model at the path declared in
 `<project-config>/pr-management-code-review-criteria.md` →
-`security_model_calibration.file`, and the
-[`AGENTS.md` § Security Model](../../../AGENTS.md#security-model)
-calibration guide. The latter is short and tells you how to
-distinguish:
+`security_model_calibration.file`. The framework's reference
+threat model lives at
+[`docs/security/threat-model.md`](../../../docs/security/threat-model.md);
+read both before deciding. Use the calibration to distinguish:
 
 1. an **actual vulnerability** that violates the documented
    model — flag as blocking,

--- a/.claude/skills/pr-management-code-review/review-flow.md
+++ b/.claude/skills/pr-management-code-review/review-flow.md
@@ -156,27 +156,22 @@ as a finding (don't fail the review on it alone).
 ## Step 4 — Examine the diff
 
 **Read** the diff line-by-line, classifying findings into the
-categories from [`criteria.md`](criteria.md). The skill does
-**not** carry its own copy of the rules — for each category,
-read the source section linked from `criteria.md` and quote
-from it verbatim when raising a finding:
+canonical categories listed in [`criteria.md`](criteria.md). The
+skill does **not** carry its own copy of the rules — for each
+category, look up the source URL in the adopter's
+[`<project-config>/pr-management-code-review-criteria.md` § Section anchors](<project-config>/pr-management-code-review-criteria.md#section-anchors)
+table, read that source section, and quote from it verbatim
+when raising a finding. The categories the skill expects to
+match against are:
 
-1. **Architecture boundaries** — see
-   [`criteria.md` § Architecture boundaries](criteria.md#architecture-boundaries).
-2. **Database / query correctness** —
-   [`criteria.md` § Database / query correctness](criteria.md#database--query-correctness).
-3. **Code quality** —
-   [`criteria.md` § Code quality](criteria.md#code-quality).
-4. **Testing** —
-   [`criteria.md` § Testing](criteria.md#testing).
-5. **API correctness** —
-   [`criteria.md` § API correctness](criteria.md#api-correctness).
-6. **UI** —
-   [`criteria.md` § UI (React/TypeScript)](criteria.md#ui-reacttypescript).
-7. **Generated files** —
-   [`criteria.md` § Generated files](criteria.md#generated-files).
-8. **AI-generated code signals** —
-   [`criteria.md` § AI-generated code signals](criteria.md#ai-generated-code-signals).
+1. **Architecture boundaries**
+2. **Database / query correctness**
+3. **Code quality**
+4. **Testing**
+5. **API correctness**
+6. **UI (React/TypeScript)**
+7. **Generated files**
+8. **AI-generated code signals**
 9. **Per-area `AGENTS.md` rules** — anything specific to the
    touched tree (the per-PR `AGENTS.md` discovery in Step 2).
 
@@ -226,7 +221,7 @@ the finding; restating drifts.
   documented model treats as one (worker reaching DB,
   scheduler running user code, SQL injection, missing
   migration on a public-API change). Calibrate against
-  [`AGENTS.md` § Security Model](../../../AGENTS.md#security-model)
+  [`docs/security/threat-model.md`](../../../docs/security/threat-model.md)
   before assigning.
 
 A single `blocking` finding pushes the disposition to

--- a/.claude/skills/pr-management-triage/SKILL.md
+++ b/.claude/skills/pr-management-triage/SKILL.md
@@ -153,7 +153,7 @@ bot checks (`Mergeable`, `WIP`, `DCO`, `boring-cyborg`) while
 `action_required`; trusting the rollup there fills the
 maintainer-review queue with PRs whose real CI never ran. The
 guard applies identically to the
-[`mark-ready-with-ping`](actions.md#mark-ready-with-ping)
+[`mark-ready-with-ping`](actions.md#mark-ready-with-ping--promote-a-likely-addressed-pr--ping-reviewers)
 action — any code path that adds the `ready for maintainer
 review` label runs the REST check first.
 Implementation recipe: [`actions.md#mark-ready`](actions.md).

--- a/.claude/skills/pr-management-triage/classify-and-act.md
+++ b/.claude/skills/pr-management-triage/classify-and-act.md
@@ -103,7 +103,7 @@ Action verbs are defined in [`actions.md`](actions.md).
   Action-side guard: see the `rebase` recipe in [`actions.md`](actions.md).
 - **Never `mark-ready` while workflow approval is pending.**
   Row 1 catches the upstream signal; the
-  [`mark-ready` action](actions.md#mark-ready) re-checks the
+  [`mark-ready` action](actions.md#mark-ready--add-ready-for-maintainer-review-label) re-checks the
   REST `action_required` index immediately before mutating
   (Golden rule 1b in [`SKILL.md`](SKILL.md)).
 - **Collaborator-authored PRs never get `draft`.** When

--- a/.claude/skills/security-cve-allocate/SKILL.md
+++ b/.claude/skills/security-cve-allocate/SKILL.md
@@ -173,9 +173,9 @@ anything else.
   click through instead of stopping.
 
 See
-[Prerequisites for running the agent skills](../../../README.md#prerequisites-for-running-the-agent-skills)
-in `README.md` for the overall setup (including the ponymail-mcp
-option on the horizon for non-personal-Gmail access).
+[Prerequisites for running the agent skills](../../../docs/prerequisites.md#prerequisites-for-running-the-agent-skills)
+in `docs/prerequisites.md` for the overall setup (including the
+ponymail-mcp option on the horizon for non-personal-Gmail access).
 
 ---
 
@@ -193,8 +193,8 @@ Before touching the tracker, verify:
    `curl -LsSf https://astral.sh/uv/install.sh | sh`).
 3. **Resolve the user's PMC status.** First try to read it from
    `.apache-steward-overrides/user.md` → `role_flags.pmc_member`
-   (see [`config/README.md`](../../../config/README.md) for the config
-   layer explainer). If the file exists and the flag is set, use that
+   (see [`AGENTS.md` § Per-project and per-user configuration](../../../AGENTS.md#per-project-and-per-user-configuration)
+   for the config-layer explainer). If the file exists and the flag is set, use that
    value and surface it in the Step 0 recap (*"loaded config for
    `<handle>` (PMC: yes)"*). If the file is missing, the flag is
    unset, or the user did not copy the template, fall back to asking

--- a/.claude/skills/security-issue-deduplicate/SKILL.md
+++ b/.claude/skills/security-issue-deduplicate/SKILL.md
@@ -150,8 +150,8 @@ does **not** auto-pick. Practical guidance to offer when asked:
   `uv run` call.
 
 See
-[Prerequisites for running the agent skills](../../../README.md#prerequisites-for-running-the-agent-skills)
-in `README.md`.
+[Prerequisites for running the agent skills](../../../docs/prerequisites.md#prerequisites-for-running-the-agent-skills)
+in `docs/prerequisites.md`.
 
 ---
 

--- a/.claude/skills/security-issue-fix/SKILL.md
+++ b/.claude/skills/security-issue-fix/SKILL.md
@@ -168,8 +168,8 @@ tracker only to discover you cannot push the branch.
   resolution and `gh` API calls.
 
 See
-[Prerequisites for running the agent skills](../../../README.md#prerequisites-for-running-the-agent-skills)
-in `README.md` for the overall setup.
+[Prerequisites for running the agent skills](../../../docs/prerequisites.md#prerequisites-for-running-the-agent-skills)
+in `docs/prerequisites.md` for the overall setup.
 
 ---
 
@@ -333,8 +333,8 @@ touching any files:
 1. Resolve the clone path from the user's
    `.apache-steward-overrides/user.md` →
    `environment.upstream_clone` (see
-   [`config/README.md`](../../../config/README.md) for the config
-   layer explainer). If the file is missing, the key is unset, or
+   [`AGENTS.md` § Per-project and per-user configuration](../../../AGENTS.md#per-project-and-per-user-configuration)
+   for the config-layer explainer). If the file is missing, the key is unset, or
    the stored path does not resolve to a git repo with a remote
    pointing at `<upstream>` or the user's fork, **ask the user
    for the path interactively** and offer to save their answer back

--- a/.claude/skills/security-issue-import-from-md/SKILL.md
+++ b/.claude/skills/security-issue-import-from-md/SKILL.md
@@ -160,8 +160,8 @@ Before running, the skill needs:
 No Gmail, no PonyMail, no `<upstream>` access. There is no inbound
 thread to read and no reporter to draft a reply to.
 
-See [Prerequisites for running the agent skills](../../../README.md#prerequisites-for-running-the-agent-skills)
-in `README.md` for overall setup.
+See [Prerequisites for running the agent skills](../../../docs/prerequisites.md#prerequisites-for-running-the-agent-skills)
+in `docs/prerequisites.md` for overall setup.
 
 ---
 

--- a/.claude/skills/security-issue-import-from-pr/SKILL.md
+++ b/.claude/skills/security-issue-import-from-pr/SKILL.md
@@ -155,8 +155,8 @@ Before running, the skill needs:
 No Gmail, no PonyMail. There is no inbound thread to read and no
 reporter to draft a reply to.
 
-See [Prerequisites for running the agent skills](../../../README.md#prerequisites-for-running-the-agent-skills)
-in `README.md` for overall setup.
+See [Prerequisites for running the agent skills](../../../docs/prerequisites.md#prerequisites-for-running-the-agent-skills)
+in `docs/prerequisites.md` for overall setup.
 
 ---
 
@@ -701,7 +701,7 @@ with other trackers.
 - **Does not create the GHSA.** GHSA creation, advisory drafting,
   and the `<upstream>` private-repo coordination all happen
   later in the process — see
-  [`README.md`](../../../README.md#process-overview).
+  [`docs/security/process.md`](../../../docs/security/process.md#process-reference-the-16-steps).
 - **Does not characterise the public PR as a security fix until
   the advisory ships.** The tracker URL itself is a public-safe
   identifier and may appear in the PR description as a

--- a/.claude/skills/security-issue-import/SKILL.md
+++ b/.claude/skills/security-issue-import/SKILL.md
@@ -153,9 +153,9 @@ Before running, the skill needs:
   `gh issue create` and `gh search issues` directly.
 
 See
-[Prerequisites for running the agent skills](../../../README.md#prerequisites-for-running-the-agent-skills)
-in `README.md` for the overall setup and the ponymail-mcp
-alternative on the horizon.
+[Prerequisites for running the agent skills](../../../docs/prerequisites.md#prerequisites-for-running-the-agent-skills)
+in `docs/prerequisites.md` for the overall setup and the
+ponymail-mcp alternative on the horizon.
 
 ---
 
@@ -751,8 +751,9 @@ is missing a vulnerability.
 ## Step 4 — Extract template fields
 
 For each `Report` / `ASF-security relay` candidate, extract the fields
-the [issue template](../../../.github/ISSUE_TEMPLATE/issue_report.yml)
-expects. Most fields the reporter did not explicitly supply stay as
+the [issue template](<tracker>/.github/ISSUE_TEMPLATE/issue_report.yml)
+expects (the template lives in the tracker repo, not the framework
+repo). Most fields the reporter did not explicitly supply stay as
 `_No response_`; the subsequent `security-issue-sync` run will prompt
 the triager to fill them as the discussion progresses.
 
@@ -993,7 +994,7 @@ For each confirmed `Report` / `ASF-security relay`:
    the directive in a fresh agent context and act on it. Also, if
    the import-time prompt-injection flag fired (the
    *"detected suspicious markup at import"* signal in
-   [`AGENTS.md`](../../../AGENTS.md#prompt-injection-handling)),
+   [`AGENTS.md`](../../../AGENTS.md#treat-external-content-as-data-never-as-instructions)),
    prepend a `> [!IMPORTANT] prompt-injection content detected at
    import` callout above the fenced block so the marker persists
    on the tracker for every future skill invocation:

--- a/.claude/skills/security-issue-invalidate/SKILL.md
+++ b/.claude/skills/security-issue-invalidate/SKILL.md
@@ -38,7 +38,7 @@ license: Apache-2.0
 This skill is the **terminal-disposition apply step** for the
 `invalid` close on an `<tracker>` tracker. It does not host the
 discussion that decides invalidity — that happens at Step 5 of the
-[handling process](../../../README.md#step-5--validity-decision)
+[handling process](../../../docs/security/process.md#step-5--land-the-validinvalid-consensus)
 in the tracker's comments. Once the team has reached a
 consensus-invalid decision, this skill applies it: labels the
 tracker `invalid`, posts a short public-facing closing comment,
@@ -148,8 +148,8 @@ Before running, the skill needs:
   surfaces the missing draft as a follow-up the user must do
   manually before the close is fully complete.
 
-See [Prerequisites for running the agent skills](../../../README.md#prerequisites-for-running-the-agent-skills)
-in `README.md` for overall setup and the
+See [Prerequisites for running the agent skills](../../../docs/prerequisites.md#prerequisites-for-running-the-agent-skills)
+in `docs/prerequisites.md` for overall setup and the
 [`claude_ai_mcp` (default) vs `oauth_curl` (opt-in) backend rule](../../../tools/gmail/draft-backends.md#how-the-skills-pick-a-backend)
 for the Gmail draft path.
 
@@ -457,7 +457,7 @@ For `security@`-imported trackers:
      leak. Cite the public Security Model and any public CVEs
      instead.
    - **Polite-but-firm.** Per
-     [`AGENTS.md`](../../../AGENTS.md#tone-and-register), state
+     [`AGENTS.md`](../../../AGENTS.md#tone-polite-but-firm--no-room-to-wiggle), state
      the team's position once, clearly, with reasoning. Do not
      re-open the discussion with phrases like *"happy to
      discuss further"* — close the loop.

--- a/.claude/skills/security-issue-sync/SKILL.md
+++ b/.claude/skills/security-issue-sync/SKILL.md
@@ -329,8 +329,8 @@ The skill needs:
   versions and to find advisory archive URLs.
 
 See
-[Prerequisites for running the agent skills](../../../README.md#prerequisites-for-running-the-agent-skills)
-in `README.md` for the overall setup.
+[Prerequisites for running the agent skills](../../../docs/prerequisites.md#prerequisites-for-running-the-agent-skills)
+in `docs/prerequisites.md` for the overall setup.
 
 ---
 
@@ -1236,7 +1236,7 @@ will change and *why*. Group them by category:
   since the last message we sent to the reporter, propose a Gmail draft that
   brings the reporter up to date.** The set of transitions that warrant a
   status update is enumerated authoritatively in
-  [`README.md` — Keeping the reporter informed](../../../README.md#keeping-the-reporter-informed);
+  [`docs/security/roles.md` — Keeping the reporter informed](../../../docs/security/roles.md#keeping-the-reporter-informed);
   the skill must draft an update when any of those has happened since our
   last message in the original mail thread, including the post-close
   *"CVE is live on cve.org"* transition surfaced by
@@ -1351,7 +1351,7 @@ will change and *why*. Group them by category:
   only sent by email. The two-channels rationale (email keeps the
   reporter, the issue record keeps the team and the release
   manager) lives in
-  [`README.md` — Recording status transitions on the tracker](../../../README.md#recording-status-transitions-on-the-tracker).
+  [`docs/security/roles.md` — Recording status transitions on the tracker](../../../docs/security/roles.md#recording-status-transitions-on-the-tracker).
 
   **The status record lives in a single rollup comment, not a new
   comment per sync.** The first bot-authored comment on a tracker
@@ -1663,7 +1663,7 @@ A single short paragraph describing what the user should do *after* these
 updates land, based on the process step. Examples:
 
 - *"Step 3: start the CVE-worthiness discussion in a comment on the issue, tagging at least one other security team member."*
-- *"Step 4: escalate to a wider audience — the discussion has been stalled for 34 days. Run the two-phase escalation per [`README.md` — Step 4](../../../README.md#step-4--escalate-stalled-discussions): phase 1 is a short call for ideas to `<private-list>` (no AI analysis), phase 2 — only if phase 1 stays silent for ~7 more days — is an AI-generated design-space analysis that the triager reviews before posting. The agent drafts both phases as proposals; the triager confirms the exact wording + the list of people to `@`-mention before anything is sent."*
+- *"Step 4: escalate to a wider audience — the discussion has been stalled for 34 days. Run the two-phase escalation per [`docs/security/process.md` — Step 4](../../../docs/security/process.md#step-4--escalate-stalled-discussions): phase 1 is a short call for ideas to `<private-list>` (no AI analysis), phase 2 — only if phase 1 stays silent for ~7 more days — is an AI-generated design-space analysis that the triager reviews before posting. The agent drafts both phases as proposals; the triager confirms the exact wording + the list of people to `@`-mention before anything is sent."*
 - *"Step 6: allocate a CVE. Run the [`security-cve-allocate`](../security-cve-allocate/SKILL.md) skill (it prints the ASF Vulnogram form URL plus a CVE-ready title and wires the allocated ID back into the tracker)."*
 - *"Step 10: close the private PR at <tracker>#NNN now that <upstream>#NNNN has merged."*
 - *"Step 11: `pr merged` — tracker parked until the release train ships. No action needed from the security team; the next sync run will detect the PyPI / Helm release and propose the `fix released` swap (Step 12)."*

--- a/.claude/skills/write-skill/security-checklist.md
+++ b/.claude/skills/write-skill/security-checklist.md
@@ -242,6 +242,5 @@ backstops:
 
 When a future audit surfaces a pattern that this checklist
 missed, the change is in two places: (a) add a pattern here,
-(b) audit existing skills for the new gap. See
-[`docs/SECURITY.md`](../../../docs/SECURITY.md) (when added)
-for the full audit-feedback loop.
+(b) audit existing skills for the new gap. `docs/SECURITY.md`
+(when added) will hold the full audit-feedback loop.

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -270,13 +270,41 @@ repos:
         files: ^(tools/sandbox-lint/(src|tests|pyproject\.toml|expected\.json)|\.claude/settings\.json)
         pass_filenames: false
 
+  - repo: local
+    hooks:
+      - id: skill-validator-ruff-check
+        name: ruff check (skill-validator)
+        language: system
+        entry: uv run --directory tools/skill-validator ruff check
+        files: ^tools/skill-validator/(src|tests|pyproject\.toml)
+        pass_filenames: false
+      - id: skill-validator-ruff-format
+        name: ruff format (skill-validator)
+        language: system
+        entry: uv run --directory tools/skill-validator ruff format --check
+        files: ^tools/skill-validator/(src|tests|pyproject\.toml)
+        pass_filenames: false
+      - id: skill-validator-mypy
+        name: mypy (skill-validator)
+        language: system
+        entry: uv run --directory tools/skill-validator mypy
+        files: ^tools/skill-validator/(src|tests|pyproject\.toml)
+        pass_filenames: false
+      - id: skill-validator-pytest
+        name: pytest (skill-validator)
+        language: system
+        entry: uv run --directory tools/skill-validator pytest
+        files: ^tools/skill-validator/(src|tests|pyproject\.toml)
+        pass_filenames: false
+
   # Validate `.claude/skills/**` via the `skill-validate` CLI. Re-fires
   # on validator-source changes so rule updates get re-applied.
+  # `--project` (not `--directory`) so CWD stays at repo root.
   - repo: local
     hooks:
       - id: skill-validate
         name: skill-validate (.claude/skills/**)
         language: system
-        entry: uv run --directory tools/skill-validator skill-validate
+        entry: uv run --project tools/skill-validator skill-validate
         files: ^(\.claude/skills/.*\.md|tools/skill-validator/(src|pyproject\.toml))
         pass_filenames: false

--- a/tools/skill-validator/src/skill_validator/__init__.py
+++ b/tools/skill-validator/src/skill_validator/__init__.py
@@ -113,6 +113,10 @@ LINK_PATTERN = re.compile(r"\[([^\]]+)\]\(([^)]+)\)")
 ANCHOR_PATTERN = re.compile(r"[^\w\s-]+")
 ANCHOR_SPACE_PATTERN = re.compile(r"\s")
 
+# Skill docs use `<token>` placeholders per AGENTS.md (e.g. `<project-config>`).
+PLACEHOLDER_TOKEN_PATTERN = re.compile(r"<[A-Za-z][\w\- ]*>")
+ELLIPSIS_URLS = {"...", "…"}
+
 
 # ---------------------------------------------------------------------------
 # Data structures
@@ -240,14 +244,33 @@ def slugify(text: str) -> str:
 
 
 def extract_headings(text: str) -> set[str]:
-    """Return the set of anchor slugs for every heading in the text."""
+    """Return anchor slugs for every heading; duplicates get GitHub-style ``-N`` suffixes."""
     slugs: set[str] = set()
+    seen: dict[str, int] = {}
     for match in re.finditer(r"^(#{1,6})\s+(.+)$", text, re.MULTILINE):
-        heading_text = match.group(2).strip()
-        # Strip trailing markdown link syntax from heading text
-        heading_text = re.sub(r"\[([^\]]+)\]\([^)]+\)", r"\1", heading_text)
-        slugs.add(slugify(heading_text))
+        heading_text = re.sub(r"\[([^\]]+)\]\([^)]+\)", r"\1", match.group(2).strip())
+        base = slugify(heading_text)
+        count = seen.get(base, 0)
+        slugs.add(base if count == 0 else f"{base}-{count}")
+        seen[base] = count + 1
     return slugs
+
+
+_FENCED_CODE_RE = re.compile(r"^```[\s\S]*?^```", re.MULTILINE)
+_DOUBLE_BACKTICK_RE = re.compile(r"``[\s\S]+?``")
+_SINGLE_BACKTICK_RE = re.compile(r"`[^`\n]+`")
+
+
+def _code_spans(text: str) -> list[tuple[int, int]]:
+    """Return ``(start, end)`` ranges covering every code span in *text*."""
+    spans: list[tuple[int, int]] = []
+    for pattern in (_FENCED_CODE_RE, _DOUBLE_BACKTICK_RE):
+        spans.extend(m.span() for m in pattern.finditer(text))
+    for m in _SINGLE_BACKTICK_RE.finditer(text):
+        s, e = m.span()
+        if not any(os <= s < oe for os, oe in spans):
+            spans.append((s, e))
+    return spans
 
 
 def resolve_link(
@@ -275,6 +298,13 @@ def resolve_link(
     return target
 
 
+def is_placeholder_url(url: str) -> bool:
+    """Return True when *url* is a `<token>` placeholder or an ellipsis stand-in."""
+    if url in ELLIPSIS_URLS:
+        return True
+    return bool(PLACEHOLDER_TOKEN_PATTERN.search(url))
+
+
 def validate_links(
     path: Path,
     text: str,
@@ -283,13 +313,18 @@ def validate_links(
 ) -> Iterable[Violation]:
     """Validate all internal markdown links in a skill file."""
     headings = extract_headings(text)
+    code_spans = _code_spans(text)
 
     for match in LINK_PATTERN.finditer(text):
         url = match.group(2)
-        line_no = text[: match.start()].count("\n") + 1
+        start = match.start()
+        line_no = text[:start].count("\n") + 1
 
-        # Skip external links
+        if any(s <= start < e for s, e in code_spans):
+            continue
         if url.startswith(("http://", "https://", "mailto:")):
+            continue
+        if is_placeholder_url(url):
             continue
 
         target = resolve_link(path, url, skill_dirs, doc_files)
@@ -378,42 +413,54 @@ def validate_placeholders(path: Path, text: str) -> Iterable[Violation]:
 # ---------------------------------------------------------------------------
 
 
-def collect_files_to_check() -> list[Path]:
+def find_repo_root(start: Path | None = None) -> Path:
+    """Walk up from *start* (or CWD) until ``.claude/skills/`` is found.
+
+    Defense in depth: lets the validator work even when the entry point
+    runs from inside a subtree (e.g. ``uv run --directory``), which
+    historically caused the suite to silently scan an empty path.
+    """
+    cur = (start or Path.cwd()).resolve()
+    for candidate in (cur, *cur.parents):
+        if (candidate / SKILLS_DIR).is_dir():
+            return candidate
+    return cur
+
+
+def collect_files_to_check(root: Path | None = None) -> list[Path]:
     """Return every .md file under .claude/skills/ that should be validated."""
-    files: list[Path] = []
-    skills_base = SKILLS_DIR.resolve()
-    if skills_base.exists():
-        for p in skills_base.rglob("*.md"):
-            files.append(p)
-    return files
+    base = (root or find_repo_root()) / SKILLS_DIR
+    if not base.exists():
+        return []
+    return list(base.rglob("*.md"))
 
 
-def collect_skill_dirs() -> set[Path]:
+def collect_skill_dirs(root: Path | None = None) -> set[Path]:
     """Return the set of skill directories (immediate children of .claude/skills)."""
-    dirs: set[Path] = set()
-    if SKILLS_DIR.exists():
-        for p in SKILLS_DIR.iterdir():
-            if p.is_dir():
-                dirs.add(p.resolve())
-    return dirs
+    base = (root or find_repo_root()) / SKILLS_DIR
+    if not base.exists():
+        return set()
+    return {p.resolve() for p in base.iterdir() if p.is_dir()}
 
 
-def collect_doc_files() -> set[Path]:
+def collect_doc_files(root: Path | None = None) -> set[Path]:
     """Return every .md file under docs/ and projects/_template/."""
+    repo_root = root or find_repo_root()
     files: set[Path] = set()
-    for base in (DOCS_DIR, PROJECTS_TEMPLATE_DIR):
+    for rel in (DOCS_DIR, PROJECTS_TEMPLATE_DIR):
+        base = repo_root / rel
         if base.exists():
-            for p in base.rglob("*.md"):
-                files.add(p.resolve())
+            files.update(p.resolve() for p in base.rglob("*.md"))
     return files
 
 
-def run_validation() -> list[Violation]:
+def run_validation(root: Path | None = None) -> list[Violation]:
     """Run the full validation suite and return all violations."""
+    repo_root = root or find_repo_root()
     violations: list[Violation] = []
-    files = collect_files_to_check()
-    skill_dirs = collect_skill_dirs()
-    doc_files = collect_doc_files()
+    files = collect_files_to_check(repo_root)
+    skill_dirs = collect_skill_dirs(repo_root)
+    doc_files = collect_doc_files(repo_root)
 
     for path in files:
         try:

--- a/tools/skill-validator/tests/test_validator.py
+++ b/tools/skill-validator/tests/test_validator.py
@@ -26,6 +26,7 @@ import pytest
 from skill_validator import (
     FORBIDDEN_PATTERNS,
     extract_headings,
+    find_repo_root,
     parse_frontmatter,
     resolve_link,
     run_validation,
@@ -114,27 +115,13 @@ class TestValidateFrontmatter:
     def test_valid_mode(self, tmp_path: Path) -> None:
         path = tmp_path / "SKILL.md"
         for mode in ("Triage", "Mentoring", "Drafting", "Pairing"):
-            text = (
-                "---\n"
-                "name: foo\n"
-                "description: bar\n"
-                "license: Apache-2.0\n"
-                f"mode: {mode}\n"
-                "---\n"
-            )
+            text = f"---\nname: foo\ndescription: bar\nlicense: Apache-2.0\nmode: {mode}\n---\n"
             violations = list(validate_frontmatter(path, text))
             assert violations == [], f"mode '{mode}' should be valid"
 
     def test_invalid_mode(self, tmp_path: Path) -> None:
         path = tmp_path / "SKILL.md"
-        text = (
-            "---\n"
-            "name: foo\n"
-            "description: bar\n"
-            "license: Apache-2.0\n"
-            "mode: Auto-merge\n"
-            "---\n"
-        )
+        text = "---\nname: foo\ndescription: bar\nlicense: Apache-2.0\nmode: Auto-merge\n---\n"
         violations = list(validate_frontmatter(path, text))
         assert any("mode" in v.message and "'Auto-merge'" in v.message for v in violations)
 
@@ -166,10 +153,7 @@ class TestSlugify:
         assert slugify("A  B   C") == "a--b---c"
 
     def test_em_dash_in_heading(self) -> None:
-        assert (
-            slugify("Mentoring")
-            == "mentoring"
-        )
+        assert slugify("Mentoring") == "mentoring"
 
 
 class TestExtractHeadings:
@@ -266,6 +250,57 @@ class TestValidateLinks:
         violations = list(validate_links(path, text, set(), set()))
         assert violations == []
 
+    def test_framework_placeholder_url_ignored(self, tmp_path: Path) -> None:
+        path = tmp_path / "SKILL.md"
+        text = "[doc](<project-config>/project.md)\n[doc2](../../../<project-config>/release-trains.md)\n"
+        violations = list(validate_links(path, text, set(), set()))
+        assert violations == []
+
+    def test_template_token_url_ignored(self, tmp_path: Path) -> None:
+        path = tmp_path / "SKILL.md"
+        text = "[a](<doc_url>)\n[b](<URL into the public source>)\n"
+        violations = list(validate_links(path, text, set(), set()))
+        assert violations == []
+
+    def test_anchor_with_placeholder_ignored(self, tmp_path: Path) -> None:
+        path = tmp_path / "SKILL.md"
+        text = "[link](#issuecomment-<id>)\n[link2](other.md#issuecomment-<id>)\n"
+        violations = list(validate_links(path, text, set(), set()))
+        assert violations == []
+
+    def test_ellipsis_url_ignored(self, tmp_path: Path) -> None:
+        path = tmp_path / "SKILL.md"
+        text = "[continues](...)\n[continues](…)\n"
+        violations = list(validate_links(path, text, set(), set()))
+        assert violations == []
+
+    def test_link_inside_inline_code_ignored(self, tmp_path: Path) -> None:
+        path = tmp_path / "SKILL.md"
+        text = "Use ``[text](url)`` form for emails.\n"
+        violations = list(validate_links(path, text, set(), set()))
+        assert violations == []
+
+    def test_link_inside_single_backtick_ignored(self, tmp_path: Path) -> None:
+        path = tmp_path / "SKILL.md"
+        text = "Write `[text](missing.md)` literally.\n"
+        violations = list(validate_links(path, text, set(), set()))
+        assert violations == []
+
+    def test_link_inside_fenced_code_ignored(self, tmp_path: Path) -> None:
+        path = tmp_path / "SKILL.md"
+        text = "```\nsee [doc](missing.md) here\n```\n"
+        violations = list(validate_links(path, text, set(), set()))
+        assert violations == []
+
+    def test_duplicate_heading_anchor_resolves(self, tmp_path: Path) -> None:
+        base = tmp_path
+        source = base / "SKILL.md"
+        target = base / "other.md"
+        target.write_text("# Setup\n# Setup\n# Setup\n", encoding="utf-8")
+        text = "[a](other.md#setup)\n[b](other.md#setup-1)\n[c](other.md#setup-2)\n"
+        violations = list(validate_links(source, text, {base}, set()))
+        assert violations == []
+
 
 # ---------------------------------------------------------------------------
 # Placeholder validation
@@ -299,6 +334,23 @@ class TestValidatePlaceholders:
         text = "For example: apache/airflow is the upstream.\n"
         violations = list(validate_placeholders(path, text))
         assert violations == []
+
+
+# ---------------------------------------------------------------------------
+# Repo-root detection
+# ---------------------------------------------------------------------------
+
+
+class TestFindRepoRoot:
+    def test_locates_root_from_validator_subtree(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        # Regression: the silent-pass bug fired only when CWD was inside the validator subtree.
+        repo = Path(__file__).resolve().parents[3]
+        assert (repo / ".claude" / "skills").is_dir(), "test setup precondition"
+        monkeypatch.chdir(repo / "tools" / "skill-validator")
+        assert find_repo_root() == repo
+
+    def test_explicit_start_outside_repo(self, tmp_path: Path) -> None:
+        assert find_repo_root(tmp_path) == tmp_path.resolve()
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
* Fixes a long-standing silent-pass bug in `skill-validate`.

  which changed the working directory before startup. As a result,
  `Path(".claude/skills")` resolved inside the validator subtree,
  zero skill files were scanned, and validation falsely reported `OK`.

  This PR switches to `--project` and adds repo-root discovery as an
  additional safeguard.

* Improves validator behavior:

  * ignore `<token>` placeholder URLs
  * ignore ellipsis/example URLs (`...`, `…`)
  * ignore markdown links inside inline/fenced code blocks
  * align repeated-heading anchors with GitHub slug rules

* Adds missing prek hooks for the validator itself:

  * `ruff-check`
  * `ruff-format`
  * `mypy`
  * `pytest`

* Repairs accumulated link rot discovered once validation started
  scanning real files again (`134 -> 0` across 14 skill files),
  including moved docs paths, renamed anchors, outdated references,
  and stale heading slugs.

## Why

Previous validations reported `0 violations`, but that result came from
the silent-pass bug above. Once the validator started scanning actual
skill files again, it surfaced stale link and anchor references that
had accumulated during earlier docs and `AGENTS.md` restructures.
