### PR TITLE
add third-party license compliance category and fix License headers routing

### DIFF
--- a/.claude/skills/pr-management-code-review/criteria.md
+++ b/.claude/skills/pr-management-code-review/criteria.md
@@ -60,6 +60,7 @@ The canonical category list:
 - Architecture boundaries
 - Database / query correctness
 - Code quality
+- Third-party license compliance
 - Testing
 - API correctness
 - UI (React/TypeScript)
@@ -72,6 +73,39 @@ The canonical category list:
 See
 [`projects/_template/pr-management-code-review-criteria.md` § Section anchors](../../../projects/_template/pr-management-code-review-criteria.md#section-anchors)
 for a worked example.
+
+---
+
+## Third-party license compliance
+
+When the diff adds or modifies a file that contains a non-Apache licence
+header (`SPDX-License-Identifier:` value other than `Apache-2.0`, or a
+recognised licence block — MIT, BSD, GPL, LGPL, CDDL, MPL, EPL, etc.) or a
+third-party copyright line (`Copyright (c) <non-ASF entity>`), classify the
+licence against the ASF `resolved_licenses` policy
+(`https://www.apache.org/legal/resolved.html`) and apply the following
+severity rules:
+
+| Category | Licences (examples) | Severity |
+|---|---|---|
+| X | GPL, AGPL, LGPL, CDDL, BUSL, SSPL | `blocking` — cannot be included in an ASF release in any form |
+| B | MPL, EPL | `blocking` — cannot be included in source form; binary-only inclusion requires explicit justification |
+| A | MIT, BSD-2, BSD-3, ISC, Apache 2.0 (other orgs) | `major` if `LICENSE` / `LICENSE.txt` / `licenses/` was **not** also updated in this PR — attribution is required before shipping |
+| A + LICENSE updated | any Category A | ✅ no finding |
+
+For Category A findings, check whether the same PR modifies `LICENSE`,
+`LICENSE.txt`, or any file under a `licenses/` directory. If it does, the
+inclusion is correctly attributed and no finding is raised.
+
+**Relationship to "License headers":** when a new file's header is non-Apache
+but not third-party (e.g. a contributor accidentally used the wrong SPDX
+identifier), the "License headers" finding applies. When the header is
+clearly from an upstream library or external author, route to this category
+instead — the fix is to preserve the original header and update `LICENSE`,
+not to replace it with an Apache header.
+
+Source: `https://www.apache.org/legal/resolved.html` and
+`https://www.apache.org/legal/apply-license.html`.
 
 ---
 

--- a/.claude/skills/pr-management-code-review/review-flow.md
+++ b/.claude/skills/pr-management-code-review/review-flow.md
@@ -167,12 +167,13 @@ match against are:
 1. **Architecture boundaries**
 2. **Database / query correctness**
 3. **Code quality**
-4. **Testing**
-5. **API correctness**
-6. **UI (React/TypeScript)**
-7. **Generated files**
-8. **AI-generated code signals**
-9. **Per-area `AGENTS.md` rules** — anything specific to the
+4. **Third-party license compliance**
+5. **Testing**
+6. **API correctness**
+7. **UI (React/TypeScript)**
+8. **Generated files**
+9. **AI-generated code signals**
+10. **Per-area `AGENTS.md` rules** — anything specific to the
    touched tree (the per-PR `AGENTS.md` discovery in Step 2).
 
 For each finding, record:

--- a/projects/_template/pr-management-code-review-criteria.md
+++ b/projects/_template/pr-management-code-review-criteria.md
@@ -97,3 +97,5 @@ These are used when the skill links out per-finding.
 | Quality signals to check | `https://github.com/apache/airflow/blob/main/.github/instructions/code-review.instructions.md#quality-signals-to-check` |
 | Commits and PRs (newsfragments, commit messages, tracking issues) | `https://github.com/apache/airflow/blob/main/AGENTS.md#commits-and-prs` |
 | Security model | `https://github.com/apache/airflow/blob/main/AGENTS.md#security-model` |
+| Third-party license compliance | `https://www.apache.org/legal/resolved.html` |
+| Applying the Apache licence | `https://www.apache.org/legal/apply-license.html` |


### PR DESCRIPTION
## Problem

The `pr-management-code-review` skill had no check for third-party-licensed
code being added to the project. A PR including a file with a GPL, MIT, or
CDDL header — or a third-party copyright line — passed through review
undetected. Under the ASF `resolved_licenses` policy, Category X and B
licences are forbidden in source form; Category A licences are allowed but
require the project's `LICENSE` file to be updated in the same PR.

A secondary gap: the existing "License headers" category (added previously)
would raise a "missing Apache header" finding against legitimately included
third-party code — the wrong fix for the wrong problem. The routing between
the two categories needed clarifying.

## Changes

**`.claude/skills/pr-management-code-review/criteria.md`**

- Added `Third-party license compliance` to the canonical category list
  (after "Code quality").
- Added a new "Third-party license compliance" section documenting:
  - What signals to detect (non-Apache SPDX identifiers, recognised licence
    blocks, third-party copyright lines).
  - Category X/B → `blocking`; Category A without LICENSE update → `major`;
    Category A with LICENSE update → no finding.
  - Routing note clarifying when to use "License headers" vs this category.

**`.claude/skills/pr-management-code-review/review-flow.md`**

- Step 4 enumeration updated: "Third-party license compliance" added as
  category 4; subsequent categories renumbered 5–10.

**`projects/_template/pr-management-code-review-criteria.md`**

- Two new rows added to the Section anchors table:
  - `Third-party license compliance` → `https://www.apache.org/legal/resolved.html`
  - `Applying the Apache licence` → `https://www.apache.org/legal/apply-license.html`
- These ship as ready-to-use defaults (global ASF policy, not project-specific).

## Testing

**Structural validation**

`tools/skill-validator` run against all SKILL.md files post-change.
Result: 0 violations in pr-management skills.

**Functional dry-run (4 cases)**

1. *Category X file added* — new file with `GNU General Public License v3.0`
   header: classified as Category X (GPL), `blocking` finding raised,
   disposition `REQUEST_CHANGES`. ✓

2. *Category A file added, LICENSE updated* — new MIT-licensed file, `LICENSE`
   also modified in same PR: Category A with attribution present, no finding
   raised. ✓

3. *Category A file added, LICENSE not updated* — same MIT file, `LICENSE`
   not touched: `major` finding raised citing
   `https://www.apache.org/legal/resolved.html`. ✓

4. *Clean PR* — all new files have Apache headers, no third-party copyright
   lines: 0 matches, no finding. ✓