### PR TITLE
fix(pr-management-triage): post-filter on conclusion to find action_required runs

### DIFF
--- a/.claude/skills/pr-management-triage/actions.md
+++ b/.claude/skills/pr-management-triage/actions.md
@@ -189,10 +189,14 @@ the maintainer queue fills with PRs whose CI has not actually
 executed.
 
 ```bash
-# Pre-check: index action_required runs repo-wide, then look up head SHA
+# Pre-check: index action_required runs at the head SHA.
+# Note: runs awaiting approval are returned as `status: "completed"`
+# with `conclusion: "action_required"`. The query parameter
+# `?status=action_required` matches no runs and would silently
+# return an empty result — post-filter on `conclusion` instead.
 head_sha=$(gh api "repos/<owner>/<repo>/pulls/<N>" --jq '.head.sha')
-pending=$(gh api "repos/<owner>/<repo>/actions/runs?head_sha=${head_sha}&status=action_required&per_page=10" \
-  --jq '.workflow_runs | length')
+pending=$(gh api "repos/<owner>/<repo>/actions/runs?head_sha=${head_sha}&per_page=20" \
+  --jq '[.workflow_runs[] | select(.conclusion == "action_required")] | length')
 if [ "$pending" -gt 0 ]; then
   echo "refuse mark-ready: <N> has ${pending} workflow run(s) awaiting approval at ${head_sha}" >&2
   # Reclassify: this PR is really pending_workflow_approval, route accordingly.
@@ -242,9 +246,12 @@ mark-ready'ing without context.
 
 ```bash
 # 1. Pre-check: refuse if any workflow run is awaiting approval (same as mark-ready).
+#    Runs awaiting approval surface as `status: "completed"` +
+#    `conclusion: "action_required"` — `?status=action_required` matches
+#    none of them, so post-filter on `conclusion`.
 head_sha=$(gh api "repos/<owner>/<repo>/pulls/<N>" --jq '.head.sha')
-pending=$(gh api "repos/<owner>/<repo>/actions/runs?head_sha=${head_sha}&status=action_required&per_page=10" \
-  --jq '.workflow_runs | length')
+pending=$(gh api "repos/<owner>/<repo>/actions/runs?head_sha=${head_sha}&per_page=20" \
+  --jq '[.workflow_runs[] | select(.conclusion == "action_required")] | length')
 if [ "$pending" -gt 0 ]; then
   echo "refuse mark-ready-with-ping: <N> has ${pending} workflow run(s) awaiting approval at ${head_sha}" >&2
   # Reclassify: this PR is really pending_workflow_approval.
@@ -438,12 +445,12 @@ protocol. Only after the maintainer confirms the diff looks
 non-malicious, approve:
 
 ```bash
-# List pending workflow runs for this PR
-gh api repos/<owner>/<repo>/actions/runs \
-  -X GET \
-  -f head_sha=<head_sha> \
-  -f status=action_required \
-  --jq '.workflow_runs[].id' |
+# List pending workflow runs for this PR.
+# Runs awaiting approval are returned as `status: "completed"` with
+# `conclusion: "action_required"` — `?status=action_required` matches
+# none of them. Post-filter on `conclusion` to enumerate the real set.
+gh api "repos/<owner>/<repo>/actions/runs?head_sha=<head_sha>&per_page=20" \
+  --jq '.workflow_runs[] | select(.conclusion == "action_required") | .id' |
   while read run_id; do
     gh api -X POST "repos/<owner>/<repo>/actions/runs/${run_id}/approve"
   done

--- a/.claude/skills/pr-management-triage/fetch-and-batch.md
+++ b/.claude/skills/pr-management-triage/fetch-and-batch.md
@@ -247,7 +247,8 @@ is the anti-pattern this file exists to prevent.
 Before classification runs, fetch one REST call per page:
 
 ```bash
-gh api "repos/<owner>/<repo>/actions/runs?event=pull_request&status=action_required&per_page=100"
+gh api "repos/<owner>/<repo>/actions/runs?event=pull_request&per_page=100" \
+  --jq '.workflow_runs[] | select(.conclusion == "action_required")'
 ```
 
 This lists **every** workflow run across the repo that is
@@ -255,6 +256,16 @@ awaiting maintainer approval. Index the response by `head_sha`;
 any PR on the current page whose head SHA appears in the index
 is `pending_workflow_approval` (see
 [`classify-and-act.md#decision-table`](classify-and-act.md), row 1).
+
+**Why the post-filter, not `?status=action_required`.** The
+GitHub Actions API returns runs awaiting approval as
+`status: "completed"` with `conclusion: "action_required"` (the
+run has *finished* the queueing phase and is now blocked
+pending approval). The query parameter `?status=action_required`
+matches no runs in this state and silently returns an empty
+result, which lets `pending_workflow_approval` PRs slip through
+classification as `passing`. The post-filter on `conclusion`
+is the only correct way to enumerate them.
 
 Why this is mandatory, not "fallback":
 


### PR DESCRIPTION
## Summary

The `?status=action_required` query parameter on `GET /repos/{owner}/{repo}/actions/runs` does not return runs awaiting maintainer approval. GitHub returns those runs as `status: "completed"` with `conclusion: "action_required"` (the queueing phase is finished, but the run is blocked pending approval).

The triage skill used `?status=action_required` in 4 places — none of them returned anything, which let `pending_workflow_approval` PRs slip through classification as `passing` and would have caused the `mark-ready` guard to silently fail-open.

## Empirical evidence

Hit live during a triage sweep on `apache/airflow` today: the mandatory `action_required` REST index missed 13 pending workflow runs across 4 first-time-contributor PRs (caught by the rollup-pattern Real-CI guard, but only because all 4 had no real CI in the rollup). One of the two `mark-ready`-classified PRs (#65974) had 3 pending workflow runs at its head SHA — the broken pre-check would have label-added it as ready for review.

## Changes

Replace `?status=action_required` with `?per_page=N` + jq post-filter `select(.conclusion == "action_required")` in 4 places:

- `fetch-and-batch.md` — mandatory per-page REST index
- `actions.md` — `mark-ready` pre-mutation guard
- `actions.md` — `mark-ready-with-ping` pre-mutation guard
- `actions.md` — `approve-workflow` recipe (used to discover the run IDs to approve)

Add explanatory text in `fetch-and-batch.md` and inline comments in the recipes so a future reader doesn't reintroduce the broken filter.

The `gh api -X POST .../approve` mutation itself works against runs in this state (verified: 16 successful approvals during the same triage sweep) — only the discovery query was broken.

## Test plan

- [x] Visual diff review — all 4 buggy uses replaced; explanatory text only references the broken filter to warn against it
- [x] `prek run --files` passes (markdownlint, skill-validate, etc.)
- [x] Verified the corrected jq filter returns the expected runs against `apache/airflow` (16 runs across 5 PRs)

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code (Opus 4.7)

Generated-by: Claude Code (Opus 4.7) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)