### PR TITLE
add License headers rule body (follow-up to #187): defer to header tooling, cover no-tooling and exclusion-masking cases

### DIFF
--- a/.claude/skills/pr-management-code-review/criteria.md
+++ b/.claude/skills/pr-management-code-review/criteria.md
@@ -100,13 +100,111 @@ inclusion is correctly attributed and no finding is raised.
 
 **Relationship to "License headers":** when a new file's header is non-Apache
 but not third-party (e.g. a contributor accidentally used the wrong SPDX
-identifier), the "License headers" finding applies. When the header is
+identifier), the "License headers" finding applies (see
+[§ License headers](#license-headers) below). When the header is
 clearly from an upstream library or external author, route to this category
 instead — the fix is to preserve the original header and update `LICENSE`,
 not to replace it with an Apache header.
 
 Source: `https://www.apache.org/legal/resolved.html` and
 `https://www.apache.org/legal/apply-license.html`.
+
+---
+
+## License headers
+
+ASF policy requires every source file in a release to carry the
+standard Apache license header
+(`https://www.apache.org/legal/src-headers.html`). This is a
+**framework-level default** that applies regardless of
+adopter-specific rules.
+
+**Defer to the project's header tooling when it exists.** Most ASF
+projects enforce headers in CI — `apache-rat`, the pre-commit
+`insert-license` hook, `license-eye` / `skywalking-eyes`, or an
+equivalent. If such a check appears in the PR's status-check
+rollup (the [CI precheck](prerequisites.md) already reads it):
+
+- That tool is **authoritative for the mechanical question** —
+  "does this file carry the header" — including which paths are
+  in scope. Do **not** raise a duplicate "missing header"
+  finding: a real miss already turns the check red, and Golden
+  rule 8 already takes `APPROVE` off the table and quotes the
+  failing check. Restating it as a review finding is noise and
+  risks contradicting the tool's own exclusion list.
+- The source of truth for **scope and exemptions** is the
+  project's tool config (the `apache-rat` `<excludes>` block,
+  `.rat-excludes`, the pre-commit `exclude:` regex, the
+  `licenserc.yaml` ignore globs — whatever the project uses),
+  **not** the policy page. When reasoning about whether a file
+  is in scope, read that config, not a summarised list here.
+
+**Fallback — projects with no header tooling.** If no
+license-header check appears in the rollup, the skill **is** the
+safety net. Scan every source file the diff **adds** (and any it
+materially rewrites) for the Apache header; raise a `major`
+finding for each contributor-authored file missing it, quoting
+`https://www.apache.org/legal/src-headers.html`. Apply the
+exemptions below using judgement, and the *When in doubt — defer*
+rule at the end of this file for anything borderline.
+
+**The exclusion-masking case — check even when CI is green.**
+Deference above assumes the tool's exclusion list is fixed. It is
+not when the **PR itself changes it**. If the same diff both
+(a) adds or modifies a header-tool exclusion entry — an
+`<exclude>` in `pom.xml` / `build.gradle`, a line in
+`.rat-excludes`, an `exclude:` pattern in
+`.pre-commit-config.yaml`, an ignore glob in `licenserc.yaml`,
+etc. — and (b) adds a file that lacks an Apache header or carries
+a third-party header, then the check passes **green by
+construction** and CI deference gives no coverage. This is
+precisely where the skill earns its place. Raise a `major`
+finding asking the maintainer to confirm the exclusion is
+appropriate:
+
+- **Legitimately exempt** — generated code, data/test fixtures,
+  binary assets, or a genuinely third-party file correctly
+  attributed in `LICENSE` (route the third-party part to
+  [§ Third-party license compliance](#third-party-license-compliance)).
+  If so, the exclusion is fine; note it and move on.
+- **Masking a missing header** — a contributor-authored source
+  file that simply has no header and was excluded to make CI
+  pass. Not acceptable; the fix is to add the header, not to
+  exclude the file.
+
+Quote the added exclusion line and the offending file path in the
+finding so the maintainer can adjudicate without digging.
+
+**Judgement cases the tool cannot decide.** Even on a
+fully-tooled project, raise a finding for:
+
+- a contributor-authored file with a **mis-applied SPDX
+  identifier** or the **wrong license** in an otherwise
+  Apache-intended header (the tool sees *a* header and passes;
+  the header is still wrong);
+- a header that is **clearly third-party / upstream** — do not
+  treat as a missing-header miss; route to
+  [§ Third-party license compliance](#third-party-license-compliance)
+  (the fix there is preserve-and-attribute, not replace).
+
+**Exemptions (no finding).** Generated files; vendored or
+third-party files (handled by the third-party category); data and
+test-resource fixtures; binary files; trivially short config/data
+files where the project conventionally omits headers. On a tooled
+project the project config is the authority for these; on an
+untooled project use judgement and defer when unsure.
+
+| Situation | Severity |
+|---|---|
+| Missing header, no header tooling in CI | `major` |
+| Missing / 3rd-party header + new tool exclusion in same PR | `major` (confirm exclusion is justified) |
+| Wrong / mis-applied SPDX on contributor-authored file | `major` |
+| Missing header but header tooling is red on the PR | no separate finding — defer to CI (Golden rule 8) |
+| Header added in this PR alongside the file | `nit` / no finding |
+
+Source: `https://www.apache.org/legal/src-headers.html` (policy)
+and the project's own header-tool configuration (scope and
+exemptions).
 
 ---
 


### PR DESCRIPTION
## Follow-up to #187 — add the missing `## License headers` rule body

#187 added **License headers** to the canonical category list in
`criteria.md` and a section-anchor URL in the template, and re-synced the
`review-flow.md` Step 4 enumeration. It did not add a `## License headers`
section. That left it the only framework-default category (the others being
*Third-party license compliance*, *Security model*, *Quality signals — image
IP / compiled artifacts*) with **neither an adopter source file nor a
`criteria.md` rule body** — just a name and a link to a policy page. The
existing *Relationship to "License headers"* cross-reference in the
Third-party section also pointed at a section that did not exist.

This PR adds that section, written as a **deference-plus-judgement layer,
not a re-implementation of `apache-rat` / pre-commit**.

### What it covers

- **Defer to header tooling when it exists.** If a license-header check
  (`apache-rat`, pre-commit `insert-license`, `license-eye`, …) is in the
  PR's status-check rollup, that tool is authoritative for mechanical
  presence/absence. The skill does **not** raise a duplicate "missing
  header" finding — Golden rule 8 + the CI precheck already take `APPROVE`
  off the table on its failure and quote the failing check. The project's
  tool config (not the policy page) is treated as the source of truth for
  scope and exclusions, so the skill cannot drift from / contradict the
  tool's own exclusion list.
- **No-tooling fallback retained.** Not every ASF project wires header
  checks into required CI. Where none is present, the skill is the safety
  net and scans added / materially-rewritten source files itself.
- **Exclusion-masking case (the gap CI deference does *not* close).** When
  the same PR both (a) adds or modifies a header-tool exclusion entry —
  `<exclude>` in `pom.xml`/`build.gradle`, a line in `.rat-excludes`, an
  `exclude:` pattern in `.pre-commit-config.yaml`, an ignore glob in
  `licenserc.yaml` — and (b) adds a file with no header or a third-party
  header, the check passes **green by construction**. Deference gives no
  coverage here, so the skill raises a finding asking the maintainer to
  confirm the new exclusion is appropriate (legitimately exempt vs masking
  a missing header).
- **Judgement cases the tool cannot decide:** mis-applied SPDX / wrong
  license on a contributor-authored file (the tool sees *a* header and
  passes), and third-party-header routing — closing the loop with the
  existing *Third-party license compliance* cross-reference, which now
  links forward to the new section.

### Scope / testing

- Single file changed: `.claude/skills/pr-management-code-review/criteria.md`
  (new `## License headers` section + a forward link added to the existing
  cross-reference so the loop resolves).
- `skill-validate`, `markdownlint`, and the full pre-commit hook set pass.
- Severity calibration is summarised in a table matching the file's
  existing compact-table house style.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
