### PR TITLE
docs(mission): fix "modes A–C" leftover in v1 vendor-neutrality goal

### DIFF
--- a/MISSION.md
+++ b/MISSION.md
@@ -82,7 +82,7 @@ Four design choices set the project apart from "just bolt a code-review bot on i
 - Settle on a contributor-sentiment evaluation methodology with Apache Plumb (separate proposal). Eval covers both ASF and non-ASF cohorts so the data isn't an internal-ASF artefact.
 - **Ship the privacy and security posture** as a release-blocking part of v1 — sandbox setup, clean-env wrapper, privacy-LLM gate, PII redactor, signed releases, pinned-tools manifest. Not a follow-up.
 - **Ship the maintainer-education stream** alongside v1 — pattern catalogue, "your first skill" path, first scheduled workshops. The platform is only as adoptable as the docs that go with it.
-- **Validate vendor-neutrality** in v1 pilots: at least one project running modes A–C against a frontier-model backend, one against fully-local inference (Ollama / vLLM), one against an Apache-hosted or Apache-aligned endpoint as it becomes available.
+- **Validate vendor-neutrality** in v1 pilots: at least one project running Triage, Mentoring, and Drafting against a frontier-model backend, one against fully-local inference (Ollama / vLLM), one against an Apache-hosted or Apache-aligned endpoint as it becomes available.
 
 ## Technical scope
 


### PR DESCRIPTION
## Summary

Follow-up to #99. One missed rename in `MISSION.md` line 85 — the
*"Validate vendor-neutrality in v1 pilots"* bullet still read
*"modes A–C"* after #99 renamed every other reference.

## Diff

```diff
- - **Validate vendor-neutrality** in v1 pilots: at least one project running modes A–C against a frontier-model backend, …
+ - **Validate vendor-neutrality** in v1 pilots: at least one project running Triage, Mentoring, and Drafting against a frontier-model backend, …
```

## Test plan

- [x] `grep -nE "\bModes?\s+[A-D]\b|\bmodes?\s+[A-D]\b" MISSION.md` returns no results
- [x] `prek run --files MISSION.md` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)