### PR TITLE
skills/pr-management-mentor: trim frontmatter to fit metadata budget

### DIFF
--- a/.claude/skills/pr-management-mentor/SKILL.md
+++ b/.claude/skills/pr-management-mentor/SKILL.md
@@ -2,34 +2,24 @@
 name: pr-management-mentor
 mode: Mentoring
 description: |
-  Draft a teaching-register comment on a single GitHub issue or
-  PR thread on the configured `<upstream>` repo (default: read
-  from `<project-config>/project.md → upstream_repo`), aimed at a
+  Draft a teaching-register comment on a single GitHub issue
+  or PR thread on the configured `<upstream>` repo, aimed at a
   contributor who is missing repo context the maintainer would
   otherwise have to spell out. The skill reads the thread,
-  decides whether a mentoring intervention is warranted, drafts
-  one comment per the project's tone guide and convention
-  pointers, runs the tone checklist, then waits for explicit
-  maintainer confirmation before posting via `gh`. Does **not**
-  triage (no labels, draft toggles, closes), review code (no
-  diff comments, approve / request-changes), or open PRs — those
-  are Triage and Drafting surfaces. Bows out and pings the
-  configured maintainer team when the thread reaches
-  `max_agent_turns`, when the contributor pushes back on a
-  substantive design point, when the topic enters
-  `out_of_scope_topics`, or when the contributor explicitly asks
-  for a human.
+  decides whether a mentoring intervention is warranted,
+  drafts one comment per the project's tone guide and
+  convention pointers, and waits for explicit maintainer
+  confirmation before posting via `gh`. Hands off to the
+  configured maintainer team on the four hand-off triggers.
 when_to_use: |
   Invoke when a maintainer says "mentor PR NNN", "help the
-  reporter on issue NNN", "draft a clarifying comment for NNN",
-  "explain the convention to this contributor on NNN", or chains
-  this skill after `pr-management-triage` flags a PR as "first
-  contributor, missing repro / convention". Not appropriate for
-  PRs already mid-review with a maintainer (the agent should
-  not talk over a human reviewer), for security-sensitive
-  threads (Mentoring always hands off these), or for any thread
-  where the maintainer has *deliberately* not replied yet — ask
-  before invoking.
+  reporter on issue NNN", "draft a clarifying comment for
+  NNN", "explain the convention to this contributor on NNN",
+  or chains this skill after `pr-management-triage` flags a PR
+  as "first contributor, missing repro / convention". Skip
+  when a PR is already mid-review with a maintainer, when the
+  thread is security-sensitive, or when the maintainer has
+  *deliberately* not replied yet — ask before invoking.
 argument-hint: "[issue-or-pr-number]"
 license: Apache-2.0
 ---


### PR DESCRIPTION
## Summary

Trims `pr-management-mentor` frontmatter (`description` + `when_to_use`) from **1,514 → 972** characters. The skill was sitting **22 characters under** Claude Code's per-skill metadata budget of 1,536 — one edit could push it over.

Same principle as #103: keep trigger phrases, short task descriptions, and routing cues in the frontmatter. Move rationale, "distinct from X" explanations, implementation details, and enumerated hand-off triggers to the body, which already covers them.

Tracking: #118

## Before / after

|              | before | after | Δ      |
|--------------|-------:|------:|-------:|
| description  | 954    | 512   | -442   |
| when_to_use  | 560    | 460   | -100   |
| **total**    | **1,514** | **972** | **-542** |
| budget margin | 22    | 564   | +542   |
| budget        | 1,536  | 1,536 |        |

## What moved where

| Detail                                                                                                | Where it lives now                                                |
|-------------------------------------------------------------------------------------------------------|-------------------------------------------------------------------|
| `<upstream>` default-resolution detail (`default: read from <project-config>/project.md → upstream_repo`) | Placeholder-convention HTML comment + `## Adopter contract`       |
| "runs the tone checklist, then waits for explicit maintainer confirmation before posting via `gh`"    | `## Runtime loop` steps 7–9                                       |
| "Does **not** triage / review code / open PRs" distinctions                                           | `## What this skill does not do` (already enumerated)             |
| Four hand-off triggers (`max_agent_turns`, design pushback, `out_of_scope_topics`, asks for human)   | `## Hand-off` section (already enumerated)                        |
| "the agent should not talk over a human reviewer"                                                     | `## Runtime loop` step 4                                          |

No body content was removed — the body already covered everything the frontmatter was duplicating.

## Trigger-phrase preservation

Every literal trigger phrase from the original `when_to_use` is preserved verbatim:

- `"mentor PR NNN"`
- `"help the reporter on issue NNN"`
- `"draft a clarifying comment for NNN"`
- `"explain the convention to this contributor on NNN"`
- chains after `pr-management-triage` flags as `"first contributor, missing repro / convention"`

Skip cues also retain their matchable substrings (`"mid-review with a maintainer"`, `"security-sensitive"`, `"*deliberately* not replied yet"`). Routing recall does not regress.