### PR TITLE
docs(naming): reflect [LAZY CONSENSUS] state in README + MISSION

### DIFF
--- a/MISSION.md
+++ b/MISSION.md
@@ -46,16 +46,14 @@ The Apache Software Foundation establishes the Apache `<PROJECT_NAME>` Project a
 
 ## Proposed Names
 
-The initial committee will discuss and vote on the final name. Starting candidates (the list isn't closed — anyone on the initial committee can pitch a different name):
+The founding-PMC bikeshed ran 8–12 May 2026; convergence is on **four names in priority order**, ratified by a [LAZY CONSENSUS] call closing **Friday 15 May 2026, 12:00 UTC** and a parallel `trademarks@apache.org` review. The first of these to clear `trademarks@`'s formal review becomes the final name:
 
-- Apache Mentor
-- Apache Guild
-- Apache Minerva
-- Apache Magpie
-- Apache Beacon
-- Apache Compass
-- Apache Lexicon
-- Apache Polyglot
+1. **Apache Magpie** — primary
+2. **Apache Beacon** — backup 1
+3. **Apache Guild** — backup 2
+4. **Apache Lichen** — backup 3
+
+The Board resolution will carry whichever name clears `trademarks@` before **Friday 15 May evening**.
 
 ## Rationale
 

--- a/README.md
+++ b/README.md
@@ -20,29 +20,30 @@
 
 # Apache Steward (to be renamed)
 
-> **Heads-up — rename in flight, name not yet chosen.** This
-> repository is currently served from `apache/airflow-steward`
-> and is going to be renamed to a **different** name — *not*
-> `apache/steward`. The current name carries `airflow` for
-> legacy reasons, but the framework is project-agnostic (it
-> stewards multiple ASF project workflows, not just Airflow's),
-> so the working group steering it will pick a new name that
-> reflects that. The final name will be chosen by **discussion
-> followed by a poll** among the working-group members.
+> **Heads-up — rename in flight, [LAZY CONSENSUS] in progress.**
+> This repository is currently served from
+> `apache/airflow-steward` and is going to be renamed to a
+> **different** name — *not* `apache/steward`. The current name
+> carries `airflow` for legacy reasons, but the framework is
+> project-agnostic (it stewards multiple ASF project workflows,
+> not just Airflow's), so the working group steering it picked
+> a new name that reflects that.
 >
-> **Current candidate names** (the list is open for additions
-> during the **week of 4–9 May 2026**, after which the poll
-> opens):
+> The founding-PMC bikeshed ran **8–12 May 2026**; convergence
+> is on four names in priority order, with a [LAZY CONSENSUS]
+> call closing **Friday 15 May 2026, 12:00 UTC** and a parallel
+> `trademarks@apache.org` review in flight. The first of these
+> to clear `trademarks@`'s formal review becomes the final name:
 >
-> - Apache Mentor
-> - Apache Reeve
-> - Apache Guild
-> - Apache Minerva
-> - Apache Magpie
-> - Apache Beacon
-> - Apache Compass
-> - Apache Lexicon
-> - Apache Polyglot
+> 1. **Apache Magpie**  — primary
+> 2. **Apache Beacon**  — backup 1
+> 3. **Apache Guild**   — backup 2
+> 4. **Apache Lichen**  — backup 3
+>
+> The Board resolution establishing the project as an ASF
+> Top-Level Project is scheduled for **Wed 20 May 2026** and
+> will carry whichever name clears `trademarks@` before
+> Friday 15 May evening.
 >
 > Until the rename lands on the GitHub side, every clone URL and
 > CI integration still uses the legacy `apache/airflow-steward`


### PR DESCRIPTION
## Summary

The 8–12 May 2026 founding-PMC bikeshed has converged on four
names in priority order. A [LAZY CONSENSUS] call is in flight
on the founding-PMC mailing thread (deadline **Friday 15 May
2026, 12:00 UTC**); a parallel formal trademark suitability
check is in flight with \`trademarks@apache.org\`.

The candidate list and timeline live in two places by intent:

- \`README.md\` — adopter-facing "Heads-up" preamble at the top
- \`MISSION.md\` — Board-resolution-facing *Proposed Names*
  section

Both are now updated.

## The four names

  1. **Apache Magpie**  — primary (10 endorsements in the
     thread; cleanest mission-fit metaphor; small AI-paper
     overlap but no commercial mark)
  2. **Apache Beacon**  — backup 1 (cleanest trademark surface
     of the four per Justin's MCP run)
  3. **Apache Guild**   — backup 2 (3 endorsements; The Guild
     / Guild Education / Guild.xyz trademark headwind in the
     developer-tooling space)
  4. **Apache Lichen**  — backup 3 (late-surfaced 13 May; the
     strongest mission-metaphor of the four — symbiosis maps
     to RFC-AI-0004 directly — but pronunciation ambiguity
     and dermatology-SERP collision keep it as fallback)

The first of these to clear \`trademarks@\`'s formal review
becomes the final name the 20 May Board resolution carries.

## What this PR does **not** touch

- The \`<PROJECT_NAME>\` placeholder convention throughout
  \`MISSION.md\` body, \`docs/modes.md\`, etc. — those stay as
  placeholders until \`trademarks@\` clears one name.
- The repo slug \`apache/airflow-steward\` — rename only lands
  on the GitHub side after Board adoption.

## Test plan

- [x] \`prek run --files README.md MISSION.md\` clean
- [ ] Visual review of the README preamble — does the four-line
      shortlist read as cleanly in the rendered Markdown as it
      does in source?
- [ ] Visual review of the MISSION *Proposed Names* section

🤖 Generated with [Claude Code](https://claude.com/claude-code)