### PR TITLE
fix(vulnogram-api): treat non-login 3xx as valid session in probe

### DIFF
--- a/tools/vulnogram/oauth-api/src/vulnogram_api/client.py
+++ b/tools/vulnogram/oauth-api/src/vulnogram_api/client.py
@@ -260,6 +260,12 @@ def probe(session: Session, *, section: str = "cve5", timeout: int = DEFAULT_TIM
 
     Used by :mod:`vulnogram_api.check`. Picks ``/<section>/new`` because
     it requires authentication but does no DB writes.
+
+    A non-login redirect (e.g. Vulnogram now 302-redirects ``/cve5/new`` to
+    ``/allocatecve``) means the session was successfully validated by the
+    app — only the post-auth destination changed. Treat any non-login 3xx
+    as ``valid``; pinning the probe URL would otherwise need a sync release
+    every time the Vulnogram app reshuffles its routing.
     """
     url = f"https://{session.host}/{section}/new"
     try:
@@ -268,6 +274,6 @@ def probe(session: Session, *, section: str = "cve5", timeout: int = DEFAULT_TIM
         return f"error: {e}"
     if _is_login_redirect(status, headers):
         return "expired"
-    if status == 200:
+    if status == 200 or status in (301, 302, 303, 307, 308):
         return "valid"
     return f"error: HTTP {status}"

--- a/tools/vulnogram/oauth-api/tests/test_client.py
+++ b/tools/vulnogram/oauth-api/tests/test_client.py
@@ -239,3 +239,12 @@ def test_probe_unexpected_status():
     with _patch_opener(open_fn):
         result = probe(_session())
     assert result.startswith("error: HTTP 500")
+
+
+def test_probe_valid_on_non_login_redirect():
+    # Vulnogram now 302-redirects /cve5/new to /allocatecve. The redirect is
+    # NOT to oauth.apache.org / /users/login, so it indicates the session
+    # passed auth — only the post-auth landing page changed.
+    open_fn = _fake_open(302, b"", {"Location": "/allocatecve"})
+    with _patch_opener(open_fn):
+        assert probe(_session()) == "valid"


### PR DESCRIPTION
## Summary

`vulnogram-api-check` was returning `error: HTTP 302` whenever the probe URL redirected to a non-login destination. Upstream Vulnogram now 302-redirects `/cve5/new` → `/allocatecve` (the PMC-gated allocation page), and the probe code treated *any* non-OAuth 3xx as an unknown error.

This was producing **false-negative "expired" diagnoses on adopter machines whose sessions were actually working** — `vulnogram-api-record-update` (which hits a different endpoint) kept succeeding, so `security-issue-sync` was incorrectly falling back to the "manual paste required" release-manager hand-off variant on trackers whose CVE JSON had in fact been auto-pushed.

## Fix

`_is_login_redirect` already encodes the only failure mode worth detecting (3xx to `oauth.apache.org` or `/users/login` → session expired). Any *other* 3xx means the app processed the session cookie successfully and chose to redirect to a different authenticated page — the session is valid; only the post-auth landing page changed.

The fix is a one-line additive condition in `probe()` plus a regression test covering the `/cve5/new` → `/allocatecve` case.

## Diff

| File | Δ |
|---|---|
| `tools/vulnogram/oauth-api/src/vulnogram_api/client.py` | +8 −1 (`probe()` accepts non-login 3xx as valid, with docstring explaining why) |
| `tools/vulnogram/oauth-api/tests/test_client.py` | +9 (new `test_probe_valid_on_non_login_redirect`) |

## Test plan

- [x] `pytest tests/test_client.py` — 14 tests pass (was 13 + the new regression test).
- [x] Live probe with my Apache OAuth session: previously returned `error: HTTP 302`, now returns `valid` (URL redirects to `/allocatecve` as expected).
- [x] Live push via `vulnogram-api-record-update` for 3 CVEs (`CVE-2026-27173`, `CVE-2026-42359`, `CVE-2026-42526`) — all succeeded, demonstrating that the session is functional and the probe was the false negative.
- [ ] Other adopters with valid sessions confirm `vulnogram-api-check` flips from `error: HTTP 302` → `valid` after this lands.

## Why "treat as valid" instead of changing the probe URL

The alternatives considered:

- **Change probe URL to `/cve5` (dashboard)** — would work for now but breaks again the next time Vulnogram reshuffles routing.
- **Follow redirects in `_request`** — invasive change to `_request`'s contract; other call sites rely on seeing the raw 3xx.
- **Accept non-login 3xx as valid (this PR)** — minimal change, doesn't pin to a specific URL, and the semantic is correct: "we got past auth" *is* what we wanted to probe.

🤖 Generated with [Claude Code](https://claude.com/claude-code)