### PR TITLE
chore(skills): drop leftover "not CVE worthy" mentions in security skills

### DIFF
--- a/.claude/skills/security-issue-invalidate/SKILL.md
+++ b/.claude/skills/security-issue-invalidate/SKILL.md
@@ -330,7 +330,7 @@ is not a security issue. Strong signals:
   (full URL, anchor links, paraphrases).
 - Phrases like *"this is by design"*, *"out of scope"*,
   *"documented behavior"*, *"requires X privileges already"*,
-  *"not a CVE"*, *"not CVE worthy"*, *"won't fix"*, *"working as
+  *"not a CVE"*, *"won't fix"*, *"working as
   intended"*.
 - Pointers to existing CVEs that already addressed the broader
   class (e.g. *"already covered by CVE-2023-37379"*).

--- a/.claude/skills/security-issue-sync/SKILL.md
+++ b/.claude/skills/security-issue-sync/SKILL.md
@@ -982,7 +982,7 @@ are in scope, run the checks in parallel via the subagent fanout
 
 **When the tracker has no CVE ID.** Closed trackers without a
 `CVE-YYYY-NNNNN` in the *CVE tool link* body field are closing
-dispositions (`invalid` / `not CVE worthy` / `duplicate` /
+dispositions (`invalid` / `duplicate` /
 `wontfix`) — skip the cve.org check entirely and drop the tracker
 from the closed-bucket sweep.
 
@@ -1201,7 +1201,7 @@ will change and *why*. Group them by category:
      When it has, propose closing the issue (do not update labels).
      This is the only place sync proposes closing an advisory-flow
      issue; all earlier closes are only for closing dispositions
-     (`invalid` / `not CVE worthy` / `duplicate` / `wontfix`) at
+     (`invalid` / `duplicate` / `wontfix`) at
      Steps 5–6.
 
   See the "CVE references must never point at non-public mailing-list
@@ -1936,7 +1936,7 @@ before moving on to the next item. Use:
   field still points at, and historical board sweeps still see the
   item. Apply the archive for every close, regardless of the close
   reason (terminal-Step-15 or non-terminal disposition like
-  `invalid` / `duplicate` / `not CVE worthy` / `wontfix`); the
+  `invalid` / `duplicate` / `wontfix`); the
   mutation is idempotent and a no-op on already-archived items.
 - **Project-board column:** apply via the `updateProjectV2ItemFieldValue`
   GraphQL recipe in
@@ -2039,7 +2039,7 @@ it out explicitly in the Step 6 recap:
   Remind the user to allocate a CVE via
   <https://cveprocess.apache.org/allocatecve> and mention that the next
   sync run will embed the JSON automatically once a CVE is set.
-- **The tracking issue was closed as `invalid` / `not CVE worthy` /
+- **The tracking issue was closed as `invalid` /
   `duplicate`** and there is nothing to attach.
 
 In every other case — including already-published CVEs — regenerate.


### PR DESCRIPTION
## Summary

The closing-disposition convention is `invalid` (not `not CVE worthy`). The two security skills mostly already reflect that, but five list-style references to the old name lingered. This PR drops them.

| File | Lines | Edit |
|---|---|---|
| `.claude/skills/security-issue-invalidate/SKILL.md` | 333 | Drop `*"not CVE worthy"*` from the quoted disposition-strings example list |
| `.claude/skills/security-issue-sync/SKILL.md` | 985 | Drop from Step 1d closed-bucket scan condition |
| `.claude/skills/security-issue-sync/SKILL.md` | 1204 | Drop from Step 2b "all earlier closes" rule |
| `.claude/skills/security-issue-sync/SKILL.md` | 1939 | Drop from Step 4 archive-from-board rationale |
| `.claude/skills/security-issue-sync/SKILL.md` | 2042 | Drop from Step 5 "when to skip regeneration" rule |

Net diff: 5 deletions, 0 additions of new wording — every touched list still reads cleanly with `invalid / duplicate / wontfix`.

## Context

On the `airflow-s/airflow-s` adopter tracker, `not CVE worthy` was a separate label that lived alongside `invalid` from earlier conventions. We've now:

- Re-labeled every historical issue carrying `not CVE worthy` to `invalid` (7 issues, open + closed).
- Deleted the `not CVE worthy` label from the tracker.
- Added an adopter-side `security-issue-invalidate.md` override capturing the "INVALID can have a PR attached" / "keep scope label on close" Airflow-specific rules.

With those local cleanups landed, the framework's own residual references to `not CVE worthy` are the last lingering use of the old term and would otherwise confuse new adopters who set up the skills fresh.

## Test plan

- [x] `grep -i "not cve worthy"` on `.claude/skills/security-issue-{sync,invalidate}/SKILL.md` returns no matches.
- [x] Each of the 5 touched lines reads cleanly after the edit (verified by hand — the affected lists become `invalid / duplicate / wontfix` etc.).
- [ ] Skill rendering on github.com is unchanged otherwise — only the dropped term differs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)