### PR TITLE
chore(agent-isolation): bump claude-code 2.1.138 → 2.1.141

### DIFF
--- a/docs/setup/secure-agent-setup.md
+++ b/docs/setup/secure-agent-setup.md
@@ -138,7 +138,7 @@ The same flow, condensed to commands you run yourself:
 #    section: "Required tools (pinned versions)" below.
 sudo apt-get install --no-install-recommends \
     bubblewrap=0.11.2-* socat=1.8.1.1-*
-npm install -g --no-save @anthropic-ai/claude-code@2.1.138
+npm install -g --no-save @anthropic-ai/claude-code@2.1.141
 
 # 2. Project-scope `.claude/settings.json`. Copy the framework's
 #    sandbox / permissions.deny / permissions.ask / allowedDomains
@@ -195,7 +195,7 @@ The current pins live in machine-readable form in
 |---|---|---|---|---|
 | `bubblewrap` | 0.11.2 | 2026-04-23 | 7d (default) | Linux user-namespace sandbox (filesystem layer). Required on Linux; macOS uses Seatbelt instead. |
 | `socat` | 1.8.1.1 | 2026-03-13 | 7d (default) | TCP relay for the sandbox network allowlist. Linux only. |
-| `claude-code` | 2.1.138 | 2026-05-09 | 1d (override) | Agent runtime. Pin separately from any system claude install so behavioural changes don't drift the framework's effective security posture without review. |
+| `claude-code` | 2.1.141 | 2026-05-13 | 1d (override) | Agent runtime. Pin separately from any system claude install so behavioural changes don't drift the framework's effective security posture without review. |
 
 The pin date floor (`pinned_at` in the manifest) is the day the
 manifest was last touched; it is the framework's promise that every
@@ -234,7 +234,7 @@ version, no pin enforced — Homebrew rolls forward, so the
 
 ```bash
 # npm distribution (the only stable channel today)
-npm install -g --no-save @anthropic-ai/claude-code@2.1.138
+npm install -g --no-save @anthropic-ai/claude-code@2.1.141
 ```
 
 ### Distro-specific shortcut — Linux Mint 22.x / Ubuntu 24.04 Noble

--- a/tools/agent-isolation/pinned-versions.toml
+++ b/tools/agent-isolation/pinned-versions.toml
@@ -52,7 +52,7 @@
 
 # When this file was last touched. The check script uses this as the
 # minimum age the entries below claim to satisfy.
-pinned_at = "2026-05-10"
+pinned_at = "2026-05-16"
 
 [tools.bubblewrap]
 version = "0.11.2"
@@ -91,8 +91,8 @@ install.dnf = "dnf install socat-1.8.1.1"
 install.from_source = "http://www.dest-unreach.org/socat/download/socat-1.8.1.1.tar.gz"
 
 [tools.claude-code]
-version = "2.1.138"
-released = "2026-05-09"
+version = "2.1.141"
+released = "2026-05-13"
 # Override the framework-wide 7-day default. Claude Code releases
 # cadence is high (multiple releases per week) and any regression
 # that affects the framework's permission-rule semantics, sandbox
@@ -118,5 +118,5 @@ upstream_releases = "https://api.github.com/repos/anthropics/claude-code/release
 # Claude Code is distributed via npm; use `--no-save` so the global
 # install doesn't drift the local lockfile of any project the user
 # installs from.
-install.npm = "npm install -g --no-save @anthropic-ai/claude-code@2.1.138"
-install.brew = "# brew tap anthropics/claude-code; brew install claude-code@2.1.138 (when available)"
+install.npm = "npm install -g --no-save @anthropic-ai/claude-code@2.1.141"
+install.brew = "# brew tap anthropics/claude-code; brew install claude-code@2.1.141 (when available)"


### PR DESCRIPTION
## Summary

- Bumps the `claude-code` pin from 2.1.138 (released 2026-05-09) to 2.1.141 (released 2026-05-13). 2.1.141 is past the 1-day per-tool cooldown — `tools/agent-isolation/check-tool-updates.sh` flagged it on 2026-05-16.
- Updates the version + `released` fields in `pinned-versions.toml`, both install command lines (`install.npm`, `install.brew`), and the top-level `pinned_at`.
- Mirrors the bump in `docs/setup/secure-agent-setup.md` — the npm install command (2 occurrences) and the "Required tools (pinned versions)" table row.

Release notes: <https://github.com/anthropics/claude-code/releases/tag/v2.1.141> — routine bug fixes and small features (`terminalSequence` hook field, `claude agents --cwd`, "Summarize up to here" rewind, IDE diff option restored on file-edit prompts). No changes to `permissions.deny` semantics, sandbox flags, or prompt-injection mitigations. Includes a fix for `transcript_path` after `EnterWorktree` switches the working directory, which is directly relevant for adopters that wire `EnterWorktree` hooks.

## Test plan

- [ ] `tools/agent-isolation/check-tool-updates.sh` no longer flags `claude-code` as an upgrade candidate after merge.
- [ ] `npm install -g --no-save @anthropic-ai/claude-code@2.1.141` succeeds (the docs' install command resolves).
- [ ] Adopters that re-fetch the snapshot via `/setup-steward upgrade` see the new pin without further intervention.

🤖 Generated with [Claude Code](https://claude.com/claude-code)