### PR TITLE
skills/security-issue-import-from-md: trim frontmatter to fit metadata budget

### DIFF
--- a/.claude/skills/security-issue-import-from-md/SKILL.md
+++ b/.claude/skills/security-issue-import-from-md/SKILL.md
@@ -2,26 +2,24 @@
 name: security-issue-import-from-md
 mode: Triage
 description: |
-  Open one or more `<tracker>` tracking issues from a markdown file
-  containing a batch of security findings (typically the output of an
-  AI security review or a third-party scanner). Each finding in the
-  file becomes one tracker, landing in the `Needs triage` board
-  column with the standard issue-template body fields populated from
-  the markdown sections. Unlike `security-issue-import` (Gmail) and
-  `security-issue-import-from-pr` (public PR), there is no inbound
-  reporter to reply to and no PR to inspect — the file itself is the
-  full report.
+  Open one or more `<tracker>` tracking issues from a markdown
+  file containing a batch of security findings (typically the
+  output of an AI security review or a third-party scanner).
+  Each finding becomes one tracker landing in the `Needs
+  triage` board column. Unlike `security-issue-import` (Gmail)
+  and `security-issue-import-from-pr` (public PR), there is no
+  inbound reporter to reply to and no PR to inspect — the file
+  itself is the full report.
 when_to_use: |
-  Invoke when a security team member says "import findings from
-  <path>", "import this scan output", "load these issues from a
-  markdown file", or hands the agent a `.md` file containing one or
-  more issue blocks separated by `---`. Typical sources: the output
-  of a `/security-review`-style AI pass over an upstream branch, a
-  third-party SAST report exported as markdown, or a security
-  consultant's findings document. Not appropriate when a single
-  inbound report is best handled through the Gmail path
-  (`security-issue-import`) or when there is a public PR to anchor
-  the import on (`security-issue-import-from-pr`).
+  Invoke when a security team member says "import findings
+  from <path>", "import this scan output", "load these issues
+  from a markdown file", or hands the agent a `.md` file with
+  one or more issue blocks separated by `---`. Typical sources:
+  AI security review output, third-party SAST report exported
+  as markdown, or a security consultant's findings document.
+  Skip when a single inbound report belongs on the Gmail path
+  (`security-issue-import`) or when there is a public PR to
+  anchor the import on (`security-issue-import-from-pr`).
 argument-hint: "[path-to-markdown-file]"
 license: Apache-2.0
 ---


### PR DESCRIPTION
## Summary

Trims `security-issue-import-from-md` frontmatter (`description` + `when_to_use`) from **1,149 → 975** characters.

Same principle as #103 and the rest of #118's audit pass: frontmatter is the routing layer. The body's sibling-comparison table (L52-59) and the standard-issue-template population details belong in the body, not the routing layer.

Tracking: #118

## Before / after

|              | before | after | Δ      |
|--------------|-------:|------:|-------:|
| description  | 539    | 444   | -95    |
| when_to_use  | 610    | 531   | -79    |
| **total**    | **1,149** | **975** | **-174** |
| budget margin | 387   | 561   | +174   |
| budget        | 1,536  | 1,536 |        |

## What moved where

| Detail                                                                                            | Where it lives now                                  |
|---------------------------------------------------------------------------------------------------|-----------------------------------------------------|
| `with the standard issue-template body fields populated from the markdown sections`               | Body Steps (issue-template field population)        |
| `the output of a /security-review-style AI pass over an upstream branch` (verbose source detail) | Tightened to `AI security review output` — the matchable substring `AI security review` survives |
| `Not appropriate when` → `Skip when`                                                              | Consistency with other trimmed skills in this audit pass |

The three sibling on-ramps (`security-issue-import`, `security-issue-import-from-pr`, this one) keep their distinguishing routing in the frontmatter: *"Gmail"*, *"public PR"*, *"the file itself is the full report"*.

## Trigger-phrase preservation

Every literal trigger phrase from the original `when_to_use` is preserved verbatim:

- `"import findings from <path>"`
- `"import this scan output"`
- `"load these issues from a markdown file"`
- *hands the agent a `.md` file with one or more issue blocks separated by `---`*

Typical-source routing signals preserved:

- *AI security review output*
- *third-party SAST report exported as markdown*
- *security consultant's findings document*

Sibling distinctions preserved verbatim:

- `security-issue-import` (Gmail path)
- `security-issue-import-from-pr` (public PR path)

Routing recall does not regress.