### PR TITLE
chore(agent-isolation): bump bubblewrap 0.11.1 → 0.11.2

### DIFF
--- a/docs/setup/secure-agent-setup.md
+++ b/docs/setup/secure-agent-setup.md
@@ -137,7 +137,7 @@ The same flow, condensed to commands you run yourself:
 #    `tools/agent-isolation/pinned-versions.toml`; canonical
 #    section: "Required tools (pinned versions)" below.
 sudo apt-get install --no-install-recommends \
-    bubblewrap=0.11.1-* socat=1.8.1.1-*
+    bubblewrap=0.11.2-* socat=1.8.1.1-*
 npm install -g --no-save @anthropic-ai/claude-code@2.1.138
 
 # 2. Project-scope `.claude/settings.json`. Copy the framework's
@@ -193,7 +193,7 @@ The current pins live in machine-readable form in
 
 | Tool | Pinned version | Released | Cooldown | Purpose |
 |---|---|---|---|---|
-| `bubblewrap` | 0.11.1 | 2026-03-21 | 7d (default) | Linux user-namespace sandbox (filesystem layer). Required on Linux; macOS uses Seatbelt instead. |
+| `bubblewrap` | 0.11.2 | 2026-04-23 | 7d (default) | Linux user-namespace sandbox (filesystem layer). Required on Linux; macOS uses Seatbelt instead. |
 | `socat` | 1.8.1.1 | 2026-03-13 | 7d (default) | TCP relay for the sandbox network allowlist. Linux only. |
 | `claude-code` | 2.1.138 | 2026-05-09 | 1d (override) | Agent runtime. Pin separately from any system claude install so behavioural changes don't drift the framework's effective security posture without review. |
 
@@ -213,7 +213,7 @@ distro. Choose whichever applies to your host.
 ```bash
 sudo apt-get update
 sudo apt-get install --no-install-recommends \
-    bubblewrap=0.11.1-* \
+    bubblewrap=0.11.2-* \
     socat=1.8.1.1-*
 ```
 
@@ -221,7 +221,7 @@ sudo apt-get install --no-install-recommends \
 
 ```bash
 sudo dnf install \
-    bubblewrap-0.11.1 \
+    bubblewrap-0.11.2 \
     socat-1.8.1.1
 ```
 
@@ -239,7 +239,7 @@ npm install -g --no-save @anthropic-ai/claude-code@2.1.138
 
 ### Distro-specific shortcut — Linux Mint 22.x / Ubuntu 24.04 Noble
 
-The pinned versions above (bubblewrap `0.11.1`, socat `1.8.1.1`) are
+The pinned versions above (bubblewrap `0.11.2`, socat `1.8.1.1`) are
 the *upstream* releases that have aged past the framework's 7-day
 cooldown. **They are not in Ubuntu Noble's main repos** — Noble
 ships `bubblewrap 0.9.0` (`0.9.0-1ubuntu0.1`) and
@@ -266,7 +266,7 @@ sandbox flags don't depend on a specific bubblewrap version (the
 `denyRead`/`allowRead` API has been stable since `0.6.x`).
 
 The framework's `tools/agent-isolation/check-tool-updates.sh` will
-still report upstream `0.11.1` / `1.8.1.1` as the pinned versions —
+still report upstream `0.11.2` / `1.8.1.1` as the pinned versions —
 that's the manifest's view of what's *upstream-current*, not what
 your distro shipped. If you want to silence the drift, override the
 manifest locally with a `pinned-versions.local.toml` (gitignored)

--- a/tools/agent-isolation/pinned-versions.toml
+++ b/tools/agent-isolation/pinned-versions.toml
@@ -55,8 +55,8 @@
 pinned_at = "2026-05-10"
 
 [tools.bubblewrap]
-version = "0.11.1"
-released = "2026-03-21"
+version = "0.11.2"
+released = "2026-04-23"
 purpose = """
 Linux user-namespace sandbox. The strongest layer of credential
 isolation: enforces the `denyRead` / `allowRead` filesystem rules
@@ -70,10 +70,10 @@ upstream_releases = "https://api.github.com/repos/containers/bubblewrap/releases
 # Install commands per distro (use the package manager's syntax for
 # requesting a specific version where supported). See
 # `docs/setup/secure-agent-setup.md` for adopter-facing install steps.
-install.apt = "apt-get install --no-install-recommends bubblewrap=0.11.1-*"
-install.dnf = "dnf install bubblewrap-0.11.1"
+install.apt = "apt-get install --no-install-recommends bubblewrap=0.11.2-*"
+install.dnf = "dnf install bubblewrap-0.11.2"
 install.brew = "# macOS does not need bubblewrap; it uses Seatbelt."
-install.from_source = "https://github.com/containers/bubblewrap/releases/tag/v0.11.1"
+install.from_source = "https://github.com/containers/bubblewrap/releases/tag/v0.11.2"
 
 [tools.socat]
 version = "1.8.1.1"


### PR DESCRIPTION
## Summary

- Bumps the `bubblewrap` pin from 0.11.1 (released 2026-03-21) to 0.11.2 (released 2026-04-23). 0.11.2 is past the framework's default 7-day cooldown — `tools/agent-isolation/check-tool-updates.sh` flagged it on 2026-05-10.
- Updates the version + `released` fields in `pinned-versions.toml` plus all install command lines (`install.apt`, `install.dnf`, `install.from_source`).
- Mirrors the bump in `docs/setup/secure-agent-setup.md` — apt + dnf install commands (4 occurrences across the manual-install block and the per-distro install section), the "Required tools (pinned versions)" table row, and two prose references in the distro-shortcut section.
- `pinned_at` already 2026-05-10 from #107 — left as-is.
- bubblewrap is Linux-only (macOS uses Seatbelt), so this bump affects Linux hosts only.

## Test plan

- [ ] `tools/agent-isolation/check-tool-updates.sh` no longer flags `bubblewrap` as an upgrade candidate after merge.
- [ ] On a Linux host: `sudo apt-get install --no-install-recommends bubblewrap=0.11.2-*` resolves (Debian/Ubuntu), and/or `sudo dnf install bubblewrap-0.11.2` resolves (Fedora/RHEL).
- [ ] Adopters that re-fetch the snapshot via `/setup-steward upgrade` see the new pin without further intervention.

🤖 Generated with [Claude Code](https://claude.com/claude-code)