### PR TITLE
docs(MISSION): add Craig L Russell to ASF members roster

### DIFF
--- a/MISSION.md
+++ b/MISSION.md
@@ -180,6 +180,7 @@ ASF members for the roster:
 - Calvin Kirs (kirs) — Doris PMC, Geode PMC
 - Rich Bowen (rbowen) — Incubator PMC, ComDev PMC, …
 - Mike Drob (mdrob) — Accumulo PMC, Curator PMC, HBase PMC, Lucene PMC, Solr PMC
+- Craig L Russell (clr) — Security Team, Incubator PMC, ComDev PMC, …
 
 The named PMC roster will accompany the resolution at the time of vote.
 


### PR DESCRIPTION
## Summary
- Add Craig L Russell (clr) — Security Team, Incubator PMC, ComDev PMC, …

## Test plan
- [ ] Confirm Apache ID `clr` against whimsy / people.apache.org before merge
- [ ] Confirm "Security Team" is the right label (vs. "ASF Security Team" / dropped — no other roster entry currently names a non-PMC group)
- [ ] Confirm the PMC list is complete / what's hidden behind the `…`

Generated-by: Claude Code (Claude Opus 4.7)