### PR TITLE
feat(triage): strip `ready for maintainer review` on regression

### DIFF
--- a/.claude/skills/pr-management-triage/actions.md
+++ b/.claude/skills/pr-management-triage/actions.md
@@ -45,18 +45,50 @@ On the `gh pr ready --undo` failing: surface the error, **do
 not** post the comment. A comment that says "converted to draft"
 on a still-open PR is a worse state than no comment at all.
 
+### If the PR carries `ready for maintainer review`
+
+The PR bypassed F4 because of post-label regression (rebase /
+push re-introduced a deterministic failure — see
+[`strip-ready-on-downgrade`](classify-and-act.md#hard-rules-cross-cutting-the-table)).
+Strip the label as the **first** mutation, before converting
+to draft, so the queue position is corrected even if a later
+step fails:
+
+```bash
+# 0. Remove the now-stale ready-for-review label (idempotent —
+#    a 422 "Label does not exist on this issue" is benign; log
+#    and continue).
+gh pr edit <N> --repo <repo> --remove-label "ready for maintainer review"
+
+# 1. Convert to draft
+gh pr ready <N> --repo <repo> --undo
+
+# 2. Post the violations comment
+gh pr comment <N> --repo <repo> --body-file /tmp/pr-<N>-draft-body.md
+```
+
+If step 0 fails with anything other than the benign "label not
+applied" / "label not found" response, surface the error and
+proceed to the draft + comment anyway — the label-removal
+failure is a soft signal (the maintainer may need to clean up
+manually), but stranding the PR in a half-state would be
+worse. The maintainer-facing preview should note when step 0
+will run so the proposal is honest about both state changes.
+
 ### If the PR is already a draft
 
 Skip the `gh pr ready --undo` step. Post only the comment. The
 decision table in [`classify-and-act.md`](classify-and-act.md)
 should have chosen `comment` instead in this case, but
-double-check here as a guard.
+double-check here as a guard. The label-removal step (when
+applicable) still runs first.
 
 ### Collaborator-authored PRs
 
 Do not draft a collaborator's PR. If somehow the action landed
 as `draft` for a collaborator, fall back to `comment` with the
-same body — no draft flip.
+same body — no draft flip. The label-removal step (when
+applicable) still runs.
 
 ---
 
@@ -78,6 +110,31 @@ gh pr comment <N> --repo <repo> --body-file /tmp/pr-<N>-comment.md
 For a `ping` action, `@`-mention every stale reviewer plus the
 PR author in the body — do not let the ping go without naming
 the people it's for.
+
+### If the PR carries `ready for maintainer review` (deterministic_flag only)
+
+When the upstream classification is `deterministic_flag` and the
+PR carries the label (regression bypass of F4 — see
+[`strip-ready-on-downgrade`](classify-and-act.md#hard-rules-cross-cutting-the-table)),
+strip the label **before** posting the comment:
+
+```bash
+# 0. Remove the now-stale ready-for-review label.
+gh pr edit <N> --repo <repo> --remove-label "ready for maintainer review"
+
+# 1. Post the violations comment
+gh pr comment <N> --repo <repo> --body-file /tmp/pr-<N>-comment.md
+```
+
+A 422 "label not applied" / "label not found" is benign — log
+and continue with the comment.
+
+This applies only to the `deterministic_flag` → `comment`
+branch (typically the collaborator-mode fallback from `draft`,
+or static-check-only failures). `stale_review` and explicit
+`ping` actions do NOT strip the label — those are transient
+signals and the ready-for-review queue position is still valid
+information for the reviewer.
 
 ---
 
@@ -452,8 +509,8 @@ For every action that includes a comment, post the comment
 
 | Action | Order |
 |---|---|
-| `draft` | convert to draft → post comment |
-| `comment` | post comment |
+| `draft` | (*if F4-regression: remove ready-for-review label*) → convert to draft → post comment |
+| `comment` | (*if F4-regression on `deterministic_flag`: remove ready-for-review label*) → post comment |
 | `close` | post comment → close → label |
 | `flag-suspicious` | post comment → close → label *(per PR in the batch)* |
 | `mark-ready` | label only |

--- a/.claude/skills/pr-management-triage/classify-and-act.md
+++ b/.claude/skills/pr-management-triage/classify-and-act.md
@@ -44,7 +44,7 @@ filter is skipped silently from the main triage flow.
 | F1 | Author is collaborator/member/owner | `authorAssociation ∈ {OWNER, MEMBER, COLLABORATOR}` (override: `authors:all` or `authors:collaborators`) |
 | F2 | Author is a known bot | login is `dependabot`, `dependabot[bot]`, `renovate[bot]`, `github-actions`, `github-actions[bot]`, or matches `*[bot]` |
 | F3 | Draft and not stale | `isDraft == true` and any activity within the last 14 days. Stale-sweep classifications in [`stale-sweeps.md`](stale-sweeps.md) may still pull the PR back in. |
-| F4 | Already marked ready, no regression | `labels` contains `ready for maintainer review` AND CI green AND `mergeable != CONFLICTING` AND no unresolved threads. Regression (any of: CI red, new conflict, new unresolved thread *after* the label was applied) bypasses this filter — surface as a regressed-passing entry so the maintainer can decide whether to pull the label. |
+| F4 | Already marked ready, no regression | `labels` contains `ready for maintainer review` AND CI green AND `mergeable != CONFLICTING` AND no unresolved threads. **Regression bypasses this filter** — any of: CI red, new conflict, or new unresolved thread whose triggering event (failing check `startedAt`, conflict detection, thread `createdAt`) is *after* the label-add timestamp. The typical case is a contributor pushing a rebase or fixup commit to a ready-for-review PR that re-introduces deterministic failures. PRs bypassing F4 fall through to the decision table normally; the cross-cutting [`strip-ready-on-downgrade` hard rule](#hard-rules-cross-cutting-the-table) ensures the label comes off if a `deterministic_flag` row fires. |
 | F5a | Recent collaborator comment (author cooldown) | Most recent comment is by a `COLLABORATOR`/`MEMBER`/`OWNER`, `createdAt < 72h` ago, AND posted after `commits(last:1).committedDate`. |
 | F5b | Maintainer-to-maintainer ping unanswered | Most recent collaborator comment `@`-mentions one or more logins other than the PR author AND none of those mentioned logins have posted on the PR or in `latestReviews` after that comment. Team mentions (e.g. `@<upstream>-committers`) are conservatively treated as F5b matches. |
 | F6 | Maintainer co-drafted | `isDraft == true` AND any of: (a) `latestReviews` has a node with `authorAssociation ∈ {OWNER, MEMBER, COLLABORATOR}` AND `author.login ≠ <viewer>` AND `state ∈ {COMMENTED, CHANGES_REQUESTED, APPROVED}` AND `submittedAt > commits(last:1).committedDate` AND review body is non-empty (avoids the "review with only inline thread comments and an empty top-level body" false positive — those are already counted by row 14/15 unresolved-thread logic); (b) `comments(last:10)` has a node with `authorAssociation ∈ {OWNER, MEMBER, COLLABORATOR}` AND `author.login ≠ <viewer>` AND `length(bodyText) ≥ 80` AND `createdAt > commits(last:1).committedDate`. Trivial signals (emoji-only, `+1`, `lgtm`, pure `@team` pings without prose) do not count — those are already covered by F5a/F5b or are below the substantive-engagement threshold. **Stale-sweep classifications in [`stale-sweeps.md`](stale-sweeps.md) may still pull the PR back in** — F6 only suppresses duplicate-proposal rows from the decision table, not eventual-resurfacing on a different action. |
@@ -116,6 +116,23 @@ Action verbs are defined in [`actions.md`](actions.md).
   Implementations evaluate row 22's precondition immediately
   before evaluating row 19; the row's table position (last) is
   documentary, not evaluation order.
+- **`strip-ready-on-downgrade`: strip `ready for maintainer
+  review` when a regressed PR matches a `deterministic_flag`
+  row.** When a PR carrying the `ready for maintainer review`
+  label bypasses [F4](#pre-filters) (rebased / pushed with new
+  deterministic failures) and matches any `deterministic_flag`
+  row whose action is `draft`, `comment`, or `close`, the
+  action MUST also remove the label. The label's contract is
+  "no maintainer time wasted on quality issues" — leaving it on
+  a PR we are now flagging *is* the false-positive the label is
+  meant to prevent, and it lets a regressed PR keep priority in
+  the review queue. Actions `rerun`, `rebase`, and `ping` do
+  NOT strip the label: those classify the regression as
+  transient (flaky CI, missing base merge, reviewer hasn't
+  responded) and the label is still informative if the
+  follow-up succeeds. Implementation: see
+  [`actions.md#draft`](actions.md#draft--convert-to-draft-and-post-violations-comment)
+  and [`actions.md#comment`](actions.md#comment--post-violations--stale-review--ping-comment).
 
 ---
 


### PR DESCRIPTION
## Summary

- F4 already bypasses the "skip already-ready" filter when a PR with the `ready for maintainer review` label regresses (CI red, new conflict, or new unresolved thread after the label was applied — typically a contributor rebasing or pushing a fixup). But no action removed the label, so regressed PRs kept queue priority while picking up the usual violations comment.
- Add a `strip-ready-on-downgrade` hard rule in `classify-and-act.md`: when a regressed PR matches a `deterministic_flag` row with action `draft` / `comment` / `close`, the action MUST also strip the label. `rerun` / `rebase` / `ping` deliberately do NOT strip — those classify the regression as transient (flaky CI, missing base merge, reviewer hasn't responded) and the label is still informative if the follow-up succeeds.
- Wire the label removal into the `draft` and `comment` action recipes in `actions.md` as an idempotent first step (`gh pr edit --remove-label "ready for maintainer review"`), with a benign-422 carve-out and an update to the order-of-operations recap. No new action verb, no new decision-table row, no comment-template change — the maintainer sees both state changes in the proposal preview and confirms once.

## Test plan

- [ ] Construct (or pick) a PR with `ready for maintainer review` whose latest push introduced a deterministic failure; run `triage pr:<N>` and verify F4's bypass surfaces it with the new combined action.
- [ ] Confirm the proposal preview shows both the label-removal step and the existing comment/draft action.
- [ ] Confirm on accept that `ready for maintainer review` is removed and the violations comment posts on the same PR.
- [ ] Spot-check the negative case: a regressed PR routed to `rerun` (e.g. flaky-only failures) keeps the label.

🤖 Generated with [Claude Code](https://claude.com/claude-code)