### PR TITLE
docs(NOTICE): acknowledge code contributions from Airflow and Groovy

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -5,6 +5,20 @@ This product includes software developed at
 The Apache Software Foundation (https://www.apache.org/).
 
 ================================================================================
+Contributions from other Apache Software Foundation projects
+================================================================================
+
+This product incorporates project-agnostic code contributed from
+other Apache Software Foundation projects:
+
+- Apache Airflow (https://airflow.apache.org/) — the framework that
+  became this project was first developed and proven within Apache
+  Airflow, already structured under Apache License 2.0 for reuse
+  inside and outside the ASF.
+- Apache Groovy (https://groovy.apache.org/) — contributions from
+  the Groovy PMC at the early stage of this project.
+
+================================================================================
 Third-party content
 ================================================================================
 


### PR DESCRIPTION
## Summary
- New section "Contributions from other Apache Software Foundation projects" in `NOTICE`, above the existing Third-party content section.
- Names Apache Airflow and Apache Groovy as the intra-ASF projects whose code is being moved into this project, matching the wording in `MISSION.md` § Source and IP.

## Rationale
The top-line `Copyright YYYY The Apache Software Foundation` technically already covers code that originated in other ASF projects (everything under the ASF shares the same copyright holder). The new section is **courtesy attribution / provenance transparency** — making the lineage visible to anyone reading the artefacts the project ships, and matching the public narrative in MISSION.md.

## Test plan
- [x] `prek run --files NOTICE` — all hooks green.
- [ ] Read-through review — confirm the wording matches the actual donation scope. If specific Groovy components donated should be named, expand the Groovy bullet.
- [ ] Once the project gets its final Board-approved name (Magpie / Beacon / Guild / Lichen), replace `this project` with the actual name on the same pass that updates the NOTICE header line `Apache Steward (formerly apache/airflow-steward)`.

Generated-by: Claude Code (Claude Opus 4.7)