### PR TITLE
skills: clear 24 frontmatter SOFT warnings, no routing-recall loss

### DIFF
--- a/.claude/skills/pr-management-code-review/SKILL.md
+++ b/.claude/skills/pr-management-code-review/SKILL.md
@@ -5,13 +5,13 @@ description: |
   Walk a maintainer through deep, sequential code review of open pull requests on the configured `<upstream>` repo.
   Defaults to the **"my reviews"** queue (the union of five maintainer signals — see the Inputs table); selectors can
   narrow to a single PR, an area label, or a collaborator subset. Drafts an `approve` / `request-changes` / `comment`
-  review per PR and posts on the maintainer's confirmation. Deep-review counterpart to the triage skill.
+  review per PR and posts on the maintainer's confirmation.
 when_to_use: |
   Invoke when a maintainer says "review my PRs", "go through my review queue", "review PR NNN", "review the
   area:scheduler PRs", "do my review pass", or any variation on "look over PRs I'm responsible for, one at a time."
   Also fires on "review my CODEOWNER PRs", "pair this PR with Codex / adversarial review", and "review the
-  ready-for-maintainer-review queue". Distinct from `pr-management-triage` (which decides *whether* to engage);
-  this skill runs **after** triage has produced reviewable PRs.
+  ready-for-maintainer-review queue". Use after `pr-management-triage` has produced reviewable PRs; skip when triage
+  has not yet engaged the PR.
 argument-hint: "[pr:N] [area:LBL] [collab:true|false] [team:NAME] [ready] [dry-run]"
 license: Apache-2.0
 ---

--- a/.claude/skills/pr-management-mentor/SKILL.md
+++ b/.claude/skills/pr-management-mentor/SKILL.md
@@ -9,7 +9,7 @@ description: |
   decides whether a mentoring intervention is warranted,
   drafts one comment per the project's tone guide and
   convention pointers, and waits for explicit maintainer
-  confirmation before posting via `gh`. Hands off to the
+  confirmation before posting via `gh`. Escalates to the
   configured maintainer team on the four hand-off triggers.
 when_to_use: |
   Invoke when a maintainer says "mentor PR NNN", "help the

--- a/.claude/skills/pr-management-triage/SKILL.md
+++ b/.claude/skills/pr-management-triage/SKILL.md
@@ -5,13 +5,11 @@ description: |
   Sweep open pull requests on the configured `<upstream>` repo,
   classify each one against the project's quality criteria,
   propose a disposition, and — on the maintainer's
-  confirmation — carry out the action via `gh`. Decides
-  whether each PR should be converted to draft, commented on,
-  closed, rebased, have CI reruns triggered, have a
-  first-time-contributor workflow approved, be pinged to a
-  stale reviewer, or marked `ready for maintainer review`.
-  Does **not** perform code review — that lives in
-  `pr-management-code-review`.
+  confirmation — carry out the action via `gh`. Disposition
+  options per PR: draft / comment / close / rebase / CI-rerun
+  / workflow-approve / ping-stale-reviewer / mark `ready for
+  maintainer review`. Does **not** perform code review — that
+  lives in `pr-management-code-review`.
 when_to_use: |
   Invoke when a maintainer says "triage the PR queue", "go
   through new contributor PRs", "run the morning triage",

--- a/.claude/skills/security-cve-allocate/SKILL.md
+++ b/.claude/skills/security-cve-allocate/SKILL.md
@@ -4,20 +4,18 @@ mode: Triage
 description: |
   Walk a security team member through allocating a CVE for an
   `<tracker>` tracking issue (PMC-gated). Prints the ASF
-  Vulnogram allocation URL and a CVE-ready title, waits for
-  the allocated CVE ID, then updates the tracker in place:
-  fills in the *CVE tool link* field, adds the `cve allocated`
-  label, posts a status-change comment, and embeds the
-  paste-ready CVE JSON in the body. Hands off to
-  `security-issue-sync` to reconcile the rest of the tracker.
+  Vulnogram allocation URL, waits for the allocated CVE ID,
+  then updates the tracker in place. Tracker updates: CVE tool
+  link field, cve allocated label, status-change comment, CVE
+  JSON. Chains into `security-issue-sync` afterwards to
+  reconcile the rest of the tracker.
 when_to_use: |
   Invoke when a security team member says "allocate a CVE for
   NNN", "open the ASF CVE tool for NNN", "time to allocate
   NNN" — typically after the tracker has been assessed and the
-  team has agreed the report is valid (process step 6). Skip
-  before the valid/invalid decision has landed, or for
-  trackers that already carry a CVE ID in their *CVE tool
-  link* body field.
+  team has agreed the report is valid. Skip before the
+  valid/invalid decision has landed, or for trackers that
+  already carry a CVE ID in their *CVE tool link* body field.
 argument-hint: "[issue-number] [CVE-YYYY-NNNNN]"
 license: Apache-2.0
 ---

--- a/.claude/skills/security-issue-deduplicate/SKILL.md
+++ b/.claude/skills/security-issue-deduplicate/SKILL.md
@@ -3,18 +3,16 @@ name: security-issue-deduplicate
 mode: Triage
 description: |
   Merge two <tracker> tracking issues that describe the same
-  root-cause vulnerability (typically discovered independently by two
-  reporters, arriving via different channels), preserving every
-  reporter's credit, every mailing-list thread reference, and every
-  independent attack-vector description. Updates the kept issue's body
-  in place, closes the duplicate with the `duplicate` label, and
-  regenerates the CVE JSON attachment so both finders land in
-  `credits[]`.
+  root-cause vulnerability, preserving every reporter's credit,
+  every mailing-list thread reference, and every independent
+  attack-vector description. Updates the kept issue's body in place,
+  closes the duplicate with the `duplicate` label, and regenerates
+  the CVE JSON attachment so both finders land in `credits[]`.
 when_to_use: |
   Invoke when a security team member says "dedupe #NNN and #MMM",
   "merge #MMM into #NNN", "#MMM is a duplicate of #NNN", or when the
-  security-issue-import skill's Step 2a surfaces a STRONG match (GHSA
-  ID collision) between a new report and an existing tracker. Also
+  security-issue-import skill surfaces a STRONG match (GHSA ID
+  collision) between a new report and an existing tracker. Also
   appropriate as a periodic cleanup action when a triager spots two
   open trackers describing the same bug from different angles.
 argument-hint: "[kept-issue] [duplicate-issue]"

--- a/.claude/skills/security-issue-fix/SKILL.md
+++ b/.claude/skills/security-issue-fix/SKILL.md
@@ -18,7 +18,7 @@ when_to_use: |
   the team has a rough consensus on what the fix should look
   like. Skip for issues still being assessed, reports not yet
   classified as valid vulnerabilities, or changes that require
-  the private-PR fallback in process step 9 of README.md.
+  the private-PR fallback path.
 argument-hint: "[issue-number]"
 license: Apache-2.0
 ---

--- a/.claude/skills/security-issue-import-from-md/SKILL.md
+++ b/.claude/skills/security-issue-import-from-md/SKILL.md
@@ -3,13 +3,10 @@ name: security-issue-import-from-md
 mode: Triage
 description: |
   Open one or more `<tracker>` tracking issues from a markdown
-  file containing a batch of security findings (typically the
-  output of an AI security review or a third-party scanner).
-  Each finding becomes one tracker landing in the `Needs
-  triage` board column. Unlike `security-issue-import` (Gmail)
-  and `security-issue-import-from-pr` (public PR), there is no
-  inbound reporter to reply to and no PR to inspect — the file
-  itself is the full report.
+  file containing a batch of security findings. Each finding
+  becomes one tracker landing in the `Needs triage` board
+  column. The file itself is the full report — there is no
+  inbound reporter to reply to and no PR to inspect.
 when_to_use: |
   Invoke when a security team member says "import findings
   from <path>", "import this scan output", "load these issues

--- a/.claude/skills/security-issue-import-from-pr/SKILL.md
+++ b/.claude/skills/security-issue-import-from-pr/SKILL.md
@@ -5,12 +5,11 @@ description: |
   Open a tracking issue in <tracker> for a security-relevant fix that
   has already been opened (or merged) as a public PR in <upstream>,
   in the case where there is no inbound `<security-list>`
-  report. The tracker lands in the `Assessed` board column (the
-  team-deliberate import implies the security assessment has already
-  happened) with the scope label applied, `pr created` / `pr merged`
-  reflecting the PR's state, and `Remediation developer` / `PR with
-  the fix` body fields populated from the PR — ready for
-  `security-cve-allocate` to take over.
+  report. The tracker lands in the `Assessed` board column with
+  the scope label applied, `pr created` / `pr merged` reflecting
+  the PR's state, and `Remediation developer` / `PR with the
+  fix` body fields populated from the PR. Pairs with
+  `security-cve-allocate` afterwards.
 when_to_use: |
   Invoke when a security team member says "import a tracker from
   PR <N>", "open a tracker for <upstream>#NNN", "we need a CVE

--- a/.claude/skills/security-issue-invalidate/SKILL.md
+++ b/.claude/skills/security-issue-invalidate/SKILL.md
@@ -14,13 +14,12 @@ description: |
 when_to_use: |
   Invoke when a security team member says "close NN as invalid",
   "invalidate NN", "mark NN invalid", "NN is not a security
-  issue" — typically after a Step 5 consensus-invalid decision
-  in the issue's discussion. Not appropriate when the team has
-  not yet reached consensus, when a CVE has already been allocated
-  (a separate Vulnogram REJECT flow is required first), or when
-  the advisory has already shipped (closing as invalid then is a
-  retraction with public consequences and needs explicit team
-  escalation).
+  issue" — typically after a consensus-invalid decision in the
+  issue's discussion. Skip when the team has not yet reached
+  consensus, when a CVE has already been allocated (a separate
+  Vulnogram REJECT flow runs first), or when the advisory has
+  already shipped — closing as invalid then is a retraction with
+  public consequences and warrants explicit team escalation.
 argument-hint: "[issue-number]"
 license: Apache-2.0
 ---

--- a/.claude/skills/security-issue-sync/SKILL.md
+++ b/.claude/skills/security-issue-sync/SKILL.md
@@ -4,11 +4,11 @@ mode: Triage
 description: |
   Synchronize a security issue in <tracker> with the state of its
   GitHub discussion, the <security-list> mailing thread, and any
-  <upstream> PRs that fix it. The skill gathers all relevant signals,
-  proposes label, milestone, assignee, field and draft-email updates, and
-  only applies changes the user has explicitly confirmed. Suggests the next
-  step in the handling process and prints the CVE allocation link when a CVE
-  is needed.
+  <upstream> PRs that fix it. The skill gathers all relevant signals
+  and proposes label / milestone / assignee / field / draft-email
+  updates — applying only what the user has explicitly confirmed.
+  Suggests the next step in the handling process and prints the CVE
+  allocation link when a CVE is needed.
 when_to_use: |
   Invoke when a security team member says "sync issue NNN", "refresh the
   state of issue NNN", "update issue NNN from the thread", or "walk me

--- a/.claude/skills/security-issue-triage/SKILL.md
+++ b/.claude/skills/security-issue-triage/SKILL.md
@@ -4,8 +4,8 @@ mode: Triage
 description: |
   For each open `<tracker>` issue carrying the `needs triage`
   label, read body + comments and classify the candidate
-  disposition into one of five classes: VALID, DEFENSE-IN-DEPTH,
-  INFO-ONLY, NOT-CVE-WORTHY, PROBABLE-DUP. On user confirmation,
+  disposition into one of five classes: VALID / DEFENSE-IN-DEPTH
+  / INFO-ONLY / NOT-CVE-WORTHY / PROBABLE-DUP. On user confirmation,
   posts a triage-proposal comment that invites the security team
   to react. Read-only on tracker state — no label flips, closes,
   or CVE allocations. Supports `--retriage` for re-litigating

--- a/.claude/skills/setup-isolated-setup-install/SKILL.md
+++ b/.claude/skills/setup-isolated-setup-install/SKILL.md
@@ -2,12 +2,10 @@
 name: setup-isolated-setup-install
 description: |
   Guide an adopter through the first-time install of the
-  framework's secure agent setup — pinned system tools
-  (`bubblewrap`, `socat`, `claude-code`), project + user-scope
-  `.claude/settings.json` wiring, the `claude-iso` clean-env
-  wrapper, and the user-scope `sandbox-bypass-warn` /
-  `sandbox-status-line` hooks. Walks every step interactively;
-  never auto-runs sudo, shell-rc edits, or settings overwrites.
+  framework's secure agent setup (bubblewrap + socat +
+  claude-code, sandbox/permissions/clean-env layers). Walks
+  every step interactively; never auto-runs sudo, shell-rc
+  edits, or settings overwrites.
 when_to_use: |
   Invoke when the user says "set up the secure agent setup",
   "first-time install of the secure config", "install the

--- a/.claude/skills/setup-isolated-setup-update/SKILL.md
+++ b/.claude/skills/setup-isolated-setup-update/SKILL.md
@@ -1,16 +1,11 @@
 ---
 name: setup-isolated-setup-update
 description: |
-  Surface drift between the user's installed secure agent setup and
-  the framework's latest. Reports framework-checkout updates
-  (`git pull` on `airflow-steward`), pinned-tool upgrade candidates
-  (`bubblewrap`, `socat`, `claude-code` newer than the manifest's
-  7-day-cooldown floor), drift between the user-scope script
-  copies (`~/.claude/scripts/`, `~/.claude/agent-isolation/`) and
-  the framework's source-of-truth, and any newly-allowed denial
-  command that should still be denied. Read-only — surfaces
-  candidates and diffs, never auto-applies. The user decides what
-  to update.
+  Surface drift between the user's installed secure agent setup
+  and the framework's latest (framework checkout, pinned tools,
+  user-scope script copies, denial commands). Read-only —
+  surfaces candidates and diffs, never auto-applies. The user
+  decides what to update.
 when_to_use: |
   Invoke when the user says "update secure setup", "check for
   secure-config drift", "is my setup at the framework's latest?",

--- a/.claude/skills/setup-isolated-setup-verify/SKILL.md
+++ b/.claude/skills/setup-isolated-setup-verify/SKILL.md
@@ -1,14 +1,12 @@
 ---
 name: setup-isolated-setup-verify
 description: |
-  Walk the verification checklist documented in
-  `docs/setup/secure-agent-setup.md` and report ✓ done / ✗ missing / ⚠ partial
-  for each piece of the secure agent setup — project + user-scope
-  `settings.json` wiring, hook scripts present + executable,
-  `claude-iso` sourced, pinned tool versions installed at the
-  pinned versions, status-line state in this session, and the three
-  denial commands that prove the sandbox + permissions + clean-env
-  layers are actually firing. Read-only — never modifies anything.
+  Walk the verification checklist for the framework's secure
+  agent setup and report ✓ done / ✗ missing / ⚠ partial for
+  each check, with concrete evidence (file paths, command
+  output, version strings). Coverage: settings.json wiring,
+  claude-iso sourced, pinned tool versions, denial commands.
+  Read-only — never modifies anything.
 when_to_use: |
   Invoke when the user says "verify my secure setup", "is my
   secure config done?", "check that the secure agent setup is

--- a/.claude/skills/setup-override-upstream/SKILL.md
+++ b/.claude/skills/setup-override-upstream/SKILL.md
@@ -3,14 +3,9 @@ name: setup-override-upstream
 description: |
   Walk an adopter through promoting a local
   `.apache-steward-overrides/<skill>.md` file into a PR
-  against `apache/airflow-steward`. Lists the adopter's
-  overrides, helps pick one, reads it alongside the framework
-  skill it modifies, decides whether the change is
-  generalisable, designs the framework-level abstraction,
-  implements it in the user's local apache-steward clone, and
-  opens the PR. After the PR merges and the adopter runs
-  `/setup-steward upgrade`, the override file is no longer
-  needed and the skill prompts for its removal.
+  against `apache/airflow-steward`. After the PR merges and
+  the adopter runs `/setup-steward upgrade`, the override file
+  is no longer needed and the skill prompts for its removal.
 when_to_use: |
   Invoke when the user says "upstream my override", "promote
   this override to the framework", "convert my local

--- a/.claude/skills/setup-steward/SKILL.md
+++ b/.claude/skills/setup-steward/SKILL.md
@@ -19,10 +19,9 @@ description: |
                                 `.apache-steward-overrides/`
     `/setup-steward unadopt` — reverse the adoption (snapshot,
                                locks, symlinks, hook, doc
-                               sections, this skill itself);
-                               preserves `.apache-steward-
-                               overrides/` by default
-                               (main-checkout only)
+                               sections); preserves
+                               `.apache-steward-overrides/` by
+                               default (main-checkout only)
 when_to_use: |
   Invoke when the user says "adopt apache-steward", "adopt
   apache/airflow-steward", "set up steward in this repo",

--- a/.claude/skills/write-skill/SKILL.md
+++ b/.claude/skills/write-skill/SKILL.md
@@ -1,18 +1,13 @@
 ---
 name: write-skill
 description: |
-  Author a new skill for the Apache Steward framework, or update an
-  existing one. Walks the user through the framework-specific skill
-  shape — YAML frontmatter (with `license: Apache-2.0`), bundled
-  resources (scripts / references / assets), placeholder convention
-  (`<tracker>`, `<upstream>`, `<security-list>`), the
-  Adopter-overrides + Snapshot-drift preamble every framework skill
-  carries, the prompt-injection-defence patterns required of every
-  skill that ingests external content (per the 2026-05 audit
-  recorded at the gist link in the skill body), and the Privacy-LLM
-  gate-check boilerplate. Scaffolds the skill via `init_skill.py`
-  and validates via the framework's existing
+  Author a new skill for the Apache Steward framework, or update
+  an existing one. Walks the user through the framework's skill
+  shape (frontmatter, resources, placeholder convention,
+  prompt-injection defences, Privacy-LLM gate-check) and
+  validates via the framework's existing
   [`tools/skill-validator`](../../../tools/skill-validator/).
+  Scaffolds new skills via `init_skill.py`.
 when_to_use: |
   Invoke when the user says "write a skill", "create a new skill",
   "add a skill for X", "I want to make a skill that does Y", or


### PR DESCRIPTION
## Summary

- Clears all 24 `skill-validator` SOFT warnings across 17 `SKILL.md` files (action-inventory / parenthetical-rationale / distinct-from / chain-handoff / criteria-source).
- Honors the rule's *spirit*, not just its regex: sub-step enumerations (workflow steps, internal component lists, implementation actions) are moved out of frontmatter into the body where they belong. Top-level routing labels (PR dispositions, triage classes, sub-action names) stay in frontmatter as short slash-separated lists since they carry routing signal.
- Preserves niche routing keywords (bubblewrap / socat / claude-code / claude-iso / settings.json / denial commands / CVE tool link / cve allocated / snapshot / locks / symlinks / hook / frontmatter / placeholder convention / prompt-injection defences / Privacy-LLM) as compact parenthetical hints in description so single-keyword user queries still route.
- Net per-routing-call cost: **~−498 tokens** (−8.8% of skill frontmatter budget) vs HEAD.

## How `Distinct from` / `Counterpart to` clauses were handled

Rewritten as concrete `Use after X` / `Skip when X` redirects so the LLM router gets the actionable routing decision instead of a comparison. The sibling skill name is preserved in every case, so cross-skill routing recall is unaffected.

## Verification

| Check | Result |
|---|---|
| `skill-validate` | `OK (no violations)` (was: 24 SOFT warnings across 17 skills) |
| `skill-validate --strict` against `HEAD` | `OK` — strict promotes trigger-preservation to hard-fail; passing proves no quoted phrase dropped from `when_to_use` |
| Custom audit script | **76/76** quoted trigger phrases preserved verbatim (per-skill 1:1) |
| Routing cue counts (`Invoke when` / `Skip when` / `Use after`) | preserved or increased on all 17 skills |
| Metadata budget (1,536-char cap) | longest skill (`setup-steward`, 1,233 chars) well under cap |


<img width="878" height="173" alt="image" src="https://github.com/user-attachments/assets/1c9d2dc0-3111-4917-9240-8385515a363a" />


## Files touched

17 `SKILL.md` files under `.claude/skills/`. Net **−22 lines** of frontmatter; bodies unchanged (existing detail files already covered the moved enumerations, so no body additions were needed).

## What this PR is *not*

- No behavioural changes to any skill.
- No body content rewrites.
- No changes to `skill-validator` rules themselves — only the skills they flag.