### PR TITLE
chore(gitignore): ignore macOS finder/metadata files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,14 @@ logs
 .claude/worktrees/
 .claude/settings.local.json
 
+# macOS
+.DS_Store
+.AppleDouble
+.LSOverride
+._*
+.Spotlight-V100
+.Trashes
+
 # Python
 __pycache__/
 *.py[cod]


### PR DESCRIPTION
## Summary

Adds the standard macOS-generated files to `.gitignore` so they don't surface
in `git status` for contributors working on macOS:

- `.DS_Store` — Finder metadata
- `._*` — AppleDouble resource forks
- `.Spotlight-V100`, `.Trashes` — Spotlight index / Trash on mounted volumes
- `.AppleDouble`, `.LSOverride` — legacy resource forks / Launch Services overrides

No behavioural change — `.gitignore` only.

## Test plan

- [ ] On macOS, `touch .DS_Store ._foo` in the repo and confirm `git status` shows clean.
- [ ] Confirm no previously-tracked file becomes untracked (these patterns aren't currently in the repo).

Generated-by: Claude Code (Opus 4.7)