### PR TITLE
skills/setup-isolated-setup-install: trim frontmatter to fit metadata budget

### DIFF
--- a/.claude/skills/setup-isolated-setup-install/SKILL.md
+++ b/.claude/skills/setup-isolated-setup-install/SKILL.md
@@ -1,29 +1,24 @@
 ---
 name: setup-isolated-setup-install
 description: |
-  Guide an adopter through the first-time install of the framework's
-  secure agent setup — pinned system tools (`bubblewrap`, `socat`,
-  `claude-code`), the project-scope `.claude/settings.json` (sandbox
-  block, `permissions.deny` / `permissions.ask` / `allowedDomains`),
-  the `claude-iso` clean-env wrapper, the `sandbox-bypass-warn` and
-  `sandbox-status-line` user-scope hooks, and the user-scope
-  `~/.claude/settings.json` wiring that turns those hooks on. The
-  skill walks every step interactively, surfaces sudo /
-  shell-rc-edit / settings-file-overwrite operations for explicit
-  approval before applying, and never auto-runs anything
-  privilege-elevating or destructive.
+  Guide an adopter through the first-time install of the
+  framework's secure agent setup — pinned system tools
+  (`bubblewrap`, `socat`, `claude-code`), project + user-scope
+  `.claude/settings.json` wiring, the `claude-iso` clean-env
+  wrapper, and the user-scope `sandbox-bypass-warn` /
+  `sandbox-status-line` hooks. Walks every step interactively;
+  never auto-runs sudo, shell-rc edits, or settings overwrites.
 when_to_use: |
   Invoke when the user says "set up the secure agent setup",
-  "first-time install of the secure config", "install the secure
-  setup in this tracker", "walk me through the secure-agent-setup
-  install", or starts working on a fresh adopter clone where
-  neither the project nor user-scope settings carry the
-  secure-config wiring yet. Also appropriate after a fresh OS
-  install / new dev machine where `~/.claude/scripts/` is empty.
-  Do **not** invoke when the secure setup is already in place — use
-  `setup-isolated-setup-verify` (to confirm completeness) or
-  `setup-isolated-setup-update` (to refresh against the framework's
-  latest) instead.
+  "first-time install of the secure config", "install the
+  secure setup in this tracker", "walk me through the
+  secure-agent-setup install", or starts working on a fresh
+  adopter clone without secure-config wiring. Also appropriate
+  after a fresh OS install / new dev machine where
+  `~/.claude/scripts/` is empty. Skip when the secure setup is
+  already in place — use `setup-isolated-setup-verify` (to
+  confirm completeness) or `setup-isolated-setup-update` (to
+  refresh against the framework's latest) instead.
 license: Apache-2.0
 ---
 


### PR DESCRIPTION
## Summary

Trims `setup-isolated-setup-install` frontmatter (`description` + `when_to_use`) from **1,292 → 962** characters.

Same principle as #103, #119, #120: frontmatter is the routing layer. The body's `## Golden rules` section already enforces every safety constraint (no `sudo`, no shell-rc edits, no settings overwrites) and `docs/setup/secure-agent-setup.md` is the canonical install path that this skill is a thin walkthrough wrapper around.

Tracking: #118

## Before / after

|              | before | after | Δ      |
|--------------|-------:|------:|-------:|
| description  | 663    | 402   | -261   |
| when_to_use  | 629    | 560   | -69    |
| **total**    | **1,292** | **962** | **-330** |
| budget margin | 244   | 574   | +330   |
| budget        | 1,536  | 1,536 |        |

## What moved where

| Detail                                                                                                                                                                                                            | Where it lives now                                                                          |
|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------|
| `.claude/settings.json` key enumeration (`sandbox block`, `permissions.deny`, `permissions.ask`, `allowedDomains`)                                                                                                | Canonical install path at [`docs/setup/secure-agent-setup.md`](../../../docs/setup/secure-agent-setup.md) — already cross-referenced in body |
| "surfaces sudo / shell-rc-edit / settings-file-overwrite operations for explicit approval before applying, and never auto-runs anything privilege-elevating or destructive"                                       | `## Golden rules` (4 explicit bullets covering sudo, shell rc, settings overwrite, stop-on-failure) |
| "user-scope `~/.claude/settings.json` wiring that turns those hooks on" (separate phrase)                                                                                                                         | Collapsed into "project + user-scope `.claude/settings.json` wiring" in the trimmed frontmatter |

The trimmed frontmatter still names every routing-relevant component (`bubblewrap`, `socat`, `claude-code`, `claude-iso`, `sandbox-bypass-warn`, `sandbox-status-line`) so a user saying *"install bubblewrap for my Claude setup"* still routes here.

## Trigger-phrase preservation

Every literal trigger phrase from the original `when_to_use` is preserved verbatim:

- `"set up the secure agent setup"`
- `"first-time install of the secure config"`
- `"install the secure setup in this tracker"`
- `"walk me through the secure-agent-setup install"`
- "fresh OS install / new dev machine where `~/.claude/scripts/` is empty"

Skip-routing to sibling skills is preserved verbatim:

- `setup-isolated-setup-verify` (to confirm completeness)
- `setup-isolated-setup-update` (to refresh against the framework's latest)

Routing recall does not regress.