### PR TITLE
feat(security-cve-allocate): title-only allocation recipe

### DIFF
--- a/.claude/skills/security-cve-allocate/SKILL.md
+++ b/.claude/skills/security-cve-allocate/SKILL.md
@@ -254,10 +254,14 @@ Blocker checks — if any fail, stop and surface the failure:
 - **Scope label set.** The CVE record's `product` / `packageName`
   fields depend on the scope (`airflow` → `apache-airflow`,
   `providers` → `apache-airflow-providers-<name>`,
-  `chart` → `apache-airflow-helm-chart`). If no scope label is
-  set, stop and ask the user to confirm the scope before allocating
-  — it is **much** easier to set the right product at allocation
-  time than to correct it after the Vulnogram record has a CVE ID.
+  `chart` → `apache-airflow-helm-chart`). Allocation itself is
+  title-only and does not need the scope label, but the Step 4
+  CVE-JSON regeneration and the Step 6 sync handoff both depend on
+  it — without a scope the product / packageName cannot be mapped
+  and the record-update push that follows will be blocked. Surface
+  it as a blocker here so the user fixes it once, up front, instead
+  of being interrupted mid-flow after the CVE has already been
+  allocated.
 - **Not still `needs triage`.** If `needs triage` is still on the
   tracker, the valid/invalid decision has not been landed yet —
   allocating now would be premature. Surface as a soft warning and
@@ -349,35 +353,30 @@ one copy-paste pass:
    <stripped title>
    ```
 
-3. Fill in the rest of the form from the tracker body — the key
-   fields and where the skill reads them from:
-   - **Product**: `<product, derived from scope — see table below>`
-   - **CWE**: `<body.CWE if set, else "_No response_ — set during allocation"`>`
-   - **Affected versions**: `<body.Affected versions>`
-   - **Summary**: `<body.Short public summary for publish>`
-   - **Reporter credits**: `<body.Reporter credited as>`
-4. Click *Allocate*. Vulnogram returns a `CVE-YYYY-NNNNN` ID.
-5. Paste the allocated CVE ID back into this conversation — the
+3. Click *Allocate*. Vulnogram returns a `CVE-YYYY-NNNNN` ID.
+4. Paste the allocated CVE ID back into this conversation — the
    skill will pick it up and update the tracker automatically.
 ````
 
-Scope → Vulnogram product table: the adopting project's scope labels
-and their CVE product / package-name mappings are defined in
-[`<project-config>/scope-labels.md`](../../../<project-config>/scope-labels.md).
-Read the label off the tracker and look up the matching product /
-`packageName` there.
-
-Note in the recipe which provider / chart / task-sdk is involved
-when the scope is not bare `airflow`, so the user does not have to
-re-infer it from the tracker body at paste time.
+**Allocation is title-only.** Every other CVE-record field —
+product / `packageName`, CWE, affected versions, public summary,
+reporter credits, references — is populated later: Step 4 of this
+skill regenerates the CVE JSON from the tracker body, Step 6 hands
+off to [`security-issue-sync`](../security-issue-sync/SKILL.md) to
+reconcile the surrounding state, and the
+[`vulnogram-api-record-update`](../../../tools/vulnogram/oauth-api/README.md)
+push that follows writes the full record into Vulnogram. Do not
+ask the user to paste those fields into the allocation form — the
+form accepts a bare title and they are easier to set correctly
+during sync, after the tracker body is in its final shape.
 
 **Before printing the recipe**, ask the user *"are you an Airflow
 PMC member?"* — a one-line yes/no question. This determines which
 of two handoff paths the recipe describes:
 
 - **User is a PMC member** — the recipe is self-service: click the
-  URL, paste the stripped title, fill the form, hit *Allocate*,
-  paste the allocated `CVE-YYYY-NNNNN` back into this conversation.
+  URL, paste the stripped title, hit *Allocate*, paste the allocated
+  `CVE-YYYY-NNNNN` back into this conversation.
 - **User is NOT a PMC member** — the ASF CVE tool will not let them
   submit the allocation. Reshape the recipe into a **relay message**
   the user posts as a comment on the tracker (``@``-mentioning one
@@ -389,13 +388,13 @@ of two handoff paths the recipe describes:
   contains only:
   - the clickable allocation URL,
   - the stripped title (ready for the Vulnogram form),
-  - the derived scope / product / package-name block from Step 2,
   - one line: *"Paste the allocated `CVE-YYYY-NNNNN` back here when
     done."*
 
-  Do not restate the vulnerability, the assessment history, or the
-  handling process in the relay — the PMC member can read the
-  tracker for any of that.
+  Do not restate the vulnerability, the assessment history, the
+  scope/product mapping, or the handling process in the relay — the
+  PMC member can read the tracker for any of that, and the
+  product / packageName lands during sync anyway.
 
 The relay message is just markdown — it does not go to Vulnogram
 directly. The PMC member reads the message, clicks through, fills


### PR DESCRIPTION
## Summary

- The Vulnogram allocation form accepts a bare title — product / `packageName`, CWE, affected versions, public summary, and reporter credits are all easier to set correctly *after* the tracker body has settled, during the existing Step 6 `security-issue-sync` handoff (and the `vulnogram-api-record-update` push that follows). Drop them from Step 3's paste-into-form recipe so the user copies one field (title) and clicks *Allocate*.
- Update the non-PMC relay message in the same vein: only the URL, the stripped title, and the "paste the allocated CVE back here" line. The scope/product/package-name block is removed — the relayed PMC member doesn't need it at allocation time, and the product lands during sync anyway.
- Refresh the Step 1 scope-label blocker rationale. The check stays (sync depends on the scope), but its old "much easier to set product at allocation time than after" justification contradicts the new model and would confuse a future reader. New rationale: surface it as a blocker so the user fixes it once, up front, instead of being interrupted mid-flow when Step 4's JSON regeneration or Step 6's sync handoff can't map the product.

## Test plan

- [ ] Invoke `security-cve-allocate` on a sample tracker; confirm Step 3's printed recipe contains only the title-paste step (no Product / CWE / Affected versions / Summary / Reporter credits list).
- [ ] Confirm the non-PMC relay message no longer contains the scope/product/package-name block.
- [ ] Confirm Step 1 still surfaces a missing scope label as a blocker, with the refreshed rationale.
- [ ] Walk a real allocation end-to-end and verify Step 6's `security-issue-sync` handoff lands product / packageName / CWE / summary / credits into the CVE JSON correctly (this is the load-bearing claim of the change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)