### PR TITLE
skills/setup-steward: trim frontmatter to fit metadata budget

### DIFF
--- a/.claude/skills/setup-steward/SKILL.md
+++ b/.claude/skills/setup-steward/SKILL.md
@@ -2,17 +2,17 @@
 name: setup-steward
 description: |
   Adopt and maintain the apache-steward framework in a project
-  repo using the snapshot-based adoption mechanism. The single
-  framework artefact that lives **committed** in an adopter's
-  repo — every other framework skill is a symlink into a
-  gitignored snapshot this skill manages. Sub-actions:
+  repo via the snapshot-based adoption mechanism. The only
+  framework skill committed in an adopter's repo — every other
+  skill is a symlink the adopt sub-action wires up.
+  Sub-actions:
     `/setup-steward`         — first-time adoption (default)
     `/setup-steward upgrade` — refresh the gitignored snapshot
                                 per the committed lock
     `/setup-steward verify`  — health check + drift detection
     `/setup-steward override <skill>` — open or scaffold an
-                               agentic override for a framework
-                               skill in `.apache-steward-overrides/`
+                                agentic override in
+                                `.apache-steward-overrides/`
     `/setup-steward unadopt` — reverse the adoption (snapshot,
                                locks, symlinks, hook, doc
                                sections, this skill itself);
@@ -21,14 +21,10 @@ description: |
 when_to_use: |
   Invoke when the user says "adopt apache-steward", "adopt
   apache/airflow-steward", "set up steward in this repo",
-  "follow .claude/skills/setup-steward", or the agent
-  equivalent triggered by following the framework's README
-  adoption instructions. Also for periodic maintenance:
-  "upgrade steward", "verify steward setup", "check steward
-  drift", "the snapshot is stale". This is the only framework
-  skill that should be **copied** into an adopter's repo
-  (every other framework skill is a symlink the adopt
-  sub-action wires up).
+  "follow .claude/skills/setup-steward", or follows the
+  framework's README adoption instructions. Also for periodic
+  maintenance: "upgrade steward", "verify steward setup",
+  "check steward drift", "the snapshot is stale".
 argument-hint: "[adopt|upgrade|verify|override skill-name|unadopt]"
 license: Apache-2.0
 ---


### PR DESCRIPTION
## Summary

Trims `setup-steward` frontmatter (`description` + `when_to_use`) from **1,231 → 971** characters.

Same principle as #103, #119, #120, #121, #122: frontmatter is the routing layer. The body's opening paragraph (L45-48) already states that this skill is the only committed framework artefact and every other apache-steward skill is a gitignored symlink it manages — so the frontmatter does not need to say it twice.

Tracking: #118

## Before / after

|              | before | after | Δ      |
|--------------|-------:|------:|-------:|
| description  | 709    | 641   | -68    |
| when_to_use  | 522    | 330   | -192   |
| **total**    | **1,231** | **971** | **-260** |
| budget margin | 305   | 565   | +260   |
| budget        | 1,536  | 1,536 |        |

## What moved where

| Detail                                                                                                                                                                              | Where it lives now                                                                       |
|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|------------------------------------------------------------------------------------------|
| "into a gitignored snapshot this skill manages" (description tail)                                                                                                                  | Body L45-48 (opening paragraph: *"Every other apache-steward skill … is a gitignored symlink into the gitignored snapshot at `<snapshot-dir>` that this skill manages."*) |
| "This is the only framework skill that should be **copied** into an adopter's repo (every other framework skill is a symlink the adopt sub-action wires up)" (when_to_use tail)    | Trimmed `description` (same fact lives there: *"The only framework skill committed in an adopter's repo — every other skill is a symlink the adopt sub-action wires up."*) |
| "the agent equivalent triggered by following the framework's README adoption instructions"                                                                                          | Tightened to *"or follows the framework's README adoption instructions"* (same matchable substring) |

The description's `Sub-actions:` block is **kept verbatim** because each `/setup-steward [subcommand]` token is a CLI routing surface a user may type.

## Trigger-phrase preservation

Every literal trigger phrase from the original `when_to_use` is preserved verbatim:

**Adoption / install:**
- `"adopt apache-steward"`
- `"adopt apache/airflow-steward"`
- `"set up steward in this repo"`
- `"follow .claude/skills/setup-steward"`

**Maintenance:**
- `"upgrade steward"`
- `"verify steward setup"`
- `"check steward drift"`
- `"the snapshot is stale"`

Sub-action surfaces preserved:

- `/setup-steward` (default — first-time adoption)
- `/setup-steward upgrade`
- `/setup-steward verify`
- `/setup-steward override <skill>`

Routing recall does not regress.