### PR TITLE
feat(skills): add argument-hint

### DIFF
--- a/.claude/skills/pr-management-code-review/SKILL.md
+++ b/.claude/skills/pr-management-code-review/SKILL.md
@@ -12,6 +12,7 @@ when_to_use: |
   Also fires on "review my CODEOWNER PRs", "pair this PR with Codex / adversarial review", and "review the
   ready-for-maintainer-review queue". Distinct from `pr-management-triage` (which decides *whether* to engage);
   this skill runs **after** triage has produced reviewable PRs.
+argument-hint: "[pr:N] [area:LBL] [collab:true|false] [team:NAME] [ready] [dry-run]"
 license: Apache-2.0
 ---
 <!-- SPDX-License-Identifier: Apache-2.0

--- a/.claude/skills/pr-management-mentor/SKILL.md
+++ b/.claude/skills/pr-management-mentor/SKILL.md
@@ -30,6 +30,7 @@ when_to_use: |
   threads (Mentoring always hands off these), or for any thread
   where the maintainer has *deliberately* not replied yet — ask
   before invoking.
+argument-hint: "[issue-or-pr-number]"
 license: Apache-2.0
 ---
 <!-- SPDX-License-Identifier: Apache-2.0

--- a/.claude/skills/pr-management-stats/SKILL.md
+++ b/.claude/skills/pr-management-stats/SKILL.md
@@ -11,6 +11,7 @@ when_to_use: |
   variation on "give me the maintainer view of the backlog". Good as a daily
   health check, before or after a triage sweep, or as an input to a planning
   session.
+argument-hint: "[repo:owner/name] [since:date] [clear-cache]"
 license: Apache-2.0
 ---
 

--- a/.claude/skills/pr-management-triage/SKILL.md
+++ b/.claude/skills/pr-management-triage/SKILL.md
@@ -23,6 +23,7 @@ when_to_use: |
   the skill is cheap against a one-page batch (default 20 PRs)
   and is a no-op when every candidate is already triaged or inside
   its grace window.
+argument-hint: "[pr:N] [label:LBL] [author:LOGIN] [review-for-me] [stale] [repo:owner/name]"
 license: Apache-2.0
 ---
 <!-- SPDX-License-Identifier: Apache-2.0

--- a/.claude/skills/security-cve-allocate/SKILL.md
+++ b/.claude/skills/security-cve-allocate/SKILL.md
@@ -22,6 +22,7 @@ when_to_use: |
   report is valid (process step 6). Not appropriate before the
   valid/invalid decision has been landed, nor for trackers that
   already carry a CVE ID in their *CVE tool link* body field.
+argument-hint: "[issue-number] [CVE-YYYY-NNNNN]"
 license: Apache-2.0
 ---
 

--- a/.claude/skills/security-issue-deduplicate/SKILL.md
+++ b/.claude/skills/security-issue-deduplicate/SKILL.md
@@ -17,6 +17,7 @@ when_to_use: |
   ID collision) between a new report and an existing tracker. Also
   appropriate as a periodic cleanup action when a triager spots two
   open trackers describing the same bug from different angles.
+argument-hint: "[kept-issue] [duplicate-issue]"
 license: Apache-2.0
 ---
 

--- a/.claude/skills/security-issue-fix/SKILL.md
+++ b/.claude/skills/security-issue-fix/SKILL.md
@@ -23,6 +23,7 @@ when_to_use: |
   valid vulnerabilities, or for changes that require private
   code-review in `<tracker>` itself (the private-PR fallback
   in process step 9 of README.md).
+argument-hint: "[issue-number]"
 license: Apache-2.0
 ---
 

--- a/.claude/skills/security-issue-import-from-md/SKILL.md
+++ b/.claude/skills/security-issue-import-from-md/SKILL.md
@@ -22,6 +22,7 @@ when_to_use: |
   inbound report is best handled through the Gmail path
   (`security-issue-import`) or when there is a public PR to anchor
   the import on (`security-issue-import-from-pr`).
+argument-hint: "[path-to-markdown-file]"
 license: Apache-2.0
 ---
 

--- a/.claude/skills/security-issue-import-from-pr/SKILL.md
+++ b/.claude/skills/security-issue-import-from-pr/SKILL.md
@@ -20,6 +20,7 @@ when_to_use: |
   security relevance has already been agreed informally; this skill
   does not host a validity discussion. For reports that arrive on
   `<security-list>`, use `security-issue-import`.
+argument-hint: "[pr-number] [repo:owner/name]"
 license: Apache-2.0
 ---
 

--- a/.claude/skills/security-issue-import/SKILL.md
+++ b/.claude/skills/security-issue-import/SKILL.md
@@ -20,6 +20,7 @@ when_to_use: |
   no-op when every recent thread is already tracked or already
   answered-and-closed on-thread. Use `import last 30d` / `import all`
   (= 90d) for a wider backlog sweep when genuinely warranted.
+argument-hint: "[import] [last Nd|all] [skip threadId]"
 license: Apache-2.0
 ---
 

--- a/.claude/skills/security-issue-invalidate/SKILL.md
+++ b/.claude/skills/security-issue-invalidate/SKILL.md
@@ -21,6 +21,7 @@ when_to_use: |
   the advisory has already shipped (closing as invalid then is a
   retraction with public consequences and needs explicit team
   escalation).
+argument-hint: "[issue-number]"
 license: Apache-2.0
 ---
 

--- a/.claude/skills/security-issue-sync/SKILL.md
+++ b/.claude/skills/security-issue-sync/SKILL.md
@@ -15,6 +15,7 @@ when_to_use: |
   through issue NNN". Also appropriate as part of a recurring triage sweep
   where the team member wants to reconcile a batch of open issues with the
   current state of the world.
+argument-hint: "[issue-number]"
 license: Apache-2.0
 ---
 

--- a/.claude/skills/setup-override-upstream/SKILL.md
+++ b/.claude/skills/setup-override-upstream/SKILL.md
@@ -23,6 +23,7 @@ when_to_use: |
   this override", or similar — typically after running the
   override locally for a while and deciding the change is
   worth contributing back.
+argument-hint: "[skill-name]"
 license: Apache-2.0
 ---
 

--- a/.claude/skills/setup-steward/SKILL.md
+++ b/.claude/skills/setup-steward/SKILL.md
@@ -24,6 +24,7 @@ when_to_use: |
   skill that should be **copied** into an adopter's repo
   (every other framework skill is a symlink the adopt
   sub-action wires up).
+argument-hint: "[adopt|upgrade|verify|override skill-name]"
 license: Apache-2.0
 ---
 

--- a/tools/skill-validator/tests/test_validator.py
+++ b/tools/skill-validator/tests/test_validator.py
@@ -149,6 +149,22 @@ class TestValidateFrontmatter:
         violations = list(validate_frontmatter(path, text))
         assert any("truncates" in v.message and str(MAX_METADATA_CHARS) in v.message for v in violations)
 
+    def test_argument_hint_accepted(self, tmp_path: Path) -> None:
+        # argument-hint is a Claude Code autocomplete-only field; it must not be
+        # rejected as an unknown key, and it must not count toward the
+        # description+when_to_use metadata budget.
+        path = tmp_path / "SKILL.md"
+        text = (
+            "---\n"
+            "name: foo\n"
+            "description: bar\n"
+            "license: Apache-2.0\n"
+            "argument-hint: [--quick|--standard|--deep] <idea>\n"
+            "---\n"
+        )
+        violations = list(validate_frontmatter(path, text))
+        assert violations == []
+
     def test_metadata_block_scalar_indicator_not_counted(self) -> None:
         text = f"---\nname: foo\ndescription: |\n  {'a' * 100}\nlicense: Apache-2.0\n---\n"
         fm = parse_frontmatter(text)


### PR DESCRIPTION

## Summary

- Add `argument-hint` frontmatter to 14 skills across `pr-management-*`, `security-*`, and `setup-*` so Claude Code can show per-skill argument hints in slash-command autocomplete.
- Align each hint with the invocation patterns already documented in the skill body (for example: `pr-management-triage` → `[pr:N] [label:LBL] [author:LOGIN] [review-for-me] [stale] [repo:owner/name]`).
- Extend `skill-validator` with `test_argument_hint_accepted` to verify that:
  - `argument-hint` is an allowed frontmatter key
  - it is excluded from the `description + when_to_use` metadata budget calculation

## Why

`argument-hint` is a Claude Code autocomplete-only metadata field.  
Without an explicit validator test, future validator tightening could accidentally reject the key or count it toward the metadata budget. This test locks in the current behavior.

## After

<img width="1019" height="154" alt="image" src="https://github.com/user-attachments/assets/00e1d1f7-1493-47ea-82a5-adcdfe83cb34" />


<img width="1024" height="150" alt="Screenshot 2026-05-11 at 4 01 23 PM" src="https://github.com/user-attachments/assets/4a7d640d-7132-4a18-8ec3-b14ecf583040" />
