### PR TITLE
skills/security-issue-fix: trim frontmatter to fit metadata budget

### DIFF
--- a/.claude/skills/security-issue-fix/SKILL.md
+++ b/.claude/skills/security-issue-fix/SKILL.md
@@ -2,27 +2,23 @@
 name: security-issue-fix
 mode: Drafting
 description: |
-  Attempt to fix a security issue tracked in <tracker> by
-  implementing the change in a public <upstream> PR. Runs the
-  security-issue-sync skill first to reconcile the issue's state, then
-  analyses the discussion to decide whether the issue is easily fixable
-  (clear consensus, small scope, known location). If it is, proposes an
-  implementation plan, waits for explicit user confirmation, writes the
-  change in the user's local <upstream> clone, runs the local checks
-  and tests, opens a PR from the user's fork via `gh pr create --web`,
-  and updates the <tracker> tracking issue with the new PR link and any
-  relevant labels. Public PR content is checked to make sure it does
-  **not** reveal the CVE, the security nature of the change, or any link
-  back to <tracker>.
+  Attempt to fix a security issue tracked in `<tracker>` by
+  implementing the change in a public `<upstream>` PR. Runs
+  `security-issue-sync` first to reconcile the issue's state,
+  proposes an implementation plan, and on explicit user
+  confirmation writes the change, opens a PR from the user's
+  fork, and updates the `<tracker>` tracking issue. Public PR
+  content is scrubbed so it does **not** reveal the CVE, the
+  security nature of the change, or any link back to
+  `<tracker>`.
 when_to_use: |
-  Invoke when a security team member says "try to fix issue NNN", "see
-  if you can land a fix for NNN", "draft a PR for NNN", or similar —
-  *after* the issue has been triaged and the team has a rough consensus
-  on what the fix should look like. Not appropriate for issues that are
-  still being assessed, for reports that haven't been classified as
-  valid vulnerabilities, or for changes that require private
-  code-review in `<tracker>` itself (the private-PR fallback
-  in process step 9 of README.md).
+  Invoke when a security team member says "try to fix issue
+  NNN", "see if you can land a fix for NNN", "draft a PR for
+  NNN", or similar — *after* the issue has been triaged and
+  the team has a rough consensus on what the fix should look
+  like. Skip for issues still being assessed, reports not yet
+  classified as valid vulnerabilities, or changes that require
+  the private-PR fallback in process step 9 of README.md.
 argument-hint: "[issue-number]"
 license: Apache-2.0
 ---


### PR DESCRIPTION
## Summary

Trims `security-issue-fix` frontmatter (`description` + `when_to_use`) from **1,249 → 881** characters.

Same principle as #103, #119, #120, #121: frontmatter is the routing layer. The body's Golden rule already enforces that every state-changing action (writes, commits, pushes, PR open, tracker update) is a proposal requiring explicit user confirmation, and the confidentiality section already itemises every public-PR scrub requirement.

Tracking: #118

## Before / after

|              | before | after | Δ      |
|--------------|-------:|------:|-------:|
| description  | 757    | 471   | -286   |
| when_to_use  | 492    | 410   | -82    |
| **total**    | **1,249** | **881** | **-368** |
| budget margin | 287   | 655   | +368   |
| budget        | 1,536  | 1,536 |        |

## What moved where

| Detail                                                                                                                                                                                                | Where it lives now                                                                          |
|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------|
| Easily-fixable analysis rationale ("clear consensus, small scope, known location"; "If it is, proposes an implementation plan, waits for explicit user confirmation, …")                              | Body's Golden rule (state-changing actions are proposals requiring explicit confirmation)   |
| Implementation step enumeration ("writes the change in the user's local `<upstream>` clone, runs the local checks and tests, opens a PR from the user's fork via `gh pr create --web`, …")           | Body's Steps section + the sync-first composition note (L42-45)                             |

The confidentiality scrub (`not reveal the CVE`, `not the security nature of the change`, `not any link back to <tracker>`) is **kept** in the trimmed `description` — even though body L56-65 itemises it — because it is load-bearing for routing: a user asking *"draft a public PR for this CVE"* must see the scrub requirement before the agent decides to invoke this skill.

## Trigger-phrase preservation

Every literal trigger phrase from the original `when_to_use` is preserved verbatim:

- `"try to fix issue NNN"`
- `"see if you can land a fix for NNN"`
- `"draft a PR for NNN"`
- `*after* the issue has been triaged and the team has a rough consensus`

Skip cues preserved:

- `still being assessed`
- `not yet classified as valid vulnerabilities` (was *"haven't been classified as valid vulnerabilities"* — semantically identical, kept matchable substring `classified as valid vulnerabilities`)
- `private-PR fallback in process step 9 of README.md`

Routing recall does not regress.