### PR TITLE
skills/security-issue-triage: trim frontmatter to fit metadata budget

### DIFF
--- a/.claude/skills/security-issue-triage/SKILL.md
+++ b/.claude/skills/security-issue-triage/SKILL.md
@@ -2,27 +2,24 @@
 name: security-issue-triage
 mode: Triage
 description: |
-  For each open `<tracker>` issue carrying the `needs triage` label,
-  read body + comments, apply the project's Security Model framing, and
-  classify the candidate disposition into one of five classes (VALID,
-  DEFENSE-IN-DEPTH, INFO-ONLY, NOT-CVE-WORTHY, PROBABLE-DUP). On user
-  confirmation posts a standalone top-level comment that invites the
-  security team to react. Read-only on tracker state — no label flips,
-  closes, body PATCHes, or CVE allocations. Composes with
-  security-issue-import (on-ramp), security-cve-allocate /
-  security-issue-invalidate / security-issue-deduplicate (post-consensus
-  actions), and security-issue-sync (applies state change after
-  consensus). Supports --retriage for re-litigating passed-triage
-  decisions when substantive new activity lands.
+  For each open `<tracker>` issue carrying the `needs triage`
+  label, read body + comments and classify the candidate
+  disposition into one of five classes: VALID, DEFENSE-IN-DEPTH,
+  INFO-ONLY, NOT-CVE-WORTHY, PROBABLE-DUP. On user confirmation,
+  posts a triage-proposal comment that invites the security team
+  to react. Read-only on tracker state — no label flips, closes,
+  or CVE allocations. Supports `--retriage` for re-litigating
+  passed-triage decisions when substantive new activity lands.
 when_to_use: |
-  Invoke when a security team member says "triage open issues", "start
-  triage discussions on the new trackers", or "propose dispositions for
-  the needs-triage queue". Also appropriate after a batch import via
-  `/security-issue-import` lands new trackers, or as a periodic sweep
-  on stale needs-triage trackers. Use --retriage when a passed-triage
-  decision needs re-litigating after new comment activity. Not
-  appropriate after team consensus on validity has already landed — at
-  that point invoke `/security-cve-allocate` (VALID),
+  Invoke when a security team member says "triage open issues",
+  "start triage discussions on the new trackers", or "propose
+  dispositions for the needs-triage queue". Also appropriate
+  after a batch import via `/security-issue-import` lands new
+  trackers, or as a periodic sweep on stale needs-triage
+  trackers. Use `--retriage` when a passed-triage decision
+  needs re-litigating after new comment activity. Skip when
+  team consensus on validity has already landed — invoke
+  `/security-cve-allocate` (VALID),
   `/security-issue-invalidate` (INFO-ONLY / NOT-CVE-WORTHY), or
   `/security-issue-deduplicate` (PROBABLE-DUP) directly.
 license: Apache-2.0


### PR DESCRIPTION
## Summary

Trims `security-issue-triage` frontmatter (`description` + `when_to_use`) from **1,405 → 1,103** characters. The skill shipped in #113 with only 131 characters of margin under Claude Code's per-skill metadata budget of 1,536.

Same principle as #103 and #119: keep trigger phrases, short task descriptions, and routing cues in the frontmatter; move rationale, sibling-skill composition details, and read-only invariant enumeration to the body, which already covers them.

Tracking: #118

## Before / after

|              | before | after | Δ      |
|--------------|-------:|------:|-------:|
| description  | 765    | 487   | -278   |
| when_to_use  | 640    | 616   | -24    |
| **total**    | **1,405** | **1,103** | **-302** |
| budget margin | 131   | 433   | +302   |
| budget        | 1,536  | 1,536 |        |

The when_to_use shrunk by only 24 chars because almost every line in it is either a literal trigger phrase or a post-consensus skip-routing cue — both must be preserved verbatim.

## What moved where

| Detail                                                                                                                                                                  | Where it lives now                              |
|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------|--------------------------------------------------|
| "apply the project's Security Model framing"                                                                                                                            | `## Golden rules` § Golden rule 4 disposition table |
| "Composes with security-issue-import (on-ramp), security-cve-allocate / -invalidate / -deduplicate (post-consensus actions), and security-issue-sync (state change)"   | `It composes with:` bullet list (top of body)   |
| "standalone top-level comment"                                                                                                                                          | Golden rule 3 (`Post these as top-level comments`) |
| "body PATCHes" from the read-only invariant                                                                                                                             | Golden rule 1 (`no body PATCH`)                 |

No body content was removed — the body already covered everything the frontmatter was duplicating.

## Trigger-phrase preservation

Every literal trigger phrase from the original `when_to_use` is preserved verbatim:

- `"triage open issues"`
- `"start triage discussions on the new trackers"`
- `"propose dispositions for the needs-triage queue"`
- `batch import via /security-issue-import lands new trackers`
- `periodic sweep on stale needs-triage trackers`
- `--retriage when a passed-triage decision needs re-litigating`

The skip-routing cues are also preserved verbatim:

- `/security-cve-allocate` (VALID)
- `/security-issue-invalidate` (INFO-ONLY / NOT-CVE-WORTHY)
- `/security-issue-deduplicate` (PROBABLE-DUP)

The five-class names (`VALID`, `DEFENSE-IN-DEPTH`, `INFO-ONLY`, `NOT-CVE-WORTHY`, `PROBABLE-DUP`) stay in the `description` because a user may say *"propose VALID for tracker NNN"*. Routing recall does not regress.