### PR TITLE
docs(MISSION): add Rich Bowen and Mike Drob to ASF members roster

### DIFF
--- a/.typos.toml
+++ b/.typos.toml
@@ -48,6 +48,10 @@ lose = "lose"
 # in `.asf.yaml` collaborators). typos flags it as a typo of
 # `assert`.
 asert = "asert"
+# `Drob` is a surname — Mike Drob (Accumulo / Curator / HBase /
+# Lucene / Solr PMC member, listed in the MISSION.md roster).
+# typos flags it as a typo of `Drop`.
+Drob = "Drob"
 
 [default.extend-identifiers]
 # Identifiers that look like typos but are real symbol names.

--- a/MISSION.md
+++ b/MISSION.md
@@ -178,6 +178,8 @@ ASF members for the roster:
 - Zili Chen / tison (tison) — Pulsar PMC, Curator PMC, ZooKeeper PMC, …
 - James Fredley (jamesfredley) — Grails PMC
 - Calvin Kirs (kirs) — Doris PMC, Geode PMC
+- Rich Bowen (rbowen) — Incubator PMC, ComDev PMC, …
+- Mike Drob (mdrob) — Accumulo PMC, Curator PMC, HBase PMC, Lucene PMC, Solr PMC
 
 The named PMC roster will accompany the resolution at the time of vote.
 


### PR DESCRIPTION
## Summary
- Add Rich Bowen (rbowen) — Incubator PMC, ComDev PMC, …
- Add Mike Drob (mdrob) — Accumulo PMC, Curator PMC, HBase PMC, Lucene PMC, Solr PMC
- Allowlist `Drob` in `.typos.toml` (typos flags it as `Drop`; same fix shape as the existing `asert` entry for `paulk-asert`)

## Test plan
- [ ] Confirm Apache IDs (`rbowen`, `mdrob`) against whimsy / people.apache.org before merge
- [ ] Confirm the PMC list for each is accurate / not missing entries hidden behind the `…`

Generated-by: Claude Code (Claude Opus 4.7)