### PR TITLE
docs(mission): add Calvin Kirs + Apache LDAP IDs for all roster members

### DIFF
--- a/MISSION.md
+++ b/MISSION.md
@@ -162,21 +162,22 @@ PMC composition matters more than most because the project's social stakes are h
 
 ASF members for the roster:
 
-- Jarek Potiuk — Airflow PMC
-- Piotr Karwasz — Log4J PMC
-- Elad Kalif — Airflow PMC
-- Matthew Topol — Arrow PMC, Iceberg PMC
-- Pavan Kumar — Airflow PMC
-- Amogh Desai — Airflow PMC
-- Andrew Musselman — Mahout PMC
-- Justin Mclean — Incubator PMC, Training PMC
-- Jean-Baptiste Onofré — Incubator PMC, Polaris PMC, …
-- Paul King — Groovy PMC, Grails PMC, Incubator PMC
-- Evan Rusackas — Superset PMC
-- Russell Spitzer — Incubator PMC, Polaris PMC, Iceberg PMC
-- Ismael Mejia — Beam PMC, Incubator PMC
-- Zili Chen (tison) — Pulsar PMC, Curator PMC, ZooKeeper PMC, …
-- James Fredley — Grails PMC
+- Jarek Potiuk (potiuk) — Airflow PMC
+- Piotr Karwasz (pkarwasz) — Log4J PMC
+- Elad Kalif (eladkal) — Airflow PMC
+- Matthew Topol (zeroshade) — Arrow PMC, Iceberg PMC
+- Pavan Kumar Gopidesu (gopidesu) — Airflow PMC
+- Amogh Desai (amoghdesai) — Airflow PMC
+- Andrew Musselman (akm) — Mahout PMC
+- Justin Mclean (jmclean) — Incubator PMC, Training PMC
+- Jean-Baptiste Onofré (jbonofre) — Incubator PMC, Polaris PMC, …
+- Paul King (paulk) — Groovy PMC, Grails PMC, Incubator PMC
+- Evan Rusackas (rusackas) — Superset PMC
+- Russell Spitzer (russellspitzer) — Incubator PMC, Polaris PMC, Iceberg PMC
+- Ismael Mejia (iemejia) — Beam PMC, Incubator PMC
+- Zili Chen / tison (tison) — Pulsar PMC, Curator PMC, ZooKeeper PMC, …
+- James Fredley (jamesfredley) — Grails PMC
+- Calvin Kirs (kirs) — Doris PMC, Geode PMC
 
 The named PMC roster will accompany the resolution at the time of vote.
 


### PR DESCRIPTION
## Summary

Two changes landed together (one commit; happy to split if reviewers prefer):

### 1. Add Calvin Kirs to the ASF-members roster

Calvin got back to me saying yes — adding him alongside the other late additions (Ismael, tison, James). New line:

\`\`\`
- Calvin Kirs (kirs) — Doris PMC, Geode PMC
\`\`\`

### 2. Add Apache LDAP IDs in parentheses for every roster entry

Now that the Board resolution is two days out, the roster needs to be unambiguously linked to ASF identity. Format mirrors common ASF roster conventions:

\`\`\`
- <Full Name> (<apache-id>) — <PMC list>
\`\`\`

## IDs that need a quick confirmation in review

All IDs were derived from the @apache.org email each member uses, with two best-guess exceptions:

- **Calvin Kirs → \`kirs\`** — Calvin, please confirm. Alternative guesses if wrong: \`calvinkirs\`, \`ck\`.
- **Justin Mclean → \`jmclean\`** — Justin, please confirm. You primarily use \`justin@classsoftware.com\`; if the ASF ID is something different, flag it here.

Everyone else's ID is the prefix of their published \`@apache.org\` address and should be correct, but anyone who spots a mistake on their own line — please call it out and I'll fix in a follow-up.

## What this PR does **not** touch

Same \`.asf.yaml\` cap caveat as #138 / #140: the collaborators block is at the ASF Infra cap of 10 entries (bumping requires a vp-infra@apache.org request). Leaving as-is.

## Test plan

- [x] \`prek run --files MISSION.md\` clean
- [ ] Calvin Kirs confirms \`kirs\` as his ASF LDAP ID
- [ ] Justin Mclean confirms \`jmclean\` as his ASF LDAP ID
- [ ] Visual review of the 16-line roster

🤖 Generated with [Claude Code](https://claude.com/claude-code)