### PR TITLE
suggested amendments from spiking groovy-reassess skill contribution

### DIFF
--- a/.claude/skills/setup-steward/conventions.md
+++ b/.claude/skills/setup-steward/conventions.md
@@ -29,6 +29,29 @@ For framework symlinks: create them at
 `<repo-root>/.claude/skills/<n>` → relative path into
 `.apache-steward/.claude/skills/<n>/`.
 
+**Caveat — `.claude/` already gitignored.** Some adopters (notably
+those that previously used Claude Code with per-user `.claude/`
+settings) have `.claude/` listed in their repo's `.gitignore`.
+This prevents `.claude/skills/setup-steward/` from being committed
+per [`SKILL.md` Golden rule 6](SKILL.md#golden-rules) (which expects
+`setup-steward` itself to be the only committed framework skill).
+
+Three resolution paths:
+
+- **Override the gitignore** — add `!/.claude/skills/setup-steward/`
+  after the broader `.claude/` line. Keeps the rest of `.claude/`
+  gitignored; commits only the framework's bootstrap skill.
+- **Switch to Pattern B** — move skills to `.github/skills/` and use
+  the double-symlinked layout. Sidesteps the `.claude/` gitignore
+  entirely. See *B. Double-symlinked* below.
+- **Defer commit** — treat the whole adoption as a no-commit local
+  experiment until the gitignore is revised. Useful for spike-style
+  evaluation.
+
+The adopt flow surfaces the conflict when it detects `.claude/` is
+gitignored AND Pattern A was selected; the user picks one of the
+three above.
+
 ### B. Double-symlinked — `.claude/skills/` mirrors `.github/skills/`
 
 ```text

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -323,9 +323,9 @@ the active configuration before executing any command:
 
 | Placeholder | Resolves to | Source |
 |---|---|---|
-| `<project-config>` | The adopting project's `.apache-steward/` directory in its tracker repo. | Filesystem convention. |
+| `<project-config>` | The adopting project's config directory in its tracker repo (path is adopter's choice; alongside the gitignored `.apache-steward/` snapshot, not inside it). Bootstrapped from `projects/_template/`. | Filesystem convention. |
 | `<framework>` | The framework's root — i.e. this repository. In adopting projects, `.apache-steward/` (the gitignored snapshot path managed by `setup-steward`); in framework standalone, `.` (the repository root). Used in `uv run` and other invocations that need to address the framework's `tools/<name>/` subtrees from a path the agent can resolve at the agent's current `cwd`. | Filesystem convention. |
-| `<tracker>` | The GitHub slug of the tracker repo (example: `airflow-s/airflow-s` for the Apache Airflow security team). | `<project-config>/project.md` → `tracker_repo` |
+| `<tracker>` | The GitHub slug of the (security) tracker repo (example: `airflow-s/airflow-s` for the Apache Airflow security team). | `<project-config>/project.md` → `tracker_repo` |
 | `<upstream>` | The GitHub slug of the upstream codebase the fixes land in (example: `apache/airflow`). | `<project-config>/project.md` → `upstream_repo` |
 | `<security-list>` | The project's security mailing list (example: `security@airflow.apache.org`). | `<project-config>/project.md` → `mailing_lists.security` |
 | `<N>` | An issue or PR number. | The user's input to the skill |


### PR DESCRIPTION
docs: clarify <project-config> resolution; document .claude/-gitignored adopter caveat

Three small placeholder-table and convention-doc clarifications,
surfaced during a separate spike of adopting the framework into
apache/groovy:

- AGENTS.md placeholder table: the <project-config> row claimed
  the placeholder resolves to .apache-steward/, but the body text
  at lines 237-262 is authoritative — <project-config> is an
  adopter-chosen path alongside the snapshot, not inside it.
  Rewrite the row to match.

- AGENTS.md placeholder table: clarify <tracker> as the (security)
  tracker, since adopters with general-issue trackers (separate
  from security) need disambiguation.

- setup-steward/conventions.md: document the .claude/-gitignored
  adopter case (some repos gitignore .claude/ for user-local
  Claude Code settings; this conflicts with committing the
  setup-steward skill per Pattern A). Add three resolution paths.

Extracted from a larger contribution (the issue-* skill family)
per maintainer feedback to keep the contribution PRs focused.