### PR TITLE
skills/security-cve-allocate: trim frontmatter to fit metadata budget

### DIFF
--- a/.claude/skills/security-cve-allocate/SKILL.md
+++ b/.claude/skills/security-cve-allocate/SKILL.md
@@ -3,25 +3,21 @@ name: security-cve-allocate
 mode: Triage
 description: |
   Walk a security team member through allocating a CVE for an
-  <tracker> tracking issue. Prints the ASF Vulnogram
-  allocation URL and a CVE-ready title (the issue title stripped of
-  redundant `<vendor>: <product>:` (e.g. `Apache Airflow:`), `[ Security Report ]`, trailing
-  version parens and similar noise), waits for the allocated CVE ID
-  (allocation is PMC-gated — non-PMC triagers relay to a PMC
-  member), and then updates the tracker in place: fills in the
-  *CVE tool link* field, adds the `cve allocated` label, posts a
-  collapsed status-change comment, and runs `generate-cve-json
-  --attach` to embed the paste-ready JSON in the body. Finishes by
-  handing off to the `security-issue-sync` skill to reconcile the
-  rest of the tracker (milestone, assignee, reporter drafts, fix-PR
-  state) now that the CVE landing is complete.
+  `<tracker>` tracking issue (PMC-gated). Prints the ASF
+  Vulnogram allocation URL and a CVE-ready title, waits for
+  the allocated CVE ID, then updates the tracker in place:
+  fills in the *CVE tool link* field, adds the `cve allocated`
+  label, posts a status-change comment, and embeds the
+  paste-ready CVE JSON in the body. Hands off to
+  `security-issue-sync` to reconcile the rest of the tracker.
 when_to_use: |
-  Invoke when a security team member says "allocate a CVE for NNN",
-  "open the ASF CVE tool for NNN", "time to allocate NNN" — typically
-  after the tracker has been assessed and the team has agreed the
-  report is valid (process step 6). Not appropriate before the
-  valid/invalid decision has been landed, nor for trackers that
-  already carry a CVE ID in their *CVE tool link* body field.
+  Invoke when a security team member says "allocate a CVE for
+  NNN", "open the ASF CVE tool for NNN", "time to allocate
+  NNN" — typically after the tracker has been assessed and the
+  team has agreed the report is valid (process step 6). Skip
+  before the valid/invalid decision has landed, or for
+  trackers that already carry a CVE ID in their *CVE tool
+  link* body field.
 argument-hint: "[issue-number] [CVE-YYYY-NNNNN]"
 license: Apache-2.0
 ---


### PR DESCRIPTION
## Summary

Trims `security-cve-allocate` frontmatter (`description` + `when_to_use`) from **1,197 → 813** characters.

Same principle as #103, #119, #120, #121, #122, #123: frontmatter is the routing layer. The body already covers the title-cleanup spec, the non-PMC relay rule, the exact `generate-cve-json --attach` invocation, and the post-allocation reconciliation handed off to `security-issue-sync`.

Tracking: #118

## Before / after

|              | before | after | Δ      |
|--------------|-------:|------:|-------:|
| description  | 817    | 450   | -367   |
| when_to_use  | 380    | 363   | -17    |
| **total**    | **1,197** | **813** | **-384** |
| budget margin | 339   | 723   | +384   |
| budget        | 1,536  | 1,536 |        |

The `when_to_use` shrank by only 17 chars because nearly all of it is a literal trigger phrase or a routing skip-cue that has to stay verbatim.

## What moved where

| Detail                                                                                                                                                                                                                          | Where it lives now                                  |
|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-----------------------------------------------------|
| Title-cleanup spec (*"the issue title stripped of redundant `<vendor>: <product>:`, `[ Security Report ]`, trailing version parens and similar noise"*)                                                                       | Body Steps (CVE-ready title preparation)            |
| Non-PMC relay rule (*"allocation is PMC-gated — non-PMC triagers relay to a PMC member"*)                                                                                                                                       | Body — replaced in frontmatter by the shorter `(PMC-gated)` flag |
| Exact CLI invocation (*"runs `generate-cve-json --attach` to embed the paste-ready JSON in the body"*)                                                                                                                          | Body Steps                                          |
| Sync post-conditions (*"(milestone, assignee, reporter drafts, fix-PR state) now that the CVE landing is complete"*)                                                                                                            | `security-issue-sync`'s own frontmatter / body      |
| Comment-collapsing detail (*"collapsed status-change comment"* → *"status-change comment"*)                                                                                                                                     | Body Steps (status-change comment formatting)       |

The trimmed `description` still names every routing-relevant artefact (`ASF Vulnogram allocation URL`, `CVE-ready title`, *CVE tool link* field, `cve allocated` label, paste-ready CVE JSON, `security-issue-sync` handoff) so user phrasings like *"open the Vulnogram form for NNN"*, *"add the cve-allocated label"*, or *"generate the CVE JSON"* still route here.

## Trigger-phrase preservation

Every literal trigger phrase from the original `when_to_use` is preserved verbatim:

- `"allocate a CVE for NNN"`
- `"open the ASF CVE tool for NNN"`
- `"time to allocate NNN"`
- `(process step 6)`

Skip cues preserved:

- `before the valid/invalid decision has landed` (was *"has been landed"* — passive-voice variant; the matchable substring `valid/invalid decision` is verbatim)
- `trackers that already carry a CVE ID in their *CVE tool link* body field` (verbatim)

The `(PMC-gated)` flag is a one-word stand-in for the original parenthetical *"allocation is PMC-gated — non-PMC triagers relay to a PMC member"* — the routing distinction survives; the implementation detail of the relay flow lives in the body.

Routing recall does not regress.