### PR TITLE
fix(skills): align pr-management-code-review name with directory

### DIFF
--- a/.claude/skills/pr-management-code-review/SKILL.md
+++ b/.claude/skills/pr-management-code-review/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: maintainer-review
+name: pr-management-code-review
 mode: Triage
 description: |
   Walk a maintainer through deep, sequential code review of open pull requests on the configured `<upstream>` repo.
@@ -24,7 +24,7 @@ license: Apache-2.0
      <base>   → the PR's base branch (typically `main`)
      Substitute these before running any `gh` command below. -->
 
-# maintainer-review
+# pr-management-code-review
 
 This skill walks a maintainer through **deep, line-aware review**
 of open pull requests, **one PR at a time**. Its job is to answer

--- a/.claude/skills/pr-management-stats/SKILL.md
+++ b/.claude/skills/pr-management-stats/SKILL.md
@@ -121,7 +121,7 @@ read-only and inherits everything from `pr-management-triage`'s contract.
 
 **Golden rule 6 — recommendations are deterministic, not opinions.** Every action surfaced in the "What needs attention" panel comes from a fixed rule in [`render.md#recommendation-rules`](render.md#recommendation-rules). The skill never editorialises ("queue is doing well", "you should focus on X") — it surfaces the rule's trigger and the suggested next-step command. The maintainer reads the trigger and decides; the skill never decides for them. New rules are added by editing the rules table, not by adding free-text inside the renderer.
 
-**Golden rule 7 — actions link to other skills, never mutate.** Every recommendation's `action` field is the *exact* slash-command the maintainer can paste to do the work — almost always `/pr-management-triage`, `/maintainer-review`, or a focused variant with a label/PR-number filter. The stats skill itself remains pure-read (Golden rule 1); the dashboard makes downstream skills *one paste away* from running.
+**Golden rule 7 — actions link to other skills, never mutate.** Every recommendation's `action` field is the *exact* slash-command the maintainer can paste to do the work — almost always `/pr-management-triage`, `/pr-management-code-review`, or a focused variant with a label/PR-number filter. The stats skill itself remains pure-read (Golden rule 1); the dashboard makes downstream skills *one paste away* from running.
 
 ---
 

--- a/.claude/skills/pr-management-stats/render.md
+++ b/.claude/skills/pr-management-stats/render.md
@@ -247,7 +247,7 @@ Distinct from the colour scheme: these are the four conceptual *states* a contri
 
 | Marker | Definition | Colour | Maintainer action |
 |---|---|---|---|
-| `Ready for review` | `ready for maintainer review` label is present | green | run `/maintainer-review` to actually code-review the PR |
+| `Ready for review` | `ready for maintainer review` label is present | green | run `/pr-management-code-review` to actually code-review the PR |
 | `Responded` | PR is triaged AND author has commented or pushed after the triage comment, AND not yet `Ready` | bright cyan | re-triage; may now qualify for `request-author-confirmation` (first leg of the two-sweep mark-ready gate) |
 | `Waiting for Author` | PR is triaged, no author response — OR — PR is a draft (whether triaged or not) | amber | nothing; author owns the next move (may become a sweep candidate after 7d) |
 | `Not yet triaged` | None of the above. Non-draft PR that has never received a quality-criteria comment | blue (or grey) | run `/pr-management-triage` to give it a first look |


### PR DESCRIPTION
## Summary

- `name:` field in `.claude/skills/pr-management-code-review/SKILL.md` was still `maintainer-review`
- Updated the `name:` field and the in-file `# maintainer-review` heading.
- Updated two stale slash-command references (`/maintainer-review` →
  `/pr-management-code-review`) in `pr-management-stats/{SKILL,render}.md`.

## Test plan

- [ ] `grep -rn "maintainer-review" .claude/skills/` returns only the
      GitHub-label and prose references listed above.
- [ ] `grep "^name:" .claude/skills/pr-management-*/SKILL.md` — all four
      match their directory name.
- [ ] Skill-validator (if it runs in CI) stays green on the updated frontmatter.
