### PR TITLE
add quality-signal guidance for binary images and compiled artifacts

### DIFF
--- a/.claude/skills/pr-management-code-review/criteria.md
+++ b/.claude/skills/pr-management-code-review/criteria.md
@@ -60,6 +60,7 @@ The canonical category list:
 - Architecture boundaries
 - Database / query correctness
 - Code quality
+- Third-party license compliance
 - Testing
 - API correctness
 - UI (React/TypeScript)
@@ -72,6 +73,39 @@ The canonical category list:
 See
 [`projects/_template/pr-management-code-review-criteria.md` § Section anchors](../../../projects/_template/pr-management-code-review-criteria.md#section-anchors)
 for a worked example.
+
+---
+
+## Third-party license compliance
+
+When the diff adds or modifies a file that contains a non-Apache licence
+header (`SPDX-License-Identifier:` value other than `Apache-2.0`, or a
+recognised licence block — MIT, BSD, GPL, LGPL, CDDL, MPL, EPL, etc.) or a
+third-party copyright line (`Copyright (c) <non-ASF entity>`), classify the
+licence against the ASF `resolved_licenses` policy
+(`https://www.apache.org/legal/resolved.html`) and apply the following
+severity rules:
+
+| Category | Licences (examples) | Severity |
+|---|---|---|
+| X | GPL, AGPL, LGPL, CDDL, BUSL, SSPL | `blocking` — cannot be included in an ASF release in any form |
+| B | MPL, EPL | `blocking` — cannot be included in source form; binary-only inclusion requires explicit justification |
+| A | MIT, BSD-2, BSD-3, ISC, Apache 2.0 (other orgs) | `major` if `LICENSE` / `LICENSE.txt` / `licenses/` was **not** also updated in this PR — attribution is required before shipping |
+| A + LICENSE updated | any Category A | ✅ no finding |
+
+For Category A findings, check whether the same PR modifies `LICENSE`,
+`LICENSE.txt`, or any file under a `licenses/` directory. If it does, the
+inclusion is correctly attributed and no finding is raised.
+
+**Relationship to "License headers":** when a new file's header is non-Apache
+but not third-party (e.g. a contributor accidentally used the wrong SPDX
+identifier), the "License headers" finding applies. When the header is
+clearly from an upstream library or external author, route to this category
+instead — the fix is to preserve the original header and update `LICENSE`,
+not to replace it with an Apache header.
+
+Source: `https://www.apache.org/legal/resolved.html` and
+`https://www.apache.org/legal/apply-license.html`.
 
 ---
 

--- a/.claude/skills/pr-management-code-review/criteria.md
+++ b/.claude/skills/pr-management-code-review/criteria.md
@@ -148,6 +148,48 @@ calibration explicitly. Don't paraphrase.
 
 ---
 
+## Quality signals to check — image IP
+
+The "Quality signals to check" category is primarily driven by the adopter's
+source files. The following is a **framework-level default** that applies
+regardless of adopter-specific rules.
+
+When the diff adds one or more binary image files (`.png`, `.jpg`, `.jpeg`,
+`.gif`, `.svg`, `.ico`, `.webp`), use judgment rather than raising an
+automatic finding:
+
+- **Contributor-created screenshots, diagrams, and documentation graphics**
+  are legitimate by default — no finding.
+- **Logos, brand assets, or illustrations** that look professionally produced
+  warrant a short comment asking the contributor to confirm the source and
+  licence: *"Could you confirm this image is original work or confirm its
+  licence? If it's from a third-party source, it may need a `LICENSE` entry
+  or a different approach."*
+
+Do not flag every image addition. The signal is the visual character of the
+asset — a hand-drawn architecture diagram is different from a polished brand
+logo. When in doubt, ask rather than block.
+
+## Quality signals to check — compiled artifacts
+
+ASF releases must be source-only. Compiled or binary build artifacts added to
+the repository risk ending up in a release, violating the ASF Release Policy
+(`https://www.apache.org/legal/release-policy.html`).
+
+When the diff adds any of the following file types, raise a `major` finding:
+
+- **JVM**: `.class`, `.jar` (non-empty), `.war`, `.ear`
+- **Python**: `.pyc`, `.pyo`, `.pyd`
+- **Native**: `.so`, `.dll`, `.dylib`, `.exe`, `.o`, `.a`
+- **Packages**: `.whl`, `.egg`
+
+The finding is `major` with the text: *"Compiled artifacts must not be
+committed to the source tree — ASF releases are source-only. Remove this
+file and ensure it is generated at build time."* If the file would be
+included in a release archive, escalate to `blocking`.
+
+---
+
 ## Backports and version-specific PRs
 
 If the adopter's

--- a/.claude/skills/pr-management-code-review/review-flow.md
+++ b/.claude/skills/pr-management-code-review/review-flow.md
@@ -167,12 +167,13 @@ match against are:
 1. **Architecture boundaries**
 2. **Database / query correctness**
 3. **Code quality**
-4. **Testing**
-5. **API correctness**
-6. **UI (React/TypeScript)**
-7. **Generated files**
-8. **AI-generated code signals**
-9. **Per-area `AGENTS.md` rules** — anything specific to the
+4. **Third-party license compliance**
+5. **Testing**
+6. **API correctness**
+7. **UI (React/TypeScript)**
+8. **Generated files**
+9. **AI-generated code signals**
+10. **Per-area `AGENTS.md` rules** — anything specific to the
    touched tree (the per-PR `AGENTS.md` discovery in Step 2).
 
 For each finding, record:

--- a/projects/_template/pr-management-code-review-criteria.md
+++ b/projects/_template/pr-management-code-review-criteria.md
@@ -97,3 +97,5 @@ These are used when the skill links out per-finding.
 | Quality signals to check | `https://github.com/apache/airflow/blob/main/.github/instructions/code-review.instructions.md#quality-signals-to-check` |
 | Commits and PRs (newsfragments, commit messages, tracking issues) | `https://github.com/apache/airflow/blob/main/AGENTS.md#commits-and-prs` |
 | Security model | `https://github.com/apache/airflow/blob/main/AGENTS.md#security-model` |
+| Third-party license compliance | `https://www.apache.org/legal/resolved.html` |
+| Applying the Apache licence | `https://www.apache.org/legal/apply-license.html` |


### PR DESCRIPTION
## Problem

The `pr-management-code-review` skill had no guidance for two categories of
file that carry IP or release-policy risk:

1. **Binary images** — logos, brand assets, or stock illustrations may carry
   copyright restrictions but have no machine-readable licence metadata.
   Flagging every image would be too noisy; the right behaviour is
   judgment-based.

2. **Compiled artifacts** — ASF releases must be source-only. Committed
   `.class`, `.jar`, `.so`, `.whl`, etc. risk ending up in a release archive.
   There is little legitimate reason to commit them to a source tree.

Neither had any guidance in the skill; both passed through review unchecked.

## Changes

**`.claude/skills/pr-management-code-review/criteria.md`**

Two new framework-level default subsections added under "Quality signals
to check". Both apply regardless of what the adopter's source files say.

*Image IP:* when the diff adds binary image files (`.png`, `.jpg`, `.jpeg`,
`.gif`, `.svg`, `.ico`, `.webp`), the reviewer uses judgment rather than
raising an automatic finding. Contributor-created screenshots and diagrams
are legitimate by default. Logos, brand assets, or professionally produced
illustrations warrant a short comment asking the contributor to confirm
source and licence.

*Compiled artifacts:* when the diff adds any of the following, raise a
`major` finding with standard text directing the contributor to remove the
file and generate it at build time:

- JVM: `.class`, `.jar`, `.war`, `.ear`
- Python: `.pyc`, `.pyo`, `.pyd`
- Native: `.so`, `.dll`, `.dylib`, `.exe`, `.o`, `.a`
- Packages: `.whl`, `.egg`

If the file would be included in a release archive, the reviewer escalates
to `blocking`.

## Testing

**Structural validation**

`tools/skill-validator` run against all SKILL.md files post-change.
Result: 0 violations in pr-management skills.

**Functional dry-run (5 cases)**

1. *`.class` file added* — `major` finding raised, standard removal text. ✓
2. *Non-empty `.jar` added* — `major` finding raised. ✓
3. *`.whl` named as a release artifact* — `major` raised; reviewer escalates
   to `blocking`. ✓
4. *Documentation screenshot added* — contributor-created asset, no finding. ✓
5. *Asset named `partner_logo.png`* — looks professionally produced; reviewer
   prompted to ask contributor to confirm source and licence. ✓
6. *Clean `.py`-only PR* — no image or compiled extensions; no finding. ✓