### PR TITLE
docs(mission): add James Fredley to PMC roster

### DIFF
--- a/MISSION.md
+++ b/MISSION.md
@@ -178,6 +178,7 @@ ASF members for the roster:
 - Russell Spitzer — Incubator PMC, Polaris PMC, Iceberg PMC
 - Ismael Mejia — Beam PMC, Incubator PMC
 - Zili Chen (tison) — Pulsar PMC, Curator PMC, ZooKeeper PMC, …
+- James Fredley — Grails PMC
 
 The named PMC roster will accompany the resolution at the time of vote.
 


### PR DESCRIPTION
## Summary

Follow-up to #138 (Ismael Mejia + Zili Chen / tison).

James Fredley got back to me after I reached out — adding him to
the ASF-members roster in MISSION.md as the **last addition** to
the founding PMC ahead of the Tuesday EOD naming-bikeshed
deadline.

## Diff

\`\`\`diff
 - Zili Chen (tison) — Pulsar PMC, Curator PMC, ZooKeeper PMC, …
+- James Fredley — Grails PMC
\`\`\`

## Why James

James is VP of Apache Grails and the author of the *"Generated-by:"*
git-trailer convention this project uses on every Claude-assisted
commit. He proposed it on ai-discuss@ in April; we ratified it on
legal-discuss@ shortly after; it now lands in this repo as a
pre-committed hard-enforced pre-commit hook (\`no-coauthored-by.sh\`).

## What this PR does **not** touch

Same \`.asf.yaml\` cap caveat as #138 — the collaborators block is
at the ASF Infra cap of 10 entries and bumping it requires a
vp-infra@apache.org request. Leaving as-is; James, as an ASF
member, gets triage rights via the apache GitHub org.

## Test plan

- [x] \`prek run --files MISSION.md\` clean
- [ ] James confirms his preferred PMC affiliation listing

🤖 Generated with [Claude Code](https://claude.com/claude-code)