### PR TITLE
docs(mission): add Ismael Mejia and Zili Chen (tison) to PMC roster

### DIFF
--- a/MISSION.md
+++ b/MISSION.md
@@ -176,6 +176,8 @@ ASF members for the roster:
 - Paul King — Groovy PMC, Grails PMC, Incubator PMC
 - Evan Rusackas — Superset PMC
 - Russell Spitzer — Incubator PMC, Polaris PMC, Iceberg PMC
+- Ismael Mejia — Beam PMC, Incubator PMC
+- Zili Chen (tison) — Pulsar PMC, Curator PMC, ZooKeeper PMC, …
 
 The named PMC roster will accompany the resolution at the time of vote.
 


### PR DESCRIPTION
## Summary

Both Ismael Mejia and Zili Chen (tison) got back to me after the
founding-PMC kickoff thread (\"[Steward (to be renamed)] Founding PMC
kickoff — and the road to the 20 May Board\") saying yes — adding
them to the ASF-members roster in MISSION.md so they're on the
final list that accompanies the Board resolution.

## Diff

\`\`\`diff
 - Evan Rusackas — Superset PMC
 - Russell Spitzer — Incubator PMC, Polaris PMC, Iceberg PMC
+- Ismael Mejia — Beam PMC, Incubator PMC
+- Zili Chen (tison) — Pulsar PMC, Curator PMC, ZooKeeper PMC, …
\`\`\`

## PMC affiliations — best-known guesses

Listed as best-known. **Ismael / tison — please correct in review if the listing is off**, particularly:

- Ismael Mejia — listed as *Beam PMC, Incubator PMC*. Want any other PMCs surfaced?
- Zili Chen (tison) — listed as *Pulsar PMC, Curator PMC, ZooKeeper PMC, …* (with trailing ellipsis like JBO's entry, since tison has a long list). Want specific PMCs called out, or keep the ellipsis?

## What this PR does **not** touch

The \`.asf.yaml\` collaborators block is at the **ASF Infra cap of 10 entries** (the comment in the file flags this — exceptions require a vp-infra@apache.org request). Adding two more would put us at 12. Two ways to handle:

1. **Leave as-is** (this PR) — Ismael and tison can be granted triage rights via their apache GitHub org membership when they start working on this repo, without an Infra exception.
2. **Bump the cap** — separate PR, file the vp-infra@ ticket. If the working group prefers explicit \`.asf.yaml\` collaborator entries for all non-Airflow-committer founding-PMC members (the pattern used for Russell / JBO / Justin / etc.), this is the path.

I went with (1) here for the simplest landing. Happy to follow up with (2) in a separate PR if the working group wants the explicit entries.

## Test plan

- [x] \`prek run --files MISSION.md\` clean
- [ ] Ismael / tison confirm PMC affiliations
- [ ] Decide on \`.asf.yaml\` collaborator-cap follow-up (separate PR if needed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)