### PR TITLE
feat(pr-management-triage): add docs/spellcheck to static_check + optimistic-lock approve-workflow

### DIFF
--- a/.claude/skills/pr-management-triage/actions.md
+++ b/.claude/skills/pr-management-triage/actions.md
@@ -442,19 +442,44 @@ responsibility is clearly on the author.
 Two steps. **Inspect the diff first** — see
 [`workflow-approval.md`](workflow-approval.md) for the safety
 protocol. Only after the maintainer confirms the diff looks
-non-malicious, approve:
+non-malicious, **re-list the pending runs at action time** (the
+per-page `action_required` index built during fetch may be stale
+— another maintainer may have approved between fetch and now —
+and the optimistic-lock pattern below catches the no-op race
+without burning a useless mutation):
 
 ```bash
-# List pending workflow runs for this PR.
+# Re-list pending workflow runs for this PR at action time.
 # Runs awaiting approval are returned as `status: "completed"` with
 # `conclusion: "action_required"` — `?status=action_required` matches
 # none of them. Post-filter on `conclusion` to enumerate the real set.
-gh api "repos/<owner>/<repo>/actions/runs?head_sha=<head_sha>&per_page=20" \
-  --jq '.workflow_runs[] | select(.conclusion == "action_required") | .id' |
-  while read run_id; do
-    gh api -X POST "repos/<owner>/<repo>/actions/runs/${run_id}/approve"
-  done
+ids=$(gh api "repos/<owner>/<repo>/actions/runs?head_sha=<head_sha>&per_page=20" \
+        --jq '.workflow_runs[] | select(.conclusion == "action_required") | .id')
+
+if [ -z "$ids" ]; then
+  # Race: pending runs were approved between fetch and now (another
+  # maintainer, or auto-approval). Skip silently — the desired state
+  # ("CI is allowed to run for this contributor") is already true.
+  # Surface a one-line note to the maintainer so the no-op is visible.
+  echo "approve-workflow: no pending runs found at <head_sha> — already approved by someone else" >&2
+  exit 0
+fi
+
+while read -r run_id; do
+  [ -z "$run_id" ] && continue
+  gh api -X POST "repos/<owner>/<repo>/actions/runs/${run_id}/approve"
+done <<< "$ids"
 ```
+
+The optimistic-lock pattern is the same one
+[`mark-ready`](#mark-ready--add-ready-for-maintainer-review-label)
+uses (Golden rule 1b in [`SKILL.md`](SKILL.md)) — read the
+authoritative state immediately before mutating, exit cleanly
+if the desired state is already in place. Without it, a sweep
+that classified at T0 and acts at T0 + minutes (after the
+maintainer reviewed the diff) silently surfaces "exit=0, out=
+empty" with no guidance on whether the approval landed or
+nothing was there to approve in the first place.
 
 No comment is posted for `approve-workflow`. Approval is
 invisible to the contributor except for CI now running, which

--- a/.claude/skills/pr-management-triage/classify-and-act.md
+++ b/.claude/skills/pr-management-triage/classify-and-act.md
@@ -241,9 +241,19 @@ after that timestamp.
 Failed check name (case-insensitive substring match either
 direction) hits one of: `static check`, `pre-commit`, `lint`,
 `mypy`, `ruff`, `black`, `flake8`, `pylint`, `isort`, `bandit`,
-`codespell`, `yamllint`, `shellcheck`.
+`codespell`, `yamllint`, `shellcheck`, `spellcheck`,
+`spelling`, `build documentation`, `build docs`, `build-docs`.
 Additional patterns may be configured in
 `<project-config>/pr-management-triage-ci-check-map.md`.
+
+The doc-build / spellcheck patterns are included in the
+framework defaults because the failure mode is symmetric with
+the other static checks: the contributor introduced text the
+checker doesn't accept (a misspelled word, a broken docs
+include, a missing sphinx reference) and the fix is a code
+change, not a CI rerun. Without these patterns row 13 (`rerun`)
+fires on a single docs failure and the bot sends a useless
+rerun request that fails identically.
 
 ### `recent_main_failures`
 


### PR DESCRIPTION
## Summary

Two unrelated-but-small classifier-accuracy improvements, both prompted by misclassifications hit during the same `apache/airflow` triage sweep:

1. **Add `spellcheck`, `spelling`, `build documentation`, `build docs`, `build-docs` to the `static_check` substring list.** A docs-build / spellcheck failure is symmetric with the other static checks — the contributor introduced text the checker doesn't accept (a misspelled word, a missing sphinx reference, a broken include) and the fix is a code change. Without these patterns, row 13 (`rerun`) fires on a single docs-build failure and the bot sends a useless rerun request that fails identically.

2. **Apply the Golden Rule 1b optimistic-lock pattern to `approve-workflow` too.** Currently only `mark-ready` and `mark-ready-with-ping` re-verify state immediately before mutating. `approve-workflow` builds its run-ID list at fetch time, then mutates at action time — but maintainers spend minutes inspecting the diff between fetch and action, and another maintainer (or auto-approval) can land an approval in that window. The mutation then has nothing to approve and silently exits with empty output, leaving no signal about whether the desired state is in place. Re-listing pending runs at action time and exiting cleanly with a one-line note when the list is empty matches what `mark-ready` already does.

## Empirical evidence

- **#66509** (@IamJasonBian): single failing check `CI image checks / Build documentation (--spellcheck-only)`. Classifier picked `rerun` (row 13). The author added a word not in the wordlist; rerunning will fail identically. Manual override required to send a static-check-style comment with remediation.
- **#66065** (@petercheon, page 11) and **#66686** (@kimjune01, page 12): both classified `approve-workflow` from a fetch-time `action_required` cache hit, but at action time the pending-runs list was empty (#66065 — runs already approved by someone else between fetch and act) or non-empty (#66686 — clean approval, the more common case). The empty case in #66065 surfaced as `exit=0, out=` with no guidance — the optimistic-lock check now produces an explicit no-op message.

## Changes

`classify-and-act.md`:

- **`static_check` precondition glossary entry**: append `spellcheck`, `spelling`, `build documentation`, `build docs`, `build-docs` to the substring list. Add a short paragraph explaining the symmetry with the other static checks (a docs-build failure is a code-fix problem, not a flakiness problem).

`actions.md`:

- **`approve-workflow` recipe**: re-list pending runs at action time using the same `select(.conclusion == "action_required")` post-filter. If the list is empty, exit cleanly with a one-line note ("already approved by someone else") so the maintainer sees the no-op explicitly. Cross-references the Golden Rule 1b pattern in `SKILL.md` for symmetry with `mark-ready`.

## Test plan

- [x] Re-classified #66509 with the new `static_check` entry — now correctly routes to row 12 (`comment`) instead of row 13 (`rerun`).
- [x] Walked through the recipe by hand against #66065's situation: empty `ids` → clean exit with the no-op note, vs. previous behavior of empty stdin to the while loop with no status message.
- [x] `prek run --files` passes (markdownlint, skill-validate, typos, etc.).
- [x] No new GraphQL fields or REST endpoints required.

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code (Opus 4.7)

Generated-by: Claude Code (Opus 4.7) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)