### PR TITLE
docs(AGENTS): require agents to install + run prek before opening a PR

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -396,6 +396,17 @@ commit again. **Do not bypass the hooks with `--no-verify`** —
 if a hook is failing, fix the underlying issue or update the
 hook configuration in the same PR.
 
+**Before opening or updating a pull request, run
+`prek run --all-files` (or `prek run --from-ref <base>` against
+the PR's base branch) as a hard pre-flight gate.** The
+`prek install` git hook fires on each `git commit`, but only
+against the files in that commit — issues in files committed
+earlier on the branch (or files the current commit didn't
+touch) can slip past it. A whole-tree `prek run` mirrors what
+CI executes and surfaces those regressions locally before the
+PR round-trip, instead of after a CI failure that costs a
+round-trip and a reviewer's attention on a mechanical fix.
+
 **Keep the framework snapshot in sync with the project's pin.**
 The framework lives at `<adopter-tracker>/.apache-steward/` as a
 **gitignored snapshot** that


### PR DESCRIPTION
## Summary

- The repo's CI `prek` job recently caught a markdown-lint regression
  that a local `prek run` would have surfaced before the PR was opened
  (see #205).
- Tighten the AGENTS.md guidance: agents MUST install `prek` if it is
  not already present in the clone and MUST run it locally as a
  pre-flight gate before opening or updating any PR — CI is a
  backstop, not a substitute.

## Test plan

- [x] `prek run --files AGENTS.md` — all hooks pass locally.

## Gen-AI disclosure

This change was drafted with the help of Claude Code (Opus 4.7) as
documented in [`AGENTS.md`](AGENTS.md#commit-and-pr-conventions).

Generated-by: Claude Code (Opus 4.7)