### PR TITLE
skills/setup-override-upstream: trim frontmatter to fit metadata budget

### DIFF
--- a/.claude/skills/setup-override-upstream/SKILL.md
+++ b/.claude/skills/setup-override-upstream/SKILL.md
@@ -4,17 +4,13 @@ description: |
   Walk an adopter through promoting a local
   `.apache-steward-overrides/<skill>.md` file into a PR
   against `apache/airflow-steward`. Lists the adopter's
-  overrides, helps the user pick one, reads it alongside the
-  framework skill it modifies, helps decide whether the
-  change is generalisable (some overrides encode project-
-  specific decisions and should stay local), designs the
-  framework-level abstraction (configurable parameter,
-  optional step, changed default, etc.), implements it in
-  the user's local apache-steward clone, runs the
-  framework's pre-commit, and opens the PR. After the PR
-  merges and the adopter runs `/setup-steward upgrade`, the
-  override file in the adopter repo is no longer needed and
-  the skill prompts for its removal.
+  overrides, helps pick one, reads it alongside the framework
+  skill it modifies, decides whether the change is
+  generalisable, designs the framework-level abstraction,
+  implements it in the user's local apache-steward clone, and
+  opens the PR. After the PR merges and the adopter runs
+  `/setup-steward upgrade`, the override file is no longer
+  needed and the skill prompts for its removal.
 when_to_use: |
   Invoke when the user says "upstream my override", "promote
   this override to the framework", "convert my local


### PR DESCRIPTION
## Summary

Trims `setup-override-upstream` frontmatter (`description` + `when_to_use`) from **1,096 → 892** characters.

Same principle as #103 and the rest of #118's audit pass: frontmatter is the routing layer. The body covers the generalisability test, the design-decision example list, and the pre-commit step.

Tracking: #118

## Before / after

|              | before | after | Δ      |
|--------------|-------:|------:|-------:|
| description  | 736    | 532   | -204   |
| when_to_use  | 360    | 360   | 0      |
| **total**    | **1,096** | **892** | **-204** |
| budget margin | 440   | 644   | +204   |
| budget        | 1,536  | 1,536 |        |

`when_to_use` is untouched — every line is either a literal trigger phrase or a routing skip cue (*"typically after running the override locally for a while"*) and has to stay verbatim.

## What moved where

| Detail                                                                                                              | Where it lives now                            |
|---------------------------------------------------------------------------------------------------------------------|-----------------------------------------------|
| `(some overrides encode project-specific decisions and should stay local)` (rationale parenthetical)                | Body's generalisability discussion           |
| `(configurable parameter, optional step, changed default, etc.)` (abstraction-example list)                         | Body's design-decision section                |
| `runs the framework's pre-commit` (implementation detail)                                                            | Body Walk-through / standard project workflow |

The post-merge override-removal flow (*"After the PR merges and the adopter runs `/setup-steward upgrade`, the override file is no longer needed and the skill prompts for its removal"*) is **kept** in the frontmatter — it is the only routing signal that tells the agent this skill cleans up after itself.

## Trigger-phrase preservation

Every literal trigger phrase from the original `when_to_use` is preserved verbatim:

- `"upstream my override"`
- `"promote this override to the framework"`
- `"convert my local modification into a steward feature"`
- `"make this override a framework feature"`
- `"open a PR to apache-steward for this override"`

Routing skip cue preserved:

- *"typically after running the override locally for a while and deciding the change is worth contributing back"*

Routing recall does not regress.