### PR TITLE
skills/setup-shared-config-sync: trim frontmatter to fit metadata budget

### DIFF
--- a/.claude/skills/setup-shared-config-sync/SKILL.md
+++ b/.claude/skills/setup-shared-config-sync/SKILL.md
@@ -2,26 +2,22 @@
 name: setup-shared-config-sync
 description: |
   Commit + push the user's shared Claude config to the
-  `~/.claude-config` private dotfile-style sync repo (per
-  `docs/setup/secure-agent-setup.md` → Syncing user-scope config across
-  machines). Inspects `~/.claude-config` for uncommitted local
-  edits and unpushed commits, drafts a commit message for any
-  unstaged changes, asks for explicit approval, then commits and
-  pushes. Pull-with-rebase is run *first* if the local checkout is
-  behind, so a push never overwrites concurrent work from another
-  machine. Never force-pushes; never rewrites already-pushed
-  history; never modifies a file outside `~/.claude-config/`.
+  `~/.claude-config` private dotfile-style sync repo. Inspects
+  for uncommitted local edits and unpushed commits, drafts a
+  commit message, and after explicit approval commits and
+  pushes. Runs `git pull --rebase` first if the local checkout
+  is behind, so a push never overwrites concurrent work from
+  another machine. Never force-pushes; never rewrites
+  already-pushed history; never modifies files outside
+  `~/.claude-config/`.
 when_to_use: |
   Invoke when the user says "sync my Claude config", "push my
   ~/.claude-config", "commit shared Claude config", or after
-  modifying a file that lives in `~/.claude-config/` —
-  `~/.claude-config/scripts/*.sh`,
-  `~/.claude-config/CLAUDE.md`,
-  `~/.claude-config/commands/*`, the `sync.sh` itself, etc. Also
-  appropriate after the `setup-isolated-setup-update` skill surfaces
-  drift on a script that the user keeps in `~/.claude-config/` and
-  the user wants the framework's update propagated to every
-  machine the sync repo is checked out on.
+  modifying a file in `~/.claude-config/` (scripts, CLAUDE.md,
+  commands, sync.sh). Also appropriate after
+  `setup-isolated-setup-update` surfaces drift on a script the
+  user keeps in `~/.claude-config/` and wants propagated to
+  other machines.
 license: Apache-2.0
 ---
 


### PR DESCRIPTION
## Summary

Trims `setup-shared-config-sync` frontmatter (`description` + `when_to_use`) from **1,138 → 831** characters.

Same principle as #103 and the rest of #118's audit pass: frontmatter is the routing layer. The body already cross-references `docs/setup/secure-agent-setup.md` and details the per-file flow.

Tracking: #118

## Before / after

|              | before | after | Δ      |
|--------------|-------:|------:|-------:|
| description  | 610    | 474   | -136   |
| when_to_use  | 528    | 357   | -171   |
| **total**    | **1,138** | **831** | **-307** |
| budget margin | 398   | 705   | +307   |
| budget        | 1,536  | 1,536 |        |

## What moved where

| Detail                                                                                                                       | Where it lives now                                  |
|------------------------------------------------------------------------------------------------------------------------------|-----------------------------------------------------|
| `(per docs/setup/secure-agent-setup.md → Syncing user-scope config across machines)` doc cross-reference                     | Body L34-38 (counterpart-to-sync.sh note + cross-references) |
| Explicit file glob list (`~/.claude-config/scripts/*.sh`, `~/.claude-config/CLAUDE.md`, `~/.claude-config/commands/*`, etc.) | Tightened to a categorical list: *"scripts, CLAUDE.md, commands, sync.sh"* |
| Long "Also appropriate after the `setup-isolated-setup-update` skill surfaces drift on a script that the user keeps in `~/.claude-config/` and the user wants the framework's update propagated to every machine the sync repo is checked out on" | Tightened to *"propagated to other machines"* |

## Trigger-phrase preservation

Every literal trigger phrase from the original `when_to_use` is preserved verbatim:

- `"sync my Claude config"`
- `"push my ~/.claude-config"`
- `"commit shared Claude config"`

Behavioral routing signals preserved:

- *"after modifying a file in `~/.claude-config/`"*
- *"after `setup-isolated-setup-update` surfaces drift"*

Safety rails preserved verbatim:

- *Never force-pushes; never rewrites already-pushed history; never modifies files outside `~/.claude-config/`*
- Pull-rebase-first ordering (*"`git pull --rebase` first if the local checkout is behind"*)

Routing recall does not regress.