### PR TITLE
skills/pr-management-triage: trim frontmatter to fit metadata budget

### DIFF
--- a/.claude/skills/pr-management-triage/SKILL.md
+++ b/.claude/skills/pr-management-triage/SKILL.md
@@ -2,27 +2,24 @@
 name: pr-management-triage
 mode: Triage
 description: |
-  Sweep open pull requests on the configured `<upstream>` repo
-  (default: read from `<project-config>/project.md →
-  upstream_repo`), classify each one against the project's quality
-  criteria, propose a disposition, and — on the maintainer's
-  confirmation — carry out the action via `gh`. Decides whether
-  each PR should be converted to draft with a quality-issues
-  comment, commented on, closed, rebased, have CI reruns
-  triggered, have a first-time-contributor workflow approved, be
-  pinged to a stale reviewer, or marked `ready for maintainer
-  review`. Does **not** perform code review (no LLM line comments,
-  no approve/request-changes submissions) — that lives in
-  [`pr-management-code-review`](../pr-management-code-review/SKILL.md).
+  Sweep open pull requests on the configured `<upstream>` repo,
+  classify each one against the project's quality criteria,
+  propose a disposition, and — on the maintainer's
+  confirmation — carry out the action via `gh`. Decides
+  whether each PR should be converted to draft, commented on,
+  closed, rebased, have CI reruns triggered, have a
+  first-time-contributor workflow approved, be pinged to a
+  stale reviewer, or marked `ready for maintainer review`.
+  Does **not** perform code review — that lives in
+  `pr-management-code-review`.
 when_to_use: |
-  Invoke when a maintainer says "triage the PR queue", "go through
-  new contributor PRs", "run the morning triage", "triage PR NNN",
-  "are there any stale PRs we should close", or any variation on
-  the "sweep the contributor PRs and tell me which ones need
-  action" theme. Also appropriate as a recurring morning sweep —
-  the skill is cheap against a one-page batch (default 20 PRs)
-  and is a no-op when every candidate is already triaged or inside
-  its grace window.
+  Invoke when a maintainer says "triage the PR queue", "go
+  through new contributor PRs", "run the morning triage",
+  "triage PR NNN", "are there any stale PRs we should close",
+  or "sweep the contributor PRs and tell me which ones need
+  action". Also appropriate as a recurring morning sweep — the
+  skill is a no-op when every candidate is already triaged or
+  inside its grace window.
 argument-hint: "[pr:N] [label:LBL] [author:LOGIN] [review-for-me] [stale] [repo:owner/name]"
 license: Apache-2.0
 ---


### PR DESCRIPTION
## Summary

Trims `pr-management-triage` frontmatter (`description` + `when_to_use`) from **1,183 → 900** characters.

Same principle as #103, #119, #120, #121, #122, #123, #124: frontmatter is the routing layer. The placeholder-convention HTML comment already covers the `<upstream>` default-resolution, the body Steps covers the convert-to-draft mechanics, and the body's page-size docs cover the one-page-batch performance note.

Tracking: #118

## Before / after

|              | before | after | Δ      |
|--------------|-------:|------:|-------:|
| description  | 725    | 524   | -201   |
| when_to_use  | 458    | 376   | -82    |
| **total**    | **1,183** | **900** | **-283** |
| budget margin | 353   | 636   | +283   |
| budget        | 1,536  | 1,536 |        |

## What moved where

| Detail                                                                                                | Where it lives now                                       |
|-------------------------------------------------------------------------------------------------------|----------------------------------------------------------|
| `(default: read from <project-config>/project.md → upstream_repo)`                                    | Placeholder-convention HTML comment at the top of the body |
| `with a quality-issues comment` (convert-to-draft annotation)                                          | Body Steps (convert-to-draft mechanics)                   |
| `(no LLM line comments, no approve/request-changes submissions)`                                       | Trimmed to *"Does **not** perform code review — that lives in `pr-management-code-review`"* — the sibling distinction is preserved; the negative-list detail is the sibling's own routing layer to advertise |
| `or any variation on the "..." theme`                                                                  | Inlined as a literal trigger ("sweep the contributor PRs and tell me which ones need action") |
| `the skill is cheap against a one-page batch (default 20 PRs)`                                         | Body's page-size docs                                     |

The action-verb routing list is **kept** in the trimmed `description` (draft / comment / close / rebase / CI rerun / first-time-contributor approve / stale-reviewer ping / `ready for maintainer review` label) — each verb is something a user might type, so every one is a routing signal.

## Trigger-phrase preservation

Every literal trigger phrase from the original `when_to_use` is preserved verbatim:

- `"triage the PR queue"`
- `"go through new contributor PRs"`
- `"run the morning triage"`
- `"triage PR NNN"`
- `"are there any stale PRs we should close"`
- `"sweep the contributor PRs and tell me which ones need action"`

Sibling distinction preserved:

- `Does **not** perform code review — that lives in pr-management-code-review`

Routing recall does not regress.