### PR TITLE
fix(.asf.yaml): drop scaffolded environments block (asfyaml prevent_self_review error)

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -89,18 +89,16 @@ github:
   copilot_code_review:
     enabled: false
 
-  # Deployment environments — created here so an eventual release
-  # workflow can target them without touching the GitHub UI. The
-  # `atr-release` environment scaffolds release publishing through
-  # ASF Trusted Releases (ATR); the protected-branches policy
-  # ensures only `main` (and any future protected release branches)
-  # can deploy. Required reviewers can be added later if the
-  # release flow needs PMC sign-off at deploy time.
-  environments:
-    atr-release:
-      wait_timer: 0
-      deployment_branch_policy:
-        protected_branches: true
+  # No `environments:` block by design — asfyaml's environment
+  # handler currently passes `prevent_self_review` as a kwarg to
+  # `Repository.create_environment()`, which the PyGithub version
+  # asfyaml ships does not accept ("Repository.create_environment()
+  # got an unexpected keyword argument 'prevent_self_review'"). The
+  # block is harmless to omit while no release workflow targets a
+  # deployment environment; re-add (with the `atr-release`
+  # protected-branches scaffold for ASF Trusted Releases) once the
+  # asfyaml / PyGithub interaction is fixed upstream and a release
+  # workflow exists that needs the environment.
 
   # No `protected_branches:` block by design — branch protections are
   # configured directly in GitHub for now. Add here when the project's


### PR DESCRIPTION
## Summary

asfyaml has been failing on every push with:

> An error occurred while processing the github feature in
> .asf.yaml: `Repository.create_environment() got an unexpected
> keyword argument 'prevent_self_review'`

asfyaml's environment handler now passes \`prevent_self_review\` to
PyGithub's \`Repository.create_environment()\`, but the PyGithub
version asfyaml ships doesn't accept that kwarg.

The \`environments:\` block in our \`.asf.yaml\` was **scaffolding** for an
eventual ASF-Trusted-Releases (ATR) workflow that does not exist
yet. Removing it unblocks asfyaml processing immediately and costs
nothing (no release workflow targets the env).

A comment is left in place documenting why the block is absent and
when to re-add it.

## When to re-add the block

- Upstream fix lands in \`apache/infrastructure-asfyaml\` so the
  \`prevent_self_review\` kwarg is no longer passed (or is supported by
  the PyGithub version asfyaml uses), **and**
- a release workflow exists that targets the \`atr-release\`
  deployment environment.

## Test plan

- [x] \`prek run --files .asf.yaml\` clean
- [ ] After merge: confirm next \`.asf.yaml\` processing run on
      \`infrastructure@\` shows no \`prevent_self_review\` error

🤖 Generated with [Claude Code](https://claude.com/claude-code)