### PR TITLE
triage: mandatory Security Model citation + closed-tracker precedent search

### DIFF
--- a/.claude/skills/security-issue-triage/SKILL.md
+++ b/.claude/skills/security-issue-triage/SKILL.md
@@ -367,12 +367,123 @@ that the orchestrator aggregates into one proposal.
 
 ---
 
+## Step 2.5 — Apply the Security Model verbatim
+
+For each tracker, before proposing a class, identify the most
+directly applicable Security Model section(s) by code-path /
+attacker-model / data-flow. Fetch the section verbatim (cache for
+the run) from the URL declared in
+[`<project-config>/security-model.md`](../../../<project-config>/security-model.md).
+The proposal body **must quote the relevant 2-3 sentences** and
+explain how this tracker maps to (or escapes) that wording.
+
+### Trust-boundary cheat-sheet
+
+Apply mechanically before VALID / DEFENSE-IN-DEPTH /
+NOT-CVE-WORTHY:
+
+| If the attacker is… | …and the target / effect is… | Default class |
+|---|---|---|
+| DAG author | code execution in worker / DAG processor / Triggerer | NOT-CVE-WORTHY (cite §"DAG Authors executing arbitrary code") |
+| DAG author | cross-DAG effect within shared parser / triggerer / worker pool | NOT-CVE-WORTHY (cite §"Limiting DAG Author access to subset of Dags") |
+| Worker holding Execution JWT | read or write of another task's data via Execution API | NOT-CVE-WORTHY (cite the *"Cross-DAG access via the Task Execution API or Task SDK"* canned: `ti:self` is mutation-only, not per-DAG access control) |
+| Authenticated UI / REST user with restricted DAG-scoped perms | reads other DAGs' data via UI / REST | **VALID** (precedent: prior CVEs on this shape — search closed `cve allocated` trackers in Step 2.6) |
+| Operator / Deployment Manager | misconfigures something with side-effects | NOT-CVE-WORTHY (cite §"Connection configuration users" / operator-trust framing) |
+| Authenticated user | DoS or self-XSS | NOT-CVE-WORTHY (cite §"DoS by authenticated users" / §"Self-XSS by authenticated users") |
+| External actor (email sender, request poster) | exploit via parser on attacker-controlled input that reaches a supported platform | **VALID** |
+| External actor | exploit only manifests on a non-supported platform | NOT-CVE-WORTHY (cite the project's supported-platforms section of the Security Model) |
+| DAG author who deliberately routes user input | injection in operator / hook / SQL / shell | NOT-CVE-WORTHY (cite §"DAG Author code passing unsanitized input") |
+
+**If the answer is not in the cheat-sheet, stop and ask the
+user** rather than guessing. The classifier flags `UNCERTAIN`
+internally per the existing Step 3 contract; the new sub-step is
+to ask the user before proposing rather than emitting a
+low-confidence proposal.
+
+**Verbatim quote requirement.** The proposal body posted in
+Step 4 must include a direct quote (2-3 sentences) from the
+matched Security Model section, with the section anchor as a
+clickable link. Paraphrases are forbidden — the model wording is
+the authoritative grounding for the disposition, and paraphrasing
+introduces drift the team will catch in review and bounce the
+proposal for.
+
+**Cache the fetched Security Model for the run.** A bulk-mode
+sweep over N trackers fetches the model once, not N times.
+Subagents in bulk mode receive the fetched copy as a
+serialized-string parameter rather than re-fetching.
+
+---
+
+## Step 2.6 — Search closed-as-invalid / not-CVE-worthy precedents
+
+Step 2's fuzzy-dup search looks for open-tracker duplicates. This
+step adds **rejection-precedent search** — same fuzzy keys (GHSA
+IDs, code pointers, subject keywords from Step 2a of
+[`security-issue-import`](../security-issue-import/SKILL.md#step-2a--search-for-related-potentially-duplicate-existing-trackers)),
+but against **closed trackers labelled `invalid` /
+`not CVE worthy` / `duplicate`**:
+
+```bash
+# Per orthogonal key (code pointer, GHSA, subject keyword):
+gh search issues "<key>" --repo <tracker> --state closed \
+  --label "invalid" --json number,title,closedAt --jq '.[]'
+gh search issues "<key>" --repo <tracker> --state closed \
+  --label "not CVE worthy" --json number,title,closedAt --jq '.[]'
+```
+
+Each hit is a **rejection precedent** — surface in the Step 4
+proposal body with a one-line shape summary so the team sees the
+prior call without scrolling the closed list. A STRONG
+precedent (same code surface + same vulnerability class) lowers
+the proposal's confidence and may swing the disposition from
+VALID → NOT-CVE-WORTHY. Include the citation in the proposal:
+
+> Direct precedent: [`<tracker>#NNN`](https://github.com/<tracker>/issues/NNN)
+> (closed YYYY-MM-DD as NOT-CVE-WORTHY, same shape: <one-line>).
+
+Also search for **positive precedents** — CVE-allocated trackers
+with similar shape — via:
+
+```bash
+gh search issues "<key>" --repo <tracker> --state all \
+  --label "cve allocated" --json number,title,labels --jq '.[]'
+```
+
+A positive precedent on the same shape supports VALID. A
+positive precedent in one trust-boundary (UI/REST per-DAG
+bypass) and a negative precedent in another trust-boundary
+(Execution-API-via-worker-JWT) for the same code surface is the
+signal that the trust-boundary analysis in Step 2.5 is the
+load-bearing dimension, not the surface itself.
+
+**Budget**: ≤ 3 additional `gh search issues` calls per tracker
+on top of Step 2a's existing 5-call budget. If Step 2a already
+spent its budget on STRONG dedup matches, Step 2.6 can skip the
+search for that orthogonal key (the dedup STRONG match
+supersedes; the proposal routes to
+[`security-issue-deduplicate`](../security-issue-deduplicate/SKILL.md)
+instead).
+
+**Hard rule**: a rejection precedent in Step 2.6 does **not**
+auto-classify NOT-CVE-WORTHY — the human team reads the precedent
+and the new report side-by-side. The skill's job is to surface
+the precedent, not to vote for it.
+
+---
+
 ## Step 3 — Classify
 
 For each tracker, choose **exactly one** disposition class from
 the Golden Rule 4 table. The classifier's input is the Step 2
-state bag; the output is `(class, severity-guess, rationale,
-action-items)`.
+state bag enriched by Step 2.5 (Security Model citation +
+trust-boundary cheat-sheet) and Step 2.6 (rejection / positive
+precedent search). The output is `(class, severity-guess,
+rationale, action-items, model_citations, precedent_citations)`.
+
+A proposal that does **not** carry a Security Model citation
+matching the trust-boundary class (per Step 2.5) is malformed —
+re-run Step 2.5 rather than emitting it.
 
 ### Class-by-class decision criteria
 


### PR DESCRIPTION
## Summary

Adds two mandatory pre-classification steps to `security-issue-triage`:

- **Step 2.5 — Apply the Security Model verbatim**: the classifier must quote the relevant 2-3 sentences of the project's Security Model and explain how the tracker maps to (or escapes) that wording. A trust-boundary cheat-sheet codifies the common attacker/target combinations into default dispositions, so the classifier cannot skip the boundary analysis silently.
- **Step 2.6 — Closed-tracker precedent search**: extends the existing fuzzy-dup search to look for closed-as-invalid and closed-as-not-CVE-worthy precedents (today the search only finds open-tracker dedup candidates). A STRONG rejection precedent lowers proposal confidence and often swings the disposition.

## Motivation

In a 2026-05-14 triage sweep against `airflow-s/airflow-s`, the first-pass classification got 8 of 9 trackers wrong — proposed VALID/DEFENSE-IN-DEPTH for cases that had direct NOT-CVE-WORTHY precedents (e.g. airflow-s#258 for the `__classname__ → import_string` pattern, airflow-s#215 / #237 for cross-DAG-read via Execution API). The misclassifications were caught after a second round of human pushback ("check past similar issues; read the Security Model deeply"). This PR codifies "read the Security Model deeply" and "check past similar issues" as mandatory steps in the skill instead of relying on the human to push back.

## Test plan

- [ ] Re-run `/security-issue-triage` against airflow-s#404-#412 (the cases that originally tripped this) and confirm the new Step 2.5 trust-boundary cheat-sheet produces the correct first-pass dispositions for each.
- [ ] Confirm Step 2.6 finds airflow-s#258 when triaging a new report describing `import_string()` with attacker-controlled classnames inside the Triggerer / parser / worker pool.
- [ ] Run `gh search issues` against a closed tracker label that doesn't exist (e.g. `closed:invalid`-but-no-matches) to confirm the empty case is handled cleanly.
- [ ] Budget check: total `gh search` calls per tracker stay within the documented ≤5 envelope (the new closed search shares the same 5-call cap with the existing open search).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
