### PR TITLE
checked that a PR doesn't disclose a security issue

### DIFF
--- a/.claude/skills/pr-management-code-review/criteria.md
+++ b/.claude/skills/pr-management-code-review/criteria.md
@@ -92,8 +92,13 @@ adopter table, only the repo-wide rules apply.
 
 ## Security model — calibration
 
-Before flagging anything that looks security-flavoured, read
-the documented security model at the path declared in
+> This category also includes a **public-disclosure signal scan**
+> that runs in Step 3 (PR title, body, and commit messages),
+> before the diff is examined. See
+> [`review-flow.md` § Security-disclosure signal scan](review-flow.md#security-disclosure-signal-scan).
+
+Before flagging anything that looks security-flavoured in the
+diff, read the documented security model at the path declared in
 `<project-config>/pr-management-code-review-criteria.md` →
 `security_model_calibration.file`. The framework's reference
 threat model lives at

--- a/.claude/skills/pr-management-code-review/review-flow.md
+++ b/.claude/skills/pr-management-code-review/review-flow.md
@@ -151,6 +151,64 @@ If the body is empty or just template boilerplate, that's an
 [`criteria.md#ai-generated-code-signals`](criteria.md). Note it
 as a finding (don't fail the review on it alone).
 
+### Security-disclosure signal scan
+
+Before leaving Step 3, scan the PR **title**, **body**, and all
+**commit messages** for patterns that may indicate a security fix
+being made public before the CVE disclosure process is complete.
+ASF policy (`https://www.apache.org/security/committers.html`)
+requires that no reference to the security nature of a commit
+appear in public-facing content until the vulnerability is
+formally announced:
+
+> *"Messages associated with any commits should not make any
+> reference to the security nature of the commit."*
+
+Patterns to check (case-insensitive, across title + body +
+all commit messages):
+
+- **CVE IDs**: `CVE-\d{4}-\d+`
+- **Security-nature phrases**: "security vulnerability",
+  "security issue", "security fix", "security bug",
+  "security flaw", "security patch", "arbitrary code execution",
+  "remote code execution", `RCE`, "SQL injection", `XSS`,
+  `CSRF`, `SSRF`, "path traversal", "directory traversal",
+  "privilege escalation", "auth bypass", "authentication bypass",
+  "authorization bypass", "insecure deserialization",
+  "heap overflow", "buffer overflow", "use-after-free",
+  "exploit", "exploitable"
+
+If **any** pattern matches, surface a **pre-review warning** to
+the maintainer before continuing to Step 4:
+
+> ⚠ **Possible undisclosed security fix detected**
+>
+> The PR title / body / commit messages contain language that may
+> indicate a security vulnerability fix:
+>
+> - [quoted matched text and its location — e.g. *PR body:
+>   "This fixes a SQL injection vulnerability in…"*]
+>
+> ASF policy requires that no reference to the security nature of
+> a commit appear in public-facing content until the CVE is
+> formally announced. See
+> `https://www.apache.org/security/committers.html`.
+>
+> **Before merging:** verify that the CVE disclosure process for
+> this fix is complete (CVE status `READY`, public announcement
+> sent to the standard destinations). If disclosure is not yet
+> complete, this PR should be closed and the fix applied through
+> the private security channel instead.
+>
+> *Acknowledge and continue review? `[Y]es` / `[Q]uit`.*
+
+Wait for explicit acknowledgment before proceeding to Step 4.
+Include the warning as a leading note in the final review body
+regardless of disposition — it is information the contributor
+needs to see even on `APPROVE`.
+
+If no patterns match, proceed to Step 4 without pause.
+
 ---
 
 ## Step 4 — Examine the diff

--- a/.claude/skills/pr-management-triage/classify-and-act.md
+++ b/.claude/skills/pr-management-triage/classify-and-act.md
@@ -192,7 +192,7 @@ the GraphQL response (up to the last 250 commits).
 When building the comment, record every match with its location
 (title / body / commit SHA + first 72 chars of message) so the
 `<security_matches>` placeholder in
-[`comment-templates.md#security-language`](comment-templates.md#security-language)
+[`comment-templates.md#security-language-comment`](comment-templates.md#security-language-comment)
 can be populated verbatim.
 
 ---

--- a/.claude/skills/pr-management-triage/classify-and-act.md
+++ b/.claude/skills/pr-management-triage/classify-and-act.md
@@ -78,7 +78,8 @@ Action verbs are defined in [`actions.md`](actions.md).
 | 4  | Same as #3 but sub-state `responded`                                                           | `already_triaged`          | `skip`                 | Already triaged M days ago — author responded, maintainer to re-engage |
 | 5  | Viewer triage marker exists, posted after last commit, sub-state `waiting`, age ≥ 7 days, `isDraft == true` | `stale_draft`     | (defer to [`stale-sweeps.md`](stale-sweeps.md) Sweep 1a) | Draft triaged N days ago, no author reply |
 | 6  | `viewer == pr.author.login`                                                                   | n/a                        | `skip`                 | You are the PR author — triage skipped |
-| 7  | `now - createdAt < 30min`                                                                      | n/a                        | `skip`                 | Too fresh — CI still warming up |
+| 7a | `now - createdAt < 30min`                                                                      | n/a                        | `skip`                 | Too fresh — CI still warming up |
+| 7b | [`security_language_signal`](#security_language_signal)                                        | `security_language_signal` | `comment`              | Security-language in title / body / commits — ask contributor to neutralise or confirm CVE disclosure complete |
 | 8  | `flagged_prs_by_author > 3` AND [`has_deterministic_signal`](#has_deterministic_signal)        | `deterministic_flag`       | `close`                | Author has N flagged PRs — suggest closing to reduce queue pressure |
 | 9  | `mergeable == CONFLICTING`                                                                    | `deterministic_flag`       | `draft`                | Merge conflicts with `<base>` — author must rebase locally; convert to draft with merge-conflicts violation |
 | 10 | [`ci_failures_only`](#ci_failures_only) AND every failure ∈ `recent_main_failures`             | `deterministic_flag`       | `rerun`                | All N CI failures also appear in recent main-branch PRs — likely systemic, suggest rerun |
@@ -169,6 +170,32 @@ At least one of:
   row 17 draft fallback with an empty violation list.
 - `reviewThreads.totalCount` ≥ 1 with `isResolved == false` AND
   the thread's reviewer is `COLLABORATOR`/`MEMBER`/`OWNER`
+
+### `security_language_signal`
+
+The PR title, body, or any commit message matches at least one of
+the following patterns (case-insensitive). Evaluated against:
+`title`, `body`, and all items in `commits.nodes[].message` from
+the GraphQL response (up to the last 250 commits).
+
+- **CVE IDs**: `CVE-\d{4}-\d+`
+- **Phrases**: "security vulnerability", "security issue",
+  "security fix", "security bug", "security flaw",
+  "security patch", "arbitrary code execution",
+  "remote code execution", `RCE`, "SQL injection", `XSS`,
+  `CSRF`, `SSRF`, "path traversal", "directory traversal",
+  "privilege escalation", "auth bypass", "authentication bypass",
+  "authorization bypass", "insecure deserialization",
+  "heap overflow", "buffer overflow", "use-after-free",
+  "exploit", "exploitable"
+
+When building the comment, record every match with its location
+(title / body / commit SHA + first 72 chars of message) so the
+`<security_matches>` placeholder in
+[`comment-templates.md#security-language`](comment-templates.md#security-language)
+can be populated verbatim.
+
+---
 
 ### `ci_failures_only`
 

--- a/.claude/skills/pr-management-triage/comment-templates.md
+++ b/.claude/skills/pr-management-triage/comment-templates.md
@@ -85,6 +85,42 @@ Rules for the footer:
 
 ---
 
+## Security-language comment
+
+*(`security_language_signal` — security-disclosure warning)*
+
+Used when the action is `comment` for a
+`security_language_signal` classification (see
+[`classify-and-act.md` row 7a](classify-and-act.md#decision-table)).
+
+`<security_matches>` is a bullet list, one item per match, in the
+form: `- [location]: "[matched text]"` where location is one of
+`PR title`, `PR body`, or `commit <SHA7>`.
+
+```markdown
+@<author> This PR's title, body, or commit messages contain language that may indicate a security fix. Under the [ASF vulnerability-handling process for committers](https://www.apache.org/security/committers.html), references to the security nature of a fix must not appear in public-facing content until the CVE is formally announced:
+
+> _"Messages associated with any commits should not make any reference to the security nature of the commit."_
+
+**Matched text:**
+
+<security_matches>
+
+**To move forward, please do one of the following:**
+
+**(a) Neutralise the language** — edit the PR title and body to remove security references, and amend your commit messages so they describe the change without mentioning vulnerabilities. Then reply here to let us know it's done.
+
+**(b) Confirm disclosure is complete** — if the CVE for this fix is already publicly announced, reply with a link to the announcement. A maintainer will then proceed with normal review.
+
+If you haven't already followed the [ASF security reporting process](https://www.apache.org/security/committers.html), please report the vulnerability privately to `security@apache.org` (or the project's security list) before continuing.
+
+[Pull Request quality criteria](<quality_criteria_url>)
+
+<ai_attribution_footer>
+```
+
+---
+
 ## Draft comment
 
 *(`draft` — convert-to-draft comment)*


### PR DESCRIPTION
## Problem

Neither the triage skill nor the code-review skill checked whether a PR's
title, body, or commit messages contained language indicating a security fix.
Under the ASF vulnerability-handling process, such references must not appear
in public-facing content until the CVE is formally announced:

> *"Messages associated with any commits should not make any reference to
> the security nature of the commit."*
> — https://www.apache.org/security/committers.html

A maintainer could previously triage and approve a PR like:

```
Title:   Fix path traversal vulnerability in log viewer endpoint
Body:    This fixes a security issue. CVE-2024-47554 is pending announcement.
Commit:  "Fix path traversal vulnerability in log viewer"
```

…without ever being prompted to verify that the CVE process was complete.
PR titles, bodies, and commit messages are all editable before merge, so
early detection is directly actionable.

## Changes

**`.claude/skills/pr-management-triage/classify-and-act.md`** *(primary fix)*

- Row 7 renamed to **7a**; new row **7b** added immediately after.
- Row 7b classification: `security_language_signal` / Action: `comment`.
  Fires after the "too fresh" skip (7a) and before the first destructive
  action (row 8), so it catches otherwise-clean PRs that would otherwise
  reach `passing`.
- New `security_language_signal` predicate in the glossary — case-insensitive
  scan of `title`, `body`, and all `commits.nodes[].message` for CVE IDs
  (`CVE-\d{4}-\d+`) and a specific list of security-nature phrases. Each
  match is recorded with its location (title / body / commit SHA) for use
  in the comment template.

**`.claude/skills/pr-management-triage/comment-templates.md`** *(primary fix)*

- New `security-language` template used by row 7b's `comment` action.
- Quotes each matched text and location verbatim.
- Quotes the ASF policy sentence.
- Gives the contributor two explicit paths forward: (a) neutralise the
  language in title, body, and commit messages, or (b) confirm the CVE is
  already publicly announced with a link.
- Includes the standard AI-attribution footer.

**`.claude/skills/pr-management-code-review/review-flow.md`** *(safety net)*

- New `### Security-disclosure signal scan` subsection at the end of Step 3.
- Same pattern list as the triage predicate — scans title, body, and all
  commit messages before examining the diff.
- On any match: surfaces a pre-review warning, quotes the matched text and
  location, requires explicit `[Y]es` acknowledgment before Step 4 begins,
  and carries the warning into the final review body regardless of
  disposition.

**`.claude/skills/pr-management-code-review/criteria.md`** *(safety net)*

- Short blockquote pointer added at the top of the "Security model —
  calibration" section, cross-referencing the Step 3 disclosure scan.
  Existing calibration text is unchanged.

## Testing

**Structural validation**

`tools/skill-validator` run against all SKILL.md files post-change.
Result: 0 violations in pr-management skills.

**Functional dry-run — triage skill**

*Positive case* — PR #99998, title `"Fix path traversal vulnerability in log
viewer endpoint"`, body contains `"security issue"` and `"CVE-2024-47554"`,
commit `"Fix path traversal vulnerability in log viewer"`:

- Pre-filters pass through (external contributor, not draft, no prior triage
  marker, not own PR).
- Row 7a: created 2h ago, not `< 30min` → no match.
- Row 7b: 4 matches across title, body, and commit message → fires.
- Action: `comment` posted using `security-language` template, listing all
  matched locations verbatim. PR stays open; does not advance to
  `mark-ready`. ✓

*Negative case* — PR #99997, title `"Improve scheduler heartbeat retry
logic"`, neutral body and commits:

- Row 7b: 0 matches → skip.
- Row 20: green CI, no conflicts, no threads → `mark-ready`. No security
  comment posted. ✓

**Functional dry-run — code-review skill**

*Positive case* — PR with title `"Fix SQL injection vulnerability in DagBag
serializer"`, body referencing `"security issue"`, commit `"Fix SQL injection
in DagBag"`: 3 matches across all three locations; pre-review warning fires
before Step 4; explicit acknowledgment required. ✓

*Negative case* — PR `"Fix N+1 query in DagBag.get_dag()"`, neutral body and
commits: 0 matches; Step 4 proceeds immediately without pause. ✓