### PR TITLE
chore(asf): enable required-status-checks protection on main

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -100,9 +100,79 @@ github:
   # asfyaml / PyGithub interaction is fixed upstream and a release
   # workflow exists that needs the environment.
 
-  # No `protected_branches:` block by design — branch protections are
-  # configured directly in GitHub for now. Add here when the project's
-  # release / branching policy stabilises.
+  # Branch protection on `main`. ASF Infra reconciles this within a
+  # few minutes of merge to main (asfyaml feature
+  # `protected_branches`). Earlier note about "configured directly in
+  # GitHub" was superseded by inspection — no direct-on-GitHub rule
+  # ever existed, so the protection now lives here next to the rest
+  # of the repo config.
+  #
+  # TEMPORARY POSTURE — REVISIT AT PMC FORMATION
+  # --------------------------------------------
+  # Pull-request approvals are intentionally NOT required while the
+  # framework is in its bootstrap phase under the Airflow PMC
+  # umbrella with a small set of committers (see MISSION.md). Once
+  # the project establishes its own PMC, this block MUST be
+  # revisited: add a `required_pull_request_reviews:` section with
+  # `required_approving_review_count: 1` (or higher) and
+  # `dismiss_stale_reviews` / `require_code_owner_reviews` tuned to
+  # the new committer / CODEOWNERS shape. Until then, status checks
+  # alone gate merges — a maintainer can self-merge after CI green.
+  protected_branches:
+    main:
+      # Required status checks. Listed contexts MUST run on every PR
+      # against `main` — path-filtered workflows are excluded
+      # (classic branch-protection has no "require only if run"
+      # semantics, so a path-filtered job that doesn't post a status
+      # would block the PR). Excluded for that reason:
+      # `asf-allowlist-check` (paths: `.github/**`) and
+      # `lint .claude/settings.json against baseline` from
+      # sandbox-lint (paths: `.claude/settings.json` +
+      # `tools/sandbox-lint/**`). Also excluded: `lychee` (the
+      # link-check runs on every PR, but external link rot is a
+      # maintenance concern handled by the daily schedule — it is
+      # not a merge-blocker).
+      required_status_checks:
+        # `strict: false` — don't require the PR branch to be up
+        # to date with `main` before merging. With `strict: true`,
+        # every merge to `main` invalidates every other open PR and
+        # forces a rebase loop. False matches typical ASF practice
+        # for multi-contributor repos.
+        strict: false
+        contexts:
+          # CodeQL — two matrix legs (Python + GitHub Actions YAML).
+          - "Analyze (python)"
+          - "Analyze (actions)"
+          # zizmor (GitHub Actions security lint; complements CodeQL).
+          - "zizmor"
+          # Pre-commit (prek) — static checks across the repo.
+          - "prek"
+          # Per-project pytest matrix from tests.yml. Mirrors the
+          # `matrix.project[].name` list there; keep these two
+          # lists in sync when projects are added or renamed.
+          - "pytest (oauth-draft)"
+          - "pytest (generate-cve-json)"
+          - "pytest (skill-validator)"
+          - "pytest (privacy-llm-checker)"
+          - "pytest (privacy-llm-redactor)"
+          - "pytest (vulnogram-oauth-api)"
+          - "pytest (sandbox-lint)"
+      # `required_pull_request_reviews:` deliberately omitted — see
+      # the TEMPORARY POSTURE note above. Re-add at PMC formation.
+      #
+      # Linear history matches `enabled_merge_buttons.squash: true`
+      # above — squash is the only enabled merge mode, so every
+      # merge results in a single commit on top of main.
+      required_linear_history: true
+      # Block merge while review threads remain unresolved. This
+      # bites even without an approval requirement: any reviewer
+      # who opens a thread blocks merge until it is resolved.
+      required_conversation_resolution: true
+      # Do NOT require signed commits. External contributors
+      # without configured GPG/SSH signing would be unable to
+      # contribute. Re-enable if/when the project adopts a
+      # committer-only signing policy.
+      required_signatures: false
 
 notifications:
   # The framework is hosted under the Airflow PMC umbrella for now;


### PR DESCRIPTION
## Summary

`main` on this repo is currently unprotected (verified — `GET /branches/main/protection` returns 404; no rulesets attached). The prior `.asf.yaml` comment said *"branch protections are configured directly in GitHub for now"*, but inspection showed no direct-on-GitHub rule was ever created. This PR moves branch-protection ownership into `.asf.yaml` where it sits next to the rest of the repo config; ASF Infra reconciles it within a few minutes of merge.

## What lands

A new `protected_branches: main:` block in `.asf.yaml`, with **eleven required status checks** — every workflow that runs on every PR, named with its exact job context:

| Workflow | Required context(s) |
| --- | --- |
| `codeql.yml` (post-#203) | `Analyze (python)`, `Analyze (actions)` |
| `zizmor.yml` | `zizmor` |
| `pre-commit.yml` | `prek` |
| `tests.yml` (matrix) | `pytest (oauth-draft)`, `pytest (generate-cve-json)`, `pytest (skill-validator)`, `pytest (privacy-llm-checker)`, `pytest (privacy-llm-redactor)`, `pytest (vulnogram-oauth-api)`, `pytest (sandbox-lint)` |

Plus:
- `strict: false` — merging on `main` does not invalidate every other open PR.
- `required_linear_history: true` — matches the existing `enabled_merge_buttons.squash: true`.
- `required_conversation_resolution: true` — blocks merge while any review thread is unresolved (independent of the approval requirement).
- `required_signatures: false` — external contributors without GPG/SSH signing must remain able to contribute.

## What's intentionally NOT required

- **`asf-allowlist-check`** — path-filtered to `.github/**`.
- **`lint .claude/settings.json against baseline`** (sandbox-lint) — path-filtered to `.claude/settings.json` + `tools/sandbox-lint/**` + `.github/workflows/sandbox-lint.yml`.
- **`lychee`** (link-check) — runs on every PR but external link rot is a maintenance concern handled by the daily scheduled run, not a merge-blocker.

Classic branch protection has no *"only require if run"* semantics — a path-filtered job that doesn't post a status would block every PR that didn't touch the filtered paths. The three above are excluded for that reason.

## Temporary posture — no approval requirement (yet)

`required_pull_request_reviews:` is **deliberately omitted**. The `.asf.yaml` block carries a prominent **`TEMPORARY POSTURE — REVISIT AT PMC FORMATION`** comment so this doesn't get forgotten. Rationale: the framework is in its bootstrap phase under the Airflow PMC umbrella with a small committer set (MISSION.md); requiring approvals at this stage would block routine maintainer self-merges. Status checks alone gate merges in the interim.

When the project establishes its own PMC, that block must be re-added with `required_approving_review_count: 1` (or higher), `dismiss_stale_reviews` tuned to the new committer / CODEOWNERS shape, and any code-owner requirements the new PMC chooses to set.

## Test plan

- [ ] After merge, wait ~5 min for ASF Infra to reconcile, then `gh api repos/apache/airflow-steward/branches/main/protection` returns a non-404 payload listing the eleven contexts above.
- [ ] Open a follow-up trivial PR (e.g. a typo fix) and confirm the "Merge" button is gated on the eleven checks — and confirm that *no approval is required* and the maintainer can self-merge once all checks pass.
- [ ] Open a follow-up PR with an unresolved review thread; confirm merge is blocked even with checks green (validates `required_conversation_resolution`).
- [ ] Confirm path-filtered workflows (`asf-allowlist-check`, sandbox-lint) being skipped on an unrelated PR does NOT block merging (validates the omission rationale).
- [ ] Sanity: a non-squash merge attempt is rejected (validates `required_linear_history` together with the squash-only `enabled_merge_buttons`).
- [ ] At PMC formation, file a follow-up PR adding `required_pull_request_reviews:` and remove the TEMPORARY POSTURE comment.

Generated-by: Claude Code (Opus 4.7)