### PR TITLE
docs(setup-steward): mention preserved user.md during unadopt

### DIFF
--- a/.claude/skills/setup-steward/unadopt.md
+++ b/.claude/skills/setup-steward/unadopt.md
@@ -130,7 +130,18 @@ The following will be REMOVED:
 The following will be PRESERVED:
 
     .apache-steward-overrides/           (M file(s); pass `--purge-overrides` to remove)
+    ~/.config/apache-steward/user.md     (per-user; shared with other adopters on this machine — remove manually if this was your last adoption)
 ```
+
+Surface the `~/.config/apache-steward/user.md` line only if that
+file is actually present on disk. If it is absent (or the
+operator drove `user.md` resolution via
+`$APACHE_STEWARD_USER_CONFIG` / the legacy per-project location),
+omit the line. The framework never touches the per-user file
+regardless of `--purge-overrides` — it is shared across every
+adopter project on the operator's machine and unadopting from
+*this* project does not imply they have stopped using
+apache-steward elsewhere.
 
 If `--purge-overrides` was passed, move
 `.apache-steward-overrides/` into the *removed* section and
@@ -252,6 +263,7 @@ A summary of what was removed + what remains:
 
 Preserved:
   .apache-steward-overrides/   (M files; pass `--purge-overrides` to remove)
+  ~/.config/apache-steward/user.md   (per-user; shared with other adopters on this machine — remove manually if this was your last adoption)
   <list of any non-steward-owned content the plan flagged>
 
 Staged for commit (you'll see in `git status`):


### PR DESCRIPTION
## Summary

* Surface `~/.config/apache-steward/user.md` in `unadopt.md`'s
  preserved-artefacts block when the file exists locally.
* Add a short manual-cleanup hint for operators removing their last
  adopter on the machine.
* No behaviour change. `unadopt` still never removes the shared
  per-user `user.md`.

<img width="989" height="368" alt="image" src="https://github.com/user-attachments/assets/34996fdf-f513-42e7-a016-361ee6a99ec1" />


## Why

`adopt` scaffolds `~/.config/apache-steward/user.md` as the canonical
per-user config location. Since the file is shared across adopters,
`unadopt` intentionally leaves it untouched.

Today the flow does not mention that preserved file, which can leave
operators unaware that it still exists after their last adoption.


## Test plan

* [ ] Eyeball the rendered diff
* [ ] Run `/setup-steward unadopt --dry-run` with
  `~/.config/apache-steward/user.md` present → confirm the line
  appears in the Preserved block
* [ ] Repeat with the file absent (or resolved elsewhere via
  `APACHE_STEWARD_USER_CONFIG`) → confirm the line is omitted
