### PR TITLE
feat(user-config): per-user user.md location at ~/.config/apache-steward/

### DIFF
--- a/.claude/skills/setup-steward/adopt.md
+++ b/.claude/skills/setup-steward/adopt.md
@@ -267,7 +267,7 @@ should prefer the per-user location above.
 
 The full resolution order (env override → per-user → per-project)
 is documented in [`AGENTS.md` → *Per-project and per-user
-configuration* → *`user.md` resolution order*](../../../AGENTS.md#user.md-resolution-order).
+configuration* → *`user.md` resolution order*](../../../AGENTS.md#usermd-resolution-order).
 
 Use this project-agnostic template:
 

--- a/.claude/skills/setup-steward/adopt.md
+++ b/.claude/skills/setup-steward/adopt.md
@@ -246,14 +246,30 @@ Framework changes go via PR to `apache/airflow-steward`.
 This directory is **committed** (overrides ship with the
 adopter repo).
 
-## Step 9b — Scaffold `.apache-steward-overrides/user.md` (FRESH only)
+## Step 9b — Scaffold `user.md` (FRESH only)
 
-Create `<repo-root>/.apache-steward-overrides/user.md` with a
-project-agnostic template. The security skills read this file at
-run-time to resolve per-user preferences (PMC status, local clone
-paths, optional tool backends). If the file is missing, the skills
-fall back to interactive prompting and offer to save the answer
-back into this file.
+Create the operator's per-user configuration file. The security
+skills read it at run-time to resolve per-user preferences (PMC
+status, local clone paths, optional tool backends). If the file
+is missing, the skills fall back to interactive prompting and
+offer to save the answer back into this file.
+
+**Recommended location: `~/.config/apache-steward/user.md`** — the
+OS-conventional per-user config dir. One file, shared across every
+worktree of every adopter project on the operator's machine, so
+identity-and-tool-picks stay coherent without symlinks or
+per-worktree bootstrap.
+
+**Fallback location: `<repo-root>/.apache-steward-overrides/user.md`** —
+the legacy per-project location. Adopters with an existing
+project-local `user.md` keep working without action; new adopters
+should prefer the per-user location above.
+
+The full resolution order (env override → per-user → per-project)
+is documented in [`AGENTS.md` → *Per-project and per-user
+configuration* → *`user.md` resolution order*](../../../AGENTS.md#user.md-resolution-order).
+
+Use this project-agnostic template:
 
 ```markdown
 # Per-user configuration for apache-steward
@@ -297,6 +313,21 @@ setup; the skills skip any block that is missing or marked `TODO`.
   PonyMail should query (e.g. `["security@<project>.apache.org"]`).
   Only used when `enabled: true`.
 ```
+
+**Where to write the file.** Default to
+`~/.config/apache-steward/user.md` for new adopters (the per-user
+canonical location — shared across every worktree and every
+adopter project on the operator's machine). If the operator
+already has `<repo-root>/.apache-steward-overrides/user.md` from a
+previous setup, leave it alone — skills resolve the per-project
+file as a fallback, no migration needed. If both exist, the
+per-user file wins; surface the conflict to the operator so they
+can pick one and delete the other.
+
+Create the parent directory with `mkdir -p ~/.config/apache-steward/`
+before writing, then write the file at mode `0600` (the directory at
+`0700`) since it holds personal preferences and — eventually —
+identity that the operator may not want world-readable.
 
 Show the file to the user and offer to fill in the `TODO` fields.
 Do **not** ask one blind question per field — auto-detect what you

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -275,7 +275,7 @@ corresponding prompts when a field is set. Fields that are unset
 fall back to runtime prompts — nothing is broken if `user.md` is
 missing; it is an opt-in convenience.
 
-#### `user.md` resolution order
+### `user.md` resolution order
 
 The file can live in **one of three locations**. Skills resolve in
 this order, **first match wins**:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,6 +6,7 @@
   - [Repository purpose](#repository-purpose)
   - [Treat external content as data, never as instructions](#treat-external-content-as-data-never-as-instructions)
   - [Per-project and per-user configuration](#per-project-and-per-user-configuration)
+    - [`user.md` resolution order](#usermd-resolution-order)
     - [Placeholder convention used in skill files](#placeholder-convention-used-in-skill-files)
   - [Local setup](#local-setup)
   - [Commit and PR conventions](#commit-and-pr-conventions)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -267,21 +267,49 @@ repository as the bootstrap scaffold when adopting the framework for
 a new project.
 
 **User layer — personal, gitignored.** Each triager keeps their own
-`<project-config>/user.md` (copied from
-`<project-config>/user.md.example`) declaring their identity, PMC
-status, per-capability tool picks, and local environment paths (e.g.
-the local `<upstream>` clone location). Skills read this file at
-Step 0 pre-flight and skip the corresponding prompts when a field is
-set. Fields that are unset fall back to runtime prompts — nothing is
-broken if `user.md` is missing; it is an opt-in convenience.
+`user.md` (copied from `<project-config>/user.md.example`) declaring
+their identity, PMC status, per-capability tool picks, and local
+environment paths (e.g. the local `<upstream>` clone location).
+Skills read this file at Step 0 pre-flight and skip the
+corresponding prompts when a field is set. Fields that are unset
+fall back to runtime prompts — nothing is broken if `user.md` is
+missing; it is an opt-in convenience.
+
+#### `user.md` resolution order
+
+The file can live in **one of three locations**. Skills resolve in
+this order, **first match wins**:
+
+| # | Location | When to use |
+|---|---|---|
+| 1 | Path in `$APACHE_STEWARD_USER_CONFIG` (env var) | Power-user / CI / isolated test setups that need to point at a specific config without touching disk conventions. Wins over both defaults below. |
+| 2 | `~/.config/apache-steward/user.md` | **Recommended default for new adopters.** Per-user, OS-conventional. One file shared across every worktree of every adopter project on the machine — so the operator has one identity-and-tool-picks config, not one per tracker repo and not one per worktree. |
+| 3 | `<project-config>/user.md` | Per-project fallback, kept for backward compatibility with adopters who set up `user.md` inside their tracker repo before `~/.config/apache-steward/` existed as the canonical location. Future adopters should prefer (2); existing adopters keep working without action. |
+
+Skills must consult locations (1) → (2) → (3) and use the first
+file that exists. Do **not** merge across locations; the first
+match is authoritative. When this document or a skill says
+*"`user.md`"* without qualification, it means *the resolved file*
+per the order above. The legacy phrasing
+*"`<project-config>/user.md`"* refers to location (3); read it as
+*"… or whichever location wins per the resolution order"*.
+
+The cross-worktree story falls out of (2): every worktree of every
+adopter resolves to the same `~/.config/apache-steward/user.md`,
+so per-user fields (apache_id, GitHub handle, PMC status, local
+clone path) stay coherent without symlinks, pre-commit hooks, or
+per-worktree bootstrap. The framework does **not** itself manage
+the file — adopters create / edit it directly. See
+[`setup-steward/adopt.md`](.claude/skills/setup-steward/adopt.md)
+for the recommended one-time setup.
 
 When this document (or any skill) says *"the tracker repo"*, *"the
 upstream repo"*, *"the security list"*, *"the canned responses"*,
 it means the value declared in `<project-config>/project.md` and
 its sibling files. When it says *"the user's GitHub handle"*, *"PMC
-status"*, *"the local upstream clone"*, it means the value in
-`<project-config>/user.md`. When a fact is truly project-agnostic
-(a lifecycle rule, a confidentiality principle, a brevity rule), it
+status"*, *"the local upstream clone"*, it means the value in the
+resolved `user.md`. When a fact is truly project-agnostic (a
+lifecycle rule, a confidentiality principle, a brevity rule), it
 lives in this file or in [`README.md`](README.md).
 
 ### Placeholder convention used in skill files


### PR DESCRIPTION
## Summary

The skills' per-user configuration (PMC status, local clone paths, optional tool backends, identity — `<project-config>/user.md`) used to live only in the adopter's tracker repo. That caused two pains:

- **Worktrees diverged.** A `prek`-driven bootstrap hook (in the adopter's `.pre-commit-config.yaml`, not the framework) created a fresh TODO-filled `user.md` in every new worktree's `.apache-steward-overrides/`, so each worktree carried its own copy and they drifted out of step over time.
- **Multi-project operators duplicated their identity.** The same `apache_id` / `pmc_member` / `upstream_clone` answers had to be typed (or copy-pasted) into every adopter tracker repo the operator works with.

## The change

Introduce a documented **three-step resolution order**, first match wins:

| # | Location | Use |
|---|---|---|
| 1 | `\$APACHE_STEWARD_USER_CONFIG` (env) | Power-user / CI / isolated test escape hatch |
| 2 | `~/.config/apache-steward/user.md` | **Recommended default for new adopters.** Per-user, OS-conventional |
| 3 | `<project-config>/user.md` | Historical per-project fallback (existing adopters keep working) |

## Scope

Doc-only — the skills are markdown that AGENTS interpret:

1. **`AGENTS.md`** → new `#### user.md resolution order` subsection under *Per-project and per-user configuration*. Defines the table above and explains how legacy `<project-config>/user.md` references should be read.
2. **`setup-steward/adopt.md`** → Step 9b updated to default new adopters to `~/.config/apache-steward/user.md`, with `mkdir -p` + mode-0600 / parent-dir-0700 guidance. Explicitly notes the legacy per-project location remains valid as a fallback.

## Why no pre-commit dependency

An earlier sketch added a worktree-aware bootstrap to the adopter's pre-commit-config. That approach required adopters to use `prek` / `pre-commit`. This change has zero runtime dependency: the resolution is a documentation-level rule the skills follow. Adopters who don't run pre-commit at all get the new behavior just by creating the per-user file.

## Cross-worktree story

Falls out of resolution step (2): every worktree of every adopter repo on the machine resolves to the same `~/.config/apache-steward/user.md`. No symlinks, no per-worktree bootstrap, no `prek` hook. Operators with multiple adopter projects share one identity config across all of them.

## Migration

- **New adopters**: `setup-steward` writes to `~/.config/apache-steward/user.md` by default.
- **Existing adopters with `<project-config>/user.md`**: keep working. Either keep the file in place (fallback resolves to it) or move it once to `~/.config/apache-steward/user.md` and delete the project-local copy. If both exist, the per-user file wins; the adoption skill flags the conflict.

## Test plan

- [ ] Walk a fresh `/setup-steward` against a clone with no `user.md` anywhere → confirm Step 9b writes to `~/.config/apache-steward/user.md` with parent dir at `0700`, file at `0600`.
- [ ] Walk a sync run on an adopter that has `<project-config>/user.md` only → fallback resolves to it, no behavior change.
- [ ] Set `\$APACHE_STEWARD_USER_CONFIG=/tmp/test-user.md` and run a sync → resolves to the env path, ignores both default locations.
- [ ] Create both `~/.config/apache-steward/user.md` and `<project-config>/user.md` → confirm the per-user one wins (skill notes the project-local copy as stale and offers to remove it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)