### PR TITLE
import: distinguish GHSA-relay notifications from tracker-mirror notifications

### DIFF
--- a/.claude/skills/security-issue-import/SKILL.md
+++ b/.claude/skills/security-issue-import/SKILL.md
@@ -325,6 +325,34 @@ bookkeeping emails are filtered out at Step 3 by subject pattern
 instead — see the `cve-tool-bookkeeping` row of the classification
 table.
 
+**Do not exclude `-from:notifications@github.com` wholesale.** GitHub
+uses this address for **two distinct categories** of messages:
+
+1. **Tracker-mirror notifications** — when an action lands on a
+   tracker issue (comment, label, close), GitHub emails every
+   subscriber. These arrive with subject `[<tracker-repo>] ...`
+   and are *not* import candidates — they describe an existing
+   tracker.
+2. **GHSA-relayed reports** — when a reporter files a GitHub
+   Security Advisory against `<upstream>`, GitHub emails
+   `notifications@github.com → security@<project>.apache.org`
+   with subject `[<upstream>] ... (GHSA-...)`. **These are**
+   import candidates.
+
+Filter the mirror notifications at Step 1 only by the project's
+declared dedicated `noreply` mirror addresses (e.g.
+`<tracker-repo>@noreply.github.com`, declared in
+[`<project-config>/project.md`](../../../<project-config>/project.md#gmail-and-ponymail)).
+**Do not blanket-exclude `notifications@github.com`** — the
+remaining tracker-mirror chatter on `notifications@github.com` is
+caught at Step 2 (threadId dedup against existing tracker bodies)
+and Step 2-bis (already-answered detection).
+
+The canonical query template in
+[`tools/gmail/search-queries.md`](../../../tools/gmail/search-queries.md#security-issue-import--candidate-listing-query)
+omits the blanket exclusion; project-specific `<project-config>/project.md`
+declarations enumerate dedicated mirror noreply senders only.
+
 Adjust the time window per the user's selector (`since:` → `newer_than:`
 or `after:`; `import all` → `newer_than:90d`).
 

--- a/tools/gmail/search-queries.md
+++ b/tools/gmail/search-queries.md
@@ -54,8 +54,8 @@ Placeholder convention:
 
 The project's tracker repo mirrors GitHub issue activity onto its
 security list, producing a large volume of bot messages that match
-most content searches. Every skill that searches beyond a pure list
-scan excludes the mirror senders up front:
+most content searches. Skills that do **content searches** (not the
+import candidate-listing query) exclude the mirror senders up front:
 
 ```text
 -from:notifications@github.com
@@ -63,6 +63,13 @@ scan excludes the mirror senders up front:
 -from:<tracker-noreply>
 -from:security-noreply@github.com
 ```
+
+**Exception — `security-issue-import` candidate listing.** That
+specific query removes `-from:notifications@github.com` from the
+exclusion list so GHSA-relayed inbound reports (sent from
+`notifications@github.com` with `[<upstream>] ... (GHSA-...)`
+subject form) are not dropped along with the tracker-mirror
+chatter. See the `security-issue-import` query template below.
 
 For projects that host their tracker elsewhere (or do not mirror to
 the list), trim or replace these as needed.
@@ -72,16 +79,26 @@ the list), trim or replace these as needed.
 ### `security-issue-import` — candidate-listing query
 
 Inbound threads that might be new reports, minus GitHub-notification
-bots, within a time window:
+mirror-bots, within a time window:
 
 ```text
 list:<security-list-domain>
-  -from:notifications@github.com
-  -from:noreply@github.com
   -from:<tracker-noreply>
+  -from:noreply@github.com
   -from:security-noreply@github.com
   newer_than:30d
 ```
+
+**Do not exclude `-from:notifications@github.com` in the
+candidate-listing query.** GitHub uses that address for two
+categories: tracker-mirror chatter (subject form `[<tracker-repo>]
+...`) which is what we want to filter, **and** GHSA-relayed inbound
+reports (subject form `[<upstream>] ... (GHSA-...)`) which are
+import candidates. The mirror chatter is caught by Step 2 threadId
+dedup; the GHSA relays are valid candidates and must reach Step 3
+classification. The `<tracker-noreply>` exclusion (e.g.
+`<tracker-repo>@noreply.github.com`) handles the dedicated mirror-
+noreply sender, which is what we actually want to drop.
 
 **Do not exclude `-from:security@apache.org`.** That address is used
 for CVE-tool bookkeeping *and* for ASF-security-team forwarding of


### PR DESCRIPTION
## Summary

Changes the standard candidate-listing exclusions in `security-issue-import` Step 1 so that GHSA-relayed reports (which arrive via `notifications@github.com` with subjects of the form `[<upstream>] ... (GHSA-...)`) are no longer indiscriminately filtered out together with the tracker-mirror notifications. Adjusts the canonical query template in `tools/gmail/search-queries.md` to match.

## Motivation

In a 2026-05-14 import sweep against `airflow-s/airflow-s`, four GHSA-relayed reports from Lokhesh Ujhoodha (`yogisawesome@gmail.com`, GitHub `@Lougarou`) were missed by the default 14-day candidate query because the standard exclusion `-from:notifications@github.com` dropped them along with the GitHub mirror chatter. The reporter had been told by ASF Security to split his consolidated report into separate GHSAs and had complied — but the resulting GHSA-notification threads weren't surfaced as candidates.

The fix is a more nuanced exclusion: drop only the tracker-mirror noreply addresses (which have stable, distinct sender domains like `<tracker-repo>@noreply.github.com`) and keep `notifications@github.com`. Tracker mirror chatter is then caught at Step 2 (threadId dedup against the tracker repo body field) — which is the correct dedup layer for the mirror case.

## Adopter follow-up

Adopters must update their project's mirror-sender declarations in `<project-config>/project.md` to remove the blanket `-from:notifications@github.com` line and keep only the dedicated `<tracker-repo>@noreply.github.com` mirror sender. For `airflow-s`: drop the line from `.apache-steward-overrides/project.md`.

## Test plan

- [ ] Re-run `/security-issue-import import last 30d` against `airflow-s/airflow-s` (after the adopter follow-up lands) and confirm the 4 GHSA threads (`19e167aefdba1213`, `19e167cfa9c2acef`, `19e167da9bbff594`, `19e167e6a6eb9b03`) surface as candidates.
- [ ] Confirm that GitHub-mirror chatter on existing trackers (e.g. the `[airflow-s/airflow-s] Issue #NNN` notifications) is still correctly dropped by Step 2 threadId dedup.
- [ ] Step 2-bis (already-answered-on-thread) should NOT misfire on GHSA threads (the "team-member replied with canned response" detection looks for project team members, not GitHub automation; GHSA replies come from `notifications@github.com` which isn't on the roster, so Step 2-bis doesn't trigger).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
