### PR TITLE
[INFRA] Set up default rulesets for default and release branches

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -1,22 +1,3 @@
-# Licensed to the Apache Software Foundation (ASF) under one
-# or more contributor license agreements.  See the NOTICE file
-# distributed with this work for additional information
-# regarding copyright ownership.  The ASF licenses this file
-# to you under the Apache License, Version 2.0 (the
-# "License"); you may not use this file except in compliance
-# with the License.  You may obtain a copy of the License at
-#
-#   http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing,
-# software distributed under the License is distributed on an
-# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-# KIND, either express or implied.  See the License for the
-# specific language governing permissions and limitations
-# under the License.
-
-# https://cwiki.apache.org/confluence/display/INFRA/git+-+.asf.yaml+features
----
 github:
   description: "Agent-assisted maintainership and development framework for Apache projects — Triage and Drafting (agent-authored fixes with human review); Mentoring, Pairing (developer-side dev-cycle), and Auto-merge on the roadmap."
   homepage: "https://github.com/apache/airflow-steward"
@@ -104,6 +85,19 @@ github:
   # configured directly in GitHub for now. Add here when the project's
   # release / branching policy stabilises.
 
+  rulesets:
+    - name: "Default Branch Protection"
+      type: branch
+      branches:
+        includes:
+          - "~DEFAULT_BRANCH"
+          - "release/*"
+          - "rel/*"
+        excludes: []
+      bypass_teams:
+        - root
+      restrict_deletion: true
+      restrict_force_push: true
 notifications:
   # The framework is hosted under the Airflow PMC umbrella for now;
   # routing notifications to airflow.apache.org lists matches the
@@ -133,12 +127,12 @@ notifications:
   # Airflow PMC; jobs go to `jobs@` (CI / workflow-failure mirror).
   # Both lists are public-by-design and already moderated for
   # bot-only traffic, so there is no signal-to-noise concern.
-  jobs:                  jobs@airflow.apache.org
-  commits:               commits@airflow.apache.org
-  issues:                commits@airflow.apache.org
-  issues_status:         commits@airflow.apache.org
-  issues_comment:        commits@airflow.apache.org
-  pullrequests:          commits@airflow.apache.org
-  pullrequests_status:   commits@airflow.apache.org
-  pullrequests_comment:  commits@airflow.apache.org
-  discussions:           commits@airflow.apache.org
+  jobs: jobs@airflow.apache.org
+  commits: commits@airflow.apache.org
+  issues: commits@airflow.apache.org
+  issues_status: commits@airflow.apache.org
+  issues_comment: commits@airflow.apache.org
+  pullrequests: commits@airflow.apache.org
+  pullrequests_status: commits@airflow.apache.org
+  pullrequests_comment: commits@airflow.apache.org
+  discussions: commits@airflow.apache.org


### PR DESCRIPTION
This Pull Request enables the repository to conform with the "sane default security settings" of the Apache Software Foundation by configuring a default branch ruleset that protects the default branch and any release branches.

Note that `~DEFAULT_BRANCH` is a GitHub symbolic link to the current default branch (HEAD) of the repository and does not need changing.
If the managing project does not wish to set up these defaults, please close this Pull Request. Alternatively, the project may merge this Pull Request to apply the changes immediately.

If no action is taken, this Pull Request will be automatically merged by the Apache Infrastructure team on **2026-06-14** (30 days from now).

For any further information, please reach us on Slack or at: users@infra.apache.org
