### PR TITLE
fix(pr-management-stats): refine is_untriaged predicate + surface draft/non-draft split

### DIFF
--- a/.claude/skills/pr-management-stats/aggregate.md
+++ b/.claude/skills/pr-management-stats/aggregate.md
@@ -58,8 +58,8 @@ the label itself is evidence that the PR cleared the triage bar.
 - `contributors + collaborator_authored + bot_authored == total` (three disjoint author classes)
 - `contributors == drafts + non_drafts` (each contributor PR is one or the other)
 - `triaged_waiting + triaged_responded <= contributors`
-- `triaged_waiting + triaged_responded <= engaged` (strict-triaged is a subset of engaged)
-- `defacto_triaged + (triaged_waiting + triaged_responded) == engaged` (every engaged PR is either strictly triaged or de-facto-only)
+- `triaged_waiting + triaged_responded <= engaged` (Quality-Criteria-triaged is a subset of engaged)
+- `defacto_triaged + (triaged_waiting + triaged_responded) == engaged` (every engaged PR is either Quality-Criteria-triaged or de-facto-only)
 - `ready_for_review <= non_drafts` (a ready PR shouldn't be draft — if the inequality fails, the label is stale; surface a one-line warning but don't correct the data)
 - `untriaged_old + untriaged_med <= untriaged_nondraft <= non_drafts`
 - `engaged + untriaged_nondraft + ready_for_review == non_drafts (contributor)` (the partition: every contributor non-draft is exactly one of `is_engaged` (strict OR de-facto), `is_untriaged` (no maintainer touched), or already-`ready` labelled — the three are mutually exclusive once the `is_untriaged` definition uses `NOT is_engaged` rather than `NOT is_triaged`)

--- a/.claude/skills/pr-management-stats/aggregate.md
+++ b/.claude/skills/pr-management-stats/aggregate.md
@@ -35,11 +35,11 @@ One `_AreaStats` block per area. Only two counters (`total` and `contributors`) 
 | `triaged_waiting` | classified `triaged_waiting` (see `classify.md`) | contributor-only |
 | `triaged_responded` | classified `triaged_responded` | contributor-only |
 | `ready_for_review` | label `ready for maintainer review` present | contributor-only |
-| `engaged` | satisfies [`is_engaged`](classify.md#is_engaged--broader-maintainer-touched-this-predicate) (any maintainer touched it) | contributor-only |
-| `defacto_triaged` | satisfies [`is_defacto_triaged`](classify.md#is_defacto_triaged--engaged-but-no-marker) (engaged but no marker) | contributor-only |
-| `ai_triaged` | satisfies [`is_ai_triaged`](classify.md#is_ai_triaged--received-an-ai-generated-triage-comment) (received an AI-assisted triage comment) | contributor-only |
+| `engaged` | satisfies [`is_engaged`](classify.md#is_engaged--de-facto-triaged) (any maintainer touched it) | contributor-only |
+| `defacto_triaged` | satisfies [`is_defacto_triaged`](classify.md#is_engaged--de-facto-triaged) (engaged but no marker) | contributor-only |
+| `ai_triaged` | satisfies [`is_ai_triaged`](classify.md#is_ai_triaged--ai-assisted-triage) (received an AI-assisted triage comment) | contributor-only |
 | `bot_authored` | [`is_bot`](classify.md#is_bot--author-is-a-recognised-bot)(pr.author.login) | **all** — its own category, NOT in `contributors` |
-| `untriaged_nondraft` | satisfies [`is_untriaged`](classify.md#is_untriaged--refined-predicate) AND `isDraft == false` | contributor-only |
+| `untriaged_nondraft` | satisfies [`is_untriaged`](classify.md#is_untriaged--broad-untriaged) AND `isDraft == false` | contributor-only |
 | `untriaged_old` | `untriaged_nondraft` AND `age_bucket == ">4w"` | contributor-only |
 | `untriaged_med` | `untriaged_nondraft` AND `age_bucket == "1-4w"` | contributor-only |
 | `triager_drafted` | classified `drafted_by_triager` | contributor-only |
@@ -47,7 +47,7 @@ One `_AreaStats` block per area. Only two counters (`total` and `contributors`) 
 | `draft_age_buckets` | histogram over PRs where `drafted_at` is set, same bucket labels | contributor-only |
 
 The three `untriaged_*` counters share the same predicate (see
-[`classify.md#is_untriaged--refined-predicate`](classify.md#is_untriaged--refined-predicate))
+[`classify.md#is_untriaged--broad-untriaged`](classify.md#is_untriaged--broad-untriaged))
 — a PR carrying the `ready for maintainer review` label is **not** counted as
 untriaged regardless of whether the literal triage marker is present, because
 the label itself is evidence that the PR cleared the triage bar.
@@ -62,7 +62,7 @@ the label itself is evidence that the PR cleared the triage bar.
 - `defacto_triaged + (triaged_waiting + triaged_responded) == engaged` (every engaged PR is either strictly triaged or de-facto-only)
 - `ready_for_review <= non_drafts` (a ready PR shouldn't be draft — if the inequality fails, the label is stale; surface a one-line warning but don't correct the data)
 - `untriaged_old + untriaged_med <= untriaged_nondraft <= non_drafts`
-- `triaged_waiting + triaged_responded + ready_for_review + untriaged_nondraft <= non_drafts` (every contributor non-draft is either triaged, ready, or untriaged; the difference covers PRs in a transitional state — e.g. fresh triaged_responded that haven't been marked ready yet)
+- `engaged + untriaged_nondraft + ready_for_review == non_drafts (contributor)` (the partition: every contributor non-draft is exactly one of `is_engaged` (strict OR de-facto), `is_untriaged` (no maintainer touched), or already-`ready` labelled — the three are mutually exclusive once the `is_untriaged` definition uses `NOT is_engaged` rather than `NOT is_triaged`)
 - `sum(age_buckets.values()) == contributors`
 - `contributors <= total`
 
@@ -284,7 +284,7 @@ This panel makes the *quality* of closures visible — the velocity panel says "
 The dashboard's "Triager activity" section ranks maintainers by how many
 distinct PRs each one **engaged with** in each of the last 6 calendar weeks.
 "Engaged" uses the same predicate as
-[`is_engaged`](classify.md#is_engaged--broader-maintainer-touched-this-predicate)
+[`is_engaged`](classify.md#is_engaged--de-facto-triaged)
 (any maintainer comment / review).
 
 For each open PR currently in the fetch set, walk
@@ -312,7 +312,7 @@ Every triager's per-week count is further split into:
 
 - **AI-assisted**: comments whose body contains the AI-attribution footer
   substring (`AI-assisted triage tool` — same detector as
-  [`is_ai_triaged`](classify.md#is_ai_triaged--received-an-ai-generated-triage-comment)).
+  [`is_ai_triaged`](classify.md#is_ai_triaged--ai-assisted-triage)).
 - **Manual**: comments without the footer.
 
 Same PR can contribute to *both* sub-counts for the same maintainer-week if
@@ -375,7 +375,7 @@ Top-of-dashboard hero card. Computed as a count of fired threshold conditions:
 | > 20 stale-triaged drafts (drafts where triage comment ≥ 7 days old AND no author response) | **1** |
 
 Each "untriaged" condition above uses the refined
-[`is_untriaged`](classify.md#is_untriaged--refined-predicate) predicate —
+[`is_untriaged`](classify.md#is_untriaged--broad-untriaged) predicate —
 so a PR carrying the `ready for maintainer review` label does **not** trigger the
 health-rating points even if it lacks the literal `Pull Request quality criteria`
 marker (the label is itself evidence of triage).

--- a/.claude/skills/pr-management-stats/aggregate.md
+++ b/.claude/skills/pr-management-stats/aggregate.md
@@ -35,6 +35,10 @@ One `_AreaStats` block per area. Only two counters (`total` and `contributors`) 
 | `triaged_waiting` | classified `triaged_waiting` (see `classify.md`) | contributor-only |
 | `triaged_responded` | classified `triaged_responded` | contributor-only |
 | `ready_for_review` | label `ready for maintainer review` present | contributor-only |
+| `engaged` | satisfies [`is_engaged`](classify.md#is_engaged--broader-maintainer-touched-this-predicate) (any maintainer touched it) | contributor-only |
+| `defacto_triaged` | satisfies [`is_defacto_triaged`](classify.md#is_defacto_triaged--engaged-but-no-marker) (engaged but no marker) | contributor-only |
+| `ai_triaged` | satisfies [`is_ai_triaged`](classify.md#is_ai_triaged--received-an-ai-generated-triage-comment) (received an AI-assisted triage comment) | contributor-only |
+| `bot_authored` | [`is_bot`](classify.md#is_bot--author-is-a-recognised-bot)(pr.author.login) | **all** — its own category, NOT in `contributors` |
 | `untriaged_nondraft` | satisfies [`is_untriaged`](classify.md#is_untriaged--refined-predicate) AND `isDraft == false` | contributor-only |
 | `untriaged_old` | `untriaged_nondraft` AND `age_bucket == ">4w"` | contributor-only |
 | `untriaged_med` | `untriaged_nondraft` AND `age_bucket == "1-4w"` | contributor-only |
@@ -51,8 +55,11 @@ the label itself is evidence that the PR cleared the triage bar.
 ### Invariants
 
 - `total == total_drafts + total_non_drafts` (every PR is exactly one)
+- `contributors + collaborator_authored + bot_authored == total` (three disjoint author classes)
 - `contributors == drafts + non_drafts` (each contributor PR is one or the other)
 - `triaged_waiting + triaged_responded <= contributors`
+- `triaged_waiting + triaged_responded <= engaged` (strict-triaged is a subset of engaged)
+- `defacto_triaged + (triaged_waiting + triaged_responded) == engaged` (every engaged PR is either strictly triaged or de-facto-only)
 - `ready_for_review <= non_drafts` (a ready PR shouldn't be draft — if the inequality fails, the label is stale; surface a one-line warning but don't correct the data)
 - `untriaged_old + untriaged_med <= untriaged_nondraft <= non_drafts`
 - `triaged_waiting + triaged_responded + ready_for_review + untriaged_nondraft <= non_drafts` (every contributor non-draft is either triaged, ready, or untriaged; the difference covers PRs in a transitional state — e.g. fresh triaged_responded that haven't been marked ready yet)
@@ -269,6 +276,90 @@ Below the bars, print three summary numbers:
 ```text
 
 This panel makes the *quality* of closures visible — the velocity panel says "how many", this panel says "of what type".
+
+---
+
+## Triager activity (per-triager, per-week)
+
+The dashboard's "Triager activity" section ranks maintainers by how many
+distinct PRs each one **engaged with** in each of the last 6 calendar weeks.
+"Engaged" uses the same predicate as
+[`is_engaged`](classify.md#is_engaged--broader-maintainer-touched-this-predicate)
+(any maintainer comment / review).
+
+For each open PR currently in the fetch set, walk
+`pr.comments(last:25).nodes` and the parallel review-thread sub-comments:
+
+```text
+for each comment c by login L where authorAssociation IN
+    (OWNER, MEMBER, COLLABORATOR) AND NOT is_bot(L):
+    bucket = which_week(c.createdAt)   # see #weekly-velocity for bucket math
+    if bucket is one of the 6 windows:
+        kind = "ai" if "AI-assisted triage tool" in c.body else "manual"
+        triager_weekly[L][bucket][kind] += (first-engagement-in-bucket counter)
+```
+
+Per-week counting rule: count **at most one PR per (login, week, kind)** even
+when the same maintainer posts multiple comments in the same week of the same
+kind. The intent is "how many distinct PRs did this maintainer touch each week,
+split by AI-assisted vs manually-typed engagement" not "how many comments did
+they post"; multiple comments by the same person in the same week on the same
+PR of the same kind collapse to a single tally.
+
+### AI vs manual split
+
+Every triager's per-week count is further split into:
+
+- **AI-assisted**: comments whose body contains the AI-attribution footer
+  substring (`AI-assisted triage tool` — same detector as
+  [`is_ai_triaged`](classify.md#is_ai_triaged--received-an-ai-generated-triage-comment)).
+- **Manual**: comments without the footer.
+
+Same PR can contribute to *both* sub-counts for the same maintainer-week if
+they posted both an AI-drafted comment and a manually-typed comment in the
+same window. The dashboard shows the two side-by-side so the maintainer team
+can see how much of each person's throughput is coming through the skill
+versus through direct review.
+
+A maintainer's total for a week is `ai + manual`; both sub-counts use the
+per-PR de-duplication rule (one PR per kind per week).
+
+Counted as engagement:
+
+- Issue-level comments (`pr.comments(last:25)` in the standard fetch).
+- Review-thread comments — walk every
+  `pr.reviewThreads.nodes.comments(first:5)` for the same maintainer test.
+- `LabeledEvent` adding the `ready for maintainer review` label by a
+  maintainer (counts the label-add as the engagement timestamp). This catches
+  reviewers who applied the label without leaving a comment.
+
+The fetch shape in [`fetch.md`](fetch.md) already populates issue-level
+comments and review threads in the open-PR query. The label-add timestamp
+needs the `ready-label-timeline` query
+[(see `fetch.md#ready-label-timeline`)](fetch.md#ready-label-timeline) which
+the dashboard's "Ready-for-review trend by top areas" panel already fires —
+re-use that result.
+
+### Top-N rendering rule
+
+The "Triager activity" panel renders the top 15 maintainers by total PRs
+engaged across the 6-week window. The table layout (one row per triager,
+six week columns + a total column + a sparkline / mini-bars column) is
+defined in [`render.md#triager-activity-panel`](render.md). Maintainers with
+zero engagement in the window are excluded from the panel.
+
+### Caveats
+
+- Engagement is **at-most-one-PR-per-week-per-maintainer-per-PR**, not
+  comment-count. The maintainer who triages 20 PRs in one week and the
+  maintainer who comments 20 times on one PR show as 20 and 1 respectively.
+- The same maintainer can show up in multiple weeks for the same PR if they
+  engaged in each window — that is by design (re-engagement signals
+  continued attention).
+- Bot-account comments are excluded via the same
+  [`is_bot`](classify.md#is_bot--author-is-a-recognised-bot) test used in the
+  open-PR counters; copilot review-bots that post under a `CONTRIBUTOR`
+  association are not counted anyway (the maintainer check filters them).
 
 ---
 

--- a/.claude/skills/pr-management-stats/aggregate.md
+++ b/.claude/skills/pr-management-stats/aggregate.md
@@ -27,21 +27,35 @@ One `_AreaStats` block per area. Only two counters (`total` and `contributors`) 
 | Field | Count rule | Scope |
 |---|---|---|
 | `total` | count of PRs in the area | **all** — reference only |
+| `total_drafts` | `isDraft == true` | **all** — denominator for the dashboard draft/non-draft split |
+| `total_non_drafts` | `isDraft == false` | **all** — paired with `total_drafts` |
 | `contributors` | `authorAssociation NOT IN (OWNER, MEMBER, COLLABORATOR)` | **all** — denominator for the contributor-scoped counters below |
 | `drafts` | `isDraft == true` | contributor-only |
 | `non_drafts` | `isDraft == false` | contributor-only |
 | `triaged_waiting` | classified `triaged_waiting` (see `classify.md`) | contributor-only |
 | `triaged_responded` | classified `triaged_responded` | contributor-only |
 | `ready_for_review` | label `ready for maintainer review` present | contributor-only |
+| `untriaged_nondraft` | satisfies [`is_untriaged`](classify.md#is_untriaged--refined-predicate) AND `isDraft == false` | contributor-only |
+| `untriaged_old` | `untriaged_nondraft` AND `age_bucket == ">4w"` | contributor-only |
+| `untriaged_med` | `untriaged_nondraft` AND `age_bucket == "1-4w"` | contributor-only |
 | `triager_drafted` | classified `drafted_by_triager` | contributor-only |
 | `age_buckets` | histogram, key = bucket label from `classify.md#age-bucket` | contributor-only |
 | `draft_age_buckets` | histogram over PRs where `drafted_at` is set, same bucket labels | contributor-only |
 
+The three `untriaged_*` counters share the same predicate (see
+[`classify.md#is_untriaged--refined-predicate`](classify.md#is_untriaged--refined-predicate))
+— a PR carrying the `ready for maintainer review` label is **not** counted as
+untriaged regardless of whether the literal triage marker is present, because
+the label itself is evidence that the PR cleared the triage bar.
+
 ### Invariants
 
+- `total == total_drafts + total_non_drafts` (every PR is exactly one)
 - `contributors == drafts + non_drafts` (each contributor PR is one or the other)
 - `triaged_waiting + triaged_responded <= contributors`
 - `ready_for_review <= non_drafts` (a ready PR shouldn't be draft — if the inequality fails, the label is stale; surface a one-line warning but don't correct the data)
+- `untriaged_old + untriaged_med <= untriaged_nondraft <= non_drafts`
+- `triaged_waiting + triaged_responded + ready_for_review + untriaged_nondraft <= non_drafts` (every contributor non-draft is either triaged, ready, or untriaged; the difference covers PRs in a transitional state — e.g. fresh triaged_responded that haven't been marked ready yet)
 - `sum(age_buckets.values()) == contributors`
 - `contributors <= total`
 
@@ -264,10 +278,16 @@ Top-of-dashboard hero card. Computed as a count of fired threshold conditions:
 
 | Condition | Issue points |
 |---|---|
-| Any contributor non-draft PR untriaged AND > 4 weeks old | **2** |
-| > 30 contributor non-draft PRs untriaged AND in 1–4 weeks bucket | **1** |
+| `untriaged_old > 0` — any contributor non-draft `is_untriaged` PR > 4 weeks old | **2** |
+| `untriaged_med > 30` — > 30 contributor non-draft `is_untriaged` PRs in 1–4 weeks bucket | **1** |
 | > 100 PRs labelled `ready for maintainer review` | **1** |
 | > 20 stale-triaged drafts (drafts where triage comment ≥ 7 days old AND no author response) | **1** |
+
+Each "untriaged" condition above uses the refined
+[`is_untriaged`](classify.md#is_untriaged--refined-predicate) predicate —
+so a PR carrying the `ready for maintainer review` label does **not** trigger the
+health-rating points even if it lacks the literal `Pull Request quality criteria`
+marker (the label is itself evidence of triage).
 
 Sum the points and map:
 

--- a/.claude/skills/pr-management-stats/classify.md
+++ b/.claude/skills/pr-management-stats/classify.md
@@ -134,6 +134,116 @@ The `Ready` column counts PRs carrying the `ready for maintainer review` label. 
 
 ---
 
+## `is_engaged` — broader "maintainer touched this" predicate
+
+Beyond the strict triage-marker scan, the dashboard tracks a **broader**
+"maintainer touched this PR at some point" notion. Empirically on a large
+`<upstream>` queue the strict marker-only count under-states actual triage
+coverage by roughly 3× (21% strict vs 59% broad on a 457-PR open queue) —
+maintainers routinely engage with PRs through review-thread comments, regular
+discussion, label-add events, and review submissions that don't include the
+literal `Pull Request quality criteria` link. Counting only the marker hides
+that engagement from the dashboard.
+
+```text
+is_engaged(pr) :=
+    EXISTS comment c IN pr.comments
+      WHERE c.authorAssociation IN (OWNER, MEMBER, COLLABORATOR)
+        AND NOT is_bot(c.author.login)
+```
+
+Plus the same predicate applied to `pr.latestReviews` (any maintainer review,
+state `COMMENTED` / `CHANGES_REQUESTED` / `APPROVED`, body OR inline thread
+non-empty).
+
+Bot exclusion in the comment author — review-bots like `copilot-pull-request-
+reviewer[bot]` carry `authorAssociation: CONTRIBUTOR` so they don't trip the
+maintainer test, but defence in depth: also filter the same bot login patterns
+the `is_bot` predicate (below) uses.
+
+### `is_defacto_triaged` — engaged but no marker
+
+```text
+is_defacto_triaged(pr) := is_engaged(pr) AND NOT is_triaged(pr)
+```
+
+Surfaced as a separate category on the dashboard's expanded hero row (see
+[`render.md`](render.md)) so the maintainer can see the gap between strict and
+broad triage coverage. A high `defacto_triaged` count is a signal that the
+maintainer team is engaging with PRs *without* leaving the templated marker —
+the queue is in better shape than the strict count suggests, but the
+classifier's signal is incomplete.
+
+### `is_ai_triaged` — received an AI-generated triage comment
+
+```text
+is_ai_triaged(pr) :=
+    EXISTS comment c IN pr.comments
+      WHERE c.authorAssociation IN (OWNER, MEMBER, COLLABORATOR)
+        AND c.body CONTAINS "AI-assisted triage tool"
+```
+
+The substring `AI-assisted triage tool` is part of the canonical
+AI-attribution footer that `pr-management-triage` appends to every
+contributor-facing comment it drafts (see
+[`pr-management-triage/comment-templates.md#ai-attribution-footer`](../pr-management-triage/comment-templates.md)).
+Counting matches surfaces a useful distinction: of all the maintainer triage
+on the queue, how much was AI-assisted vs. manually typed. The category is
+**not** a quality signal in either direction — AI-assisted triage is real
+maintainer triage (the maintainer approved the draft before posting) — but it
+helps the maintainer team see at a glance how much of their throughput is
+coming through the skill vs. through manual review.
+
+Adopters with a different AI-attribution string in their override of
+[`pr-management-triage-comment-templates.md`](../pr-management-triage/comment-templates.md)
+should set
+[`<project-config>/pr-management-config.md`](../../../projects/_template/pr-management-config.md)'s
+`ai_attribution_substring` field; the framework defaults to
+`AI-assisted triage tool`. The literal substring is a single point of failure —
+keep it identical between the comment templates and this detector.
+
+`is_ai_triaged` is **independent of** `is_triaged` and `is_engaged`:
+
+- An AI-drafted comment that includes the canonical
+  `Pull Request quality criteria` link (most templates do) makes
+  `is_ai_triaged` AND `is_triaged` both true.
+- An AI-drafted ping or request-author-confirmation comment that does not
+  include the criteria link makes `is_ai_triaged` true but `is_triaged` false
+  (and it would also make `is_engaged` true via the comment).
+- A maintainer's hand-typed comment makes `is_engaged` true (and possibly
+  `is_triaged` if they pasted the criteria link) but `is_ai_triaged` false.
+
+The strict `is_triaged` definition (the literal marker scan, [Triage marker](#triage-marker)
+above) remains the source of truth for the **action-related** flows
+(`pr-management-triage` row 3-4 detection, sweep 1a's "stale triaged drafts"
+threshold). The broader `is_engaged` definition is **stats-only** — it doesn't
+gate any mutation.
+
+---
+
+## `is_bot` — author is a recognised bot
+
+```text
+is_bot(login) :=
+    login.lower() ends with "[bot]"
+    OR login.lower() IN {dependabot, renovate, github-actions}
+```
+
+Bot PRs are a **separate dashboard category** counted as `bot_authored` —
+they don't merge into `contributors` or `collaborators`, and they don't trip
+the untriaged or engaged predicates. Their lifecycle is independent: they
+follow automated update / review cycles and are reviewed-and-merged by
+maintainers without going through the triage funnel. Surfacing them in their
+own count keeps the contributor backlog signal clean.
+
+Adopters with project-specific bots not on this list — e.g. a release-bot or
+a CI-helper bot — should extend the `is_bot` match via
+[`<project-config>/pr-management-config.md`](../../../projects/_template/pr-management-config.md)'s
+`bot_logins` setting (a list of additional logins to recognise; the framework
+defaults always apply).
+
+---
+
 ## `is_untriaged` — refined predicate
 
 The "untriaged" classification used in the hero card, the health rating, the
@@ -144,10 +254,11 @@ of `is_triaged` (the triage-marker scan above). It is a stricter predicate:
 is_untriaged(pr) :=
     NOT is_triaged(pr)
     AND author_association NOT IN (OWNER, MEMBER, COLLABORATOR)
+    AND NOT is_bot(pr.author.login)
     AND `ready for maintainer review` NOT IN labels(pr)
 ```
 
-Three exclusions, three rationales:
+Four exclusions, four rationales:
 
 1. **No triage marker.** If a maintainer (any maintainer — see the [rationale
    for "any maintainer"](#rationale--any-maintainer-not-viewer-only)
@@ -158,7 +269,11 @@ Three exclusions, three rationales:
    "untriaged" hero card creates a misleading impression of an unattended
    backlog. The pre-filter F1 in `pr-management-triage/classify-and-act.md`
    already skips them from action; the stats counter must agree.
-3. **PR does not carry `ready for maintainer review`.** A PR with the label has
+3. **Author is not a bot.** Bot PRs follow an automated lifecycle (see
+   [`is_bot`](#is_bot--author-is-a-recognised-bot) above) — counting
+   them in the untriaged backlog mis-attributes their state to a maintainer
+   action gap when really the bot just rolls forward on its own cadence.
+4. **PR does not carry `ready for maintainer review`.** A PR with the label has
    *demonstrably* cleared the triage bar — a maintainer applied the label —
    even when the literal `Pull Request quality criteria` marker is absent
    (because the PR was promoted by a different path: directly by a reviewer,

--- a/.claude/skills/pr-management-stats/classify.md
+++ b/.claude/skills/pr-management-stats/classify.md
@@ -17,7 +17,7 @@ and conflates "no maintainer touched this" with "no maintainer left the
 canonical template." All four predicates apply to a single PR; they overlap
 deliberately (see the implication chains below).
 
-### `is_triaged` — *strict-triaged*
+### `is_triaged` — *Quality-Criteria-triaged*
 
 ```text
 is_triaged(pr) :=
@@ -61,11 +61,11 @@ The broader "a maintainer touched this PR at some point" definition. Catches
 review-thread comments, design discussions, label-adds, hand-typed feedback,
 and so on — all the engagement modes that don't include the literal marker
 substring. **`is_engaged` is a superset of `is_triaged`**: every
-strict-triaged PR is also engaged, but not vice-versa.
+Quality-Criteria-triaged PR is also engaged, but not vice-versa.
 
 The terminology in the dashboard:
 
-- **De-facto triaged** = engaged but not strict-triaged.
+- **De-facto triaged** = engaged but not Quality-Criteria-triaged.
   Formally: `is_engaged(pr) AND NOT is_triaged(pr)` — the
   `defacto_triaged` counter aggregates this set.
 
@@ -140,10 +140,10 @@ The age uses the `last_author_interaction` defined in the
 
 | Tier | Predicate | Means | Dashboard card |
 |---|---|---|---|
-| Strict-triaged | `is_triaged` | maintainer posted the literal `Pull Request quality criteria` link | **Strict-triaged** (hero row 2, blue) |
+| Quality-Criteria-triaged | `is_triaged` | maintainer posted the literal `Pull Request quality criteria` link | **Quality Criteria triaged** (hero row 2, blue) |
 | De-facto triaged | `is_engaged AND NOT is_triaged` | maintainer engaged but no marker | **De-facto triaged** (hero row 2, amber — the gap signal) |
 | AI-triaged | `is_ai_triaged` | comment with the AI-attribution footer | **AI-triaged** (hero row 2, purple — accounting) |
-| Engaged (overall) | `is_engaged` | union of the above two | not a card on its own; equals `strict + defacto` |
+| Engaged (overall) | `is_engaged` | union of the above two | not a card on its own; equals `triaged + defacto_triaged` |
 | Untriaged | `is_untriaged` | NOT engaged + contributor + non-bot + not ready-labelled | **Untriaged non-drafts** (hero row 1) |
 
 The number of PRs in each tier sums to a clean partition of the contributor
@@ -151,9 +151,9 @@ non-draft pool minus the ready-labelled set:
 
 ```text
 contributor_nondraft_not_ready =
-    strict_triaged_nondraft +
-    defacto_triaged_nondraft +
-    untriaged_nondraft
+    triaged_nondraft +              # Quality-Criteria-triaged (`is_triaged`)
+    defacto_triaged_nondraft +      # engaged but no marker
+    untriaged_nondraft              # no maintainer engagement
 ```
 
 The `transitional` cases (e.g. a freshly-engaged PR whose triage marker

--- a/.claude/skills/pr-management-stats/classify.md
+++ b/.claude/skills/pr-management-stats/classify.md
@@ -134,6 +134,51 @@ The `Ready` column counts PRs carrying the `ready for maintainer review` label. 
 
 ---
 
+## `is_untriaged` — refined predicate
+
+The "untriaged" classification used in the hero card, the health rating, the
+recommendation rules, and the area pressure score is **not** the simple negation
+of `is_triaged` (the triage-marker scan above). It is a stricter predicate:
+
+```text
+is_untriaged(pr) :=
+    NOT is_triaged(pr)
+    AND author_association NOT IN (OWNER, MEMBER, COLLABORATOR)
+    AND `ready for maintainer review` NOT IN labels(pr)
+```
+
+Three exclusions, three rationales:
+
+1. **No triage marker.** If a maintainer (any maintainer — see the [rationale
+   for "any maintainer"](#rationale--any-maintainer-not-viewer-only)
+   above) has posted the triage template, the PR has been through the funnel.
+2. **Author is not a collaborator/member/owner.** Committer-authored PRs have a
+   different lifecycle (see [`aggregate.md#counters-per-area`](aggregate.md)) —
+   they are not triaged by `pr-management-triage` and surfacing them in the
+   "untriaged" hero card creates a misleading impression of an unattended
+   backlog. The pre-filter F1 in `pr-management-triage/classify-and-act.md`
+   already skips them from action; the stats counter must agree.
+3. **PR does not carry `ready for maintainer review`.** A PR with the label has
+   *demonstrably* cleared the triage bar — a maintainer applied the label —
+   even when the literal `Pull Request quality criteria` marker is absent
+   (because the PR was promoted by a different path: directly by a reviewer,
+   by an older skill version, or by a contributor who responded to an
+   out-of-band review). Treating these as untriaged double-counts them
+   (they already appear in the `Ready for review` hero card) and falsely
+   inflates the "needs attention" recommendation.
+
+The same predicate has two age-bucketed variants used by `aggregate.md`:
+
+```text
+is_untriaged_old(pr) := is_untriaged(pr) AND age_bucket(pr) == ">4w"
+is_untriaged_med(pr) := is_untriaged(pr) AND age_bucket(pr) IN {"1-4w"}
+```
+
+The age uses the `last_author_interaction` defined in the
+"Age bucket" section above.
+
+---
+
 ## Responded before close (Table 1 only)
 
 Table 1's `Responded` column measures, per area, how many triaged PRs got an author reply *before* they were closed or merged. For a PR in the closed-since set:

--- a/.claude/skills/pr-management-stats/classify.md
+++ b/.claude/skills/pr-management-stats/classify.md
@@ -9,6 +9,159 @@ Classification is pure function of state from [`fetch.md`](fetch.md) — no netw
 
 ---
 
+## Triage tiers — definitions
+
+The dashboard surfaces four distinct triage-state categories side-by-side
+because the strict marker-only definition under-counts actual triage activity
+and conflates "no maintainer touched this" with "no maintainer left the
+canonical template." All four predicates apply to a single PR; they overlap
+deliberately (see the implication chains below).
+
+### `is_triaged` — *strict-triaged*
+
+```text
+is_triaged(pr) :=
+    EXISTS comment c IN pr.comments
+      WHERE c.authorAssociation IN (OWNER, MEMBER, COLLABORATOR)
+        AND c.body CONTAINS "Pull Request quality criteria"
+        AND (c.createdAt > head_commit.committedDate
+             OR head_commit.committedDate > c.createdAt)   # see [Triage marker](#triage-marker)
+```
+
+**What the literal marker is:** the **substring `Pull Request quality
+criteria`** — this is the visible link text in the canonical triage-comment
+template that every `pr-management-triage` action body carries (see
+[`pr-management-triage/comment-templates.md`](../pr-management-triage/comment-templates.md)).
+The classifier scans every comment's `body` (NOT `bodyText` — the latter
+strips HTML comments, see [Both marker forms count](#both-marker-forms-count)
+below) for the exact substring. The string is also accepted in an HTML-comment
+form left by the legacy `breeze pr auto-triage` command.
+
+The marker is a **single point of failure** — rename the link text in the
+comment template and this detector silently stops counting. Adopters can
+customise the URL the link points to via
+[`<project-config>/pr-management-triage-comment-templates.md`](../../../projects/_template/pr-management-triage-comment-templates.md)'s
+`quality_criteria_url`, but the link **text** must remain `Pull Request
+quality criteria` verbatim.
+
+### `is_engaged` — *de-facto triaged*
+
+```text
+is_engaged(pr) :=
+    EXISTS comment c IN pr.comments
+      WHERE c.authorAssociation IN (OWNER, MEMBER, COLLABORATOR)
+        AND NOT is_bot(c.author.login)
+```
+
+Plus the same predicate applied to `pr.latestReviews` (any maintainer review)
+and to `LabeledEvent` (any maintainer who added the `ready for maintainer
+review` label).
+
+The broader "a maintainer touched this PR at some point" definition. Catches
+review-thread comments, design discussions, label-adds, hand-typed feedback,
+and so on — all the engagement modes that don't include the literal marker
+substring. **`is_engaged` is a superset of `is_triaged`**: every
+strict-triaged PR is also engaged, but not vice-versa.
+
+The terminology in the dashboard:
+
+- **De-facto triaged** = engaged but not strict-triaged.
+  Formally: `is_engaged(pr) AND NOT is_triaged(pr)` — the
+  `defacto_triaged` counter aggregates this set.
+
+### `is_ai_triaged` — *AI-assisted triage*
+
+```text
+is_ai_triaged(pr) :=
+    EXISTS comment c IN pr.comments
+      WHERE c.authorAssociation IN (OWNER, MEMBER, COLLABORATOR)
+        AND c.body CONTAINS "AI-assisted triage tool"
+```
+
+A PR received at least one maintainer comment whose body contains the
+**AI-attribution footer substring** (`AI-assisted triage tool`). Every
+`pr-management-triage` comment template (draft / comment / ping /
+request-author-confirmation / close-comment etc.) ends with this footer
+verbatim — so the detector counts any PR whose triage included a skill-drafted
+comment.
+
+This predicate is **independent of** `is_triaged` and `is_engaged`:
+
+- An AI-drafted draft+comment includes the `Pull Request quality criteria`
+  link → both `is_triaged` and `is_ai_triaged` fire.
+- An AI-drafted **ping** or **request-author-confirmation** uses a different
+  template that does NOT include the criteria link → `is_engaged` and
+  `is_ai_triaged` fire but `is_triaged` does NOT.
+- A maintainer's hand-typed comment in the criteria-template form (rare —
+  this happens when a maintainer manually pastes the link text without the
+  skill) → `is_triaged` and `is_engaged` fire but `is_ai_triaged` does NOT.
+
+The implication chains:
+
+```text
+is_triaged(pr)    ⇒ is_engaged(pr)         # marker requires maintainer comment, which requires engagement
+is_ai_triaged(pr) ⇒ is_engaged(pr)         # AI footer requires maintainer comment, which requires engagement
+is_triaged(pr)    ⇎ is_ai_triaged(pr)      # independent — see cases above
+```
+
+### `is_untriaged` — *broad untriaged*
+
+```text
+is_untriaged(pr) :=
+    NOT is_engaged(pr)                                # broadest — no maintainer touched it
+    AND author_association NOT IN (OWNER, MEMBER, COLLABORATOR)
+    AND NOT is_bot(pr.author.login)
+    AND `ready for maintainer review` NOT IN labels(pr)
+```
+
+**Key change from earlier iterations:** uses `NOT is_engaged` (not `NOT
+is_triaged`). Combining strict-untriaged with de-facto-triaged double-counted
+PRs that maintainers had touched: a strict-only definition flags a PR as
+untriaged even when a maintainer left detailed inline review feedback, just
+because the feedback didn't include the canonical marker string. The broader
+predicate correctly counts only PRs with **zero maintainer engagement**.
+
+Concrete impact on a large `<upstream>` queue: the strict-only count gave
+72 untriaged non-drafts; tightening to `NOT is_engaged` brings it to 47
+(a 35% reduction). The 25 PRs that drop out had ≥1 maintainer comment but
+no template marker — they're de-facto triaged.
+
+The age-bucketed variants used by `aggregate.md`:
+
+```text
+is_untriaged_old(pr) := is_untriaged(pr) AND age_bucket(pr) == ">4w"
+is_untriaged_med(pr) := is_untriaged(pr) AND age_bucket(pr) IN {"1-4w"}
+```
+
+The age uses the `last_author_interaction` defined in the
+"Age bucket" section below.
+
+### Side-by-side summary
+
+| Tier | Predicate | Means | Dashboard card |
+|---|---|---|---|
+| Strict-triaged | `is_triaged` | maintainer posted the literal `Pull Request quality criteria` link | **Strict-triaged** (hero row 2, blue) |
+| De-facto triaged | `is_engaged AND NOT is_triaged` | maintainer engaged but no marker | **De-facto triaged** (hero row 2, amber — the gap signal) |
+| AI-triaged | `is_ai_triaged` | comment with the AI-attribution footer | **AI-triaged** (hero row 2, purple — accounting) |
+| Engaged (overall) | `is_engaged` | union of the above two | not a card on its own; equals `strict + defacto` |
+| Untriaged | `is_untriaged` | NOT engaged + contributor + non-bot + not ready-labelled | **Untriaged non-drafts** (hero row 1) |
+
+The number of PRs in each tier sums to a clean partition of the contributor
+non-draft pool minus the ready-labelled set:
+
+```text
+contributor_nondraft_not_ready =
+    strict_triaged_nondraft +
+    defacto_triaged_nondraft +
+    untriaged_nondraft
+```
+
+The `transitional` cases (e.g. a freshly-engaged PR whose triage marker
+hasn't been posted yet) are not a separate category; they sit in
+de-facto-triaged until they pick up the marker or the ready label.
+
+---
+
 ## Triage marker
 
 A PR is *triaged* when it has at least one comment that:
@@ -134,90 +287,20 @@ The `Ready` column counts PRs carrying the `ready for maintainer review` label. 
 
 ---
 
-## `is_engaged` — broader "maintainer touched this" predicate
-
-Beyond the strict triage-marker scan, the dashboard tracks a **broader**
-"maintainer touched this PR at some point" notion. Empirically on a large
-`<upstream>` queue the strict marker-only count under-states actual triage
-coverage by roughly 3× (21% strict vs 59% broad on a 457-PR open queue) —
-maintainers routinely engage with PRs through review-thread comments, regular
-discussion, label-add events, and review submissions that don't include the
-literal `Pull Request quality criteria` link. Counting only the marker hides
-that engagement from the dashboard.
-
-```text
-is_engaged(pr) :=
-    EXISTS comment c IN pr.comments
-      WHERE c.authorAssociation IN (OWNER, MEMBER, COLLABORATOR)
-        AND NOT is_bot(c.author.login)
-```
-
-Plus the same predicate applied to `pr.latestReviews` (any maintainer review,
-state `COMMENTED` / `CHANGES_REQUESTED` / `APPROVED`, body OR inline thread
-non-empty).
-
-Bot exclusion in the comment author — review-bots like `copilot-pull-request-
-reviewer[bot]` carry `authorAssociation: CONTRIBUTOR` so they don't trip the
-maintainer test, but defence in depth: also filter the same bot login patterns
-the `is_bot` predicate (below) uses.
-
-### `is_defacto_triaged` — engaged but no marker
-
-```text
-is_defacto_triaged(pr) := is_engaged(pr) AND NOT is_triaged(pr)
-```
-
-Surfaced as a separate category on the dashboard's expanded hero row (see
-[`render.md`](render.md)) so the maintainer can see the gap between strict and
-broad triage coverage. A high `defacto_triaged` count is a signal that the
-maintainer team is engaging with PRs *without* leaving the templated marker —
-the queue is in better shape than the strict count suggests, but the
-classifier's signal is incomplete.
-
-### `is_ai_triaged` — received an AI-generated triage comment
-
-```text
-is_ai_triaged(pr) :=
-    EXISTS comment c IN pr.comments
-      WHERE c.authorAssociation IN (OWNER, MEMBER, COLLABORATOR)
-        AND c.body CONTAINS "AI-assisted triage tool"
-```
-
-The substring `AI-assisted triage tool` is part of the canonical
-AI-attribution footer that `pr-management-triage` appends to every
-contributor-facing comment it drafts (see
-[`pr-management-triage/comment-templates.md#ai-attribution-footer`](../pr-management-triage/comment-templates.md)).
-Counting matches surfaces a useful distinction: of all the maintainer triage
-on the queue, how much was AI-assisted vs. manually typed. The category is
-**not** a quality signal in either direction — AI-assisted triage is real
-maintainer triage (the maintainer approved the draft before posting) — but it
-helps the maintainer team see at a glance how much of their throughput is
-coming through the skill vs. through manual review.
-
-Adopters with a different AI-attribution string in their override of
-[`pr-management-triage-comment-templates.md`](../pr-management-triage/comment-templates.md)
-should set
-[`<project-config>/pr-management-config.md`](../../../projects/_template/pr-management-config.md)'s
-`ai_attribution_substring` field; the framework defaults to
-`AI-assisted triage tool`. The literal substring is a single point of failure —
-keep it identical between the comment templates and this detector.
-
-`is_ai_triaged` is **independent of** `is_triaged` and `is_engaged`:
-
-- An AI-drafted comment that includes the canonical
-  `Pull Request quality criteria` link (most templates do) makes
-  `is_ai_triaged` AND `is_triaged` both true.
-- An AI-drafted ping or request-author-confirmation comment that does not
-  include the criteria link makes `is_ai_triaged` true but `is_triaged` false
-  (and it would also make `is_engaged` true via the comment).
-- A maintainer's hand-typed comment makes `is_engaged` true (and possibly
-  `is_triaged` if they pasted the criteria link) but `is_ai_triaged` false.
+## Stats-only vs action-only triage
 
 The strict `is_triaged` definition (the literal marker scan, [Triage marker](#triage-marker)
 above) remains the source of truth for the **action-related** flows
 (`pr-management-triage` row 3-4 detection, sweep 1a's "stale triaged drafts"
-threshold). The broader `is_engaged` definition is **stats-only** — it doesn't
-gate any mutation.
+threshold). The broader `is_engaged` definition is **stats-only** — it does
+not gate any mutation. This keeps the action-flow conservatism while letting
+the dashboard surface the fuller picture.
+
+For the configurable AI-attribution detection substring, adopters can override
+[`<project-config>/pr-management-config.md`](../../../projects/_template/pr-management-config.md)'s
+`ai_attribution_substring` field; the framework defaults to
+`AI-assisted triage tool`. The literal substring is a single point of failure
+— keep it identical between the comment templates and this detector.
 
 ---
 
@@ -241,56 +324,6 @@ a CI-helper bot — should extend the `is_bot` match via
 [`<project-config>/pr-management-config.md`](../../../projects/_template/pr-management-config.md)'s
 `bot_logins` setting (a list of additional logins to recognise; the framework
 defaults always apply).
-
----
-
-## `is_untriaged` — refined predicate
-
-The "untriaged" classification used in the hero card, the health rating, the
-recommendation rules, and the area pressure score is **not** the simple negation
-of `is_triaged` (the triage-marker scan above). It is a stricter predicate:
-
-```text
-is_untriaged(pr) :=
-    NOT is_triaged(pr)
-    AND author_association NOT IN (OWNER, MEMBER, COLLABORATOR)
-    AND NOT is_bot(pr.author.login)
-    AND `ready for maintainer review` NOT IN labels(pr)
-```
-
-Four exclusions, four rationales:
-
-1. **No triage marker.** If a maintainer (any maintainer — see the [rationale
-   for "any maintainer"](#rationale--any-maintainer-not-viewer-only)
-   above) has posted the triage template, the PR has been through the funnel.
-2. **Author is not a collaborator/member/owner.** Committer-authored PRs have a
-   different lifecycle (see [`aggregate.md#counters-per-area`](aggregate.md)) —
-   they are not triaged by `pr-management-triage` and surfacing them in the
-   "untriaged" hero card creates a misleading impression of an unattended
-   backlog. The pre-filter F1 in `pr-management-triage/classify-and-act.md`
-   already skips them from action; the stats counter must agree.
-3. **Author is not a bot.** Bot PRs follow an automated lifecycle (see
-   [`is_bot`](#is_bot--author-is-a-recognised-bot) above) — counting
-   them in the untriaged backlog mis-attributes their state to a maintainer
-   action gap when really the bot just rolls forward on its own cadence.
-4. **PR does not carry `ready for maintainer review`.** A PR with the label has
-   *demonstrably* cleared the triage bar — a maintainer applied the label —
-   even when the literal `Pull Request quality criteria` marker is absent
-   (because the PR was promoted by a different path: directly by a reviewer,
-   by an older skill version, or by a contributor who responded to an
-   out-of-band review). Treating these as untriaged double-counts them
-   (they already appear in the `Ready for review` hero card) and falsely
-   inflates the "needs attention" recommendation.
-
-The same predicate has two age-bucketed variants used by `aggregate.md`:
-
-```text
-is_untriaged_old(pr) := is_untriaged(pr) AND age_bucket(pr) == ">4w"
-is_untriaged_med(pr) := is_untriaged(pr) AND age_bucket(pr) IN {"1-4w"}
-```
-
-The age uses the `last_author_interaction` defined in the
-"Age bucket" section above.
 
 ---
 

--- a/.claude/skills/pr-management-stats/render.md
+++ b/.claude/skills/pr-management-stats/render.md
@@ -44,7 +44,7 @@ Two rows of four cards each:
 | **Repo Health** | the rating label (`✅ Healthy` / `⚠️ Needs attention` / `🔥 Action needed`) | "based on triage backlog + queue size" | green / amber / red, per [`aggregate.md#health-rating`](aggregate.md#health-rating) |
 | **Open PRs (non-bot)** | `total_contributors + total_collaborators` | `<total_non_drafts> non-draft · <total_drafts> draft` (line 1)<br>`<contrib_count> contributor · <collab_count> collaborator-authored` (line 2) | blue (informational) |
 | **Ready for review** | `len(ready_open)` | `<pct>% of contributor queue` | green |
-| **Untriaged non-drafts** | `len(untriaged_nondraft)` (uses [`is_untriaged`](classify.md#is_untriaged--refined-predicate)) | `<X> are >4 weeks old` | red if >0 are >4w, amber if total > 30, green otherwise |
+| **Untriaged non-drafts** | `len(untriaged_nondraft)` (uses [`is_untriaged`](classify.md#is_untriaged--broad-untriaged)) | `<X> are >4 weeks old` | red if >0 are >4w, amber if total > 30, green otherwise |
 
 #### Row 2 — triage coverage breakdown
 
@@ -55,8 +55,8 @@ marker-based count misses.
 | Card | Big number | Sub-label | Colour rule |
 |---|---|---|---|
 | **Strict-triaged** | `triaged_waiting + triaged_responded` (literal marker present) | `<pct>% of contributor non-drafts` | blue (informational) |
-| **De-facto triaged** | [`defacto_triaged`](classify.md#is_defacto_triaged--engaged-but-no-marker) (engaged by a maintainer, no marker) | `<pct>% of contributor non-drafts` | amber (gap signal — the bigger this is vs strict, the more triage is happening invisibly) |
-| **AI-triaged** | [`ai_triaged`](classify.md#is_ai_triaged--received-an-ai-generated-triage-comment) (received an AI-assisted triage comment) | `<pct>% of strict-triaged` | grey (informational) |
+| **De-facto triaged** | [`defacto_triaged`](classify.md#is_engaged--de-facto-triaged) (engaged by a maintainer, no marker) | `<pct>% of contributor non-drafts` | amber (gap signal — the bigger this is vs strict, the more triage is happening invisibly) |
+| **AI-triaged** | [`ai_triaged`](classify.md#is_ai_triaged--ai-assisted-triage) (received an AI-assisted triage comment) | `<pct>% of strict-triaged` | grey (informational) |
 | **Bot PRs** | [`bot_authored`](classify.md#is_bot--author-is-a-recognised-bot) | `<dependabot> dependabot · <other> other` | grey (separate lifecycle, surfaced for accounting parity) |
 
 The **De-facto triaged** card is the key new signal: on a large `<upstream>`
@@ -71,7 +71,7 @@ The **Bot PRs** card is a separate accounting category — bot-authored PRs
 follow their own automated lifecycle and don't merge into the
 `contributors` / `collaborators` split. Their count is informational; the
 "Untriaged" hero card never includes them (bots are excluded via
-[`is_untriaged`](classify.md#is_untriaged--refined-predicate)).
+[`is_untriaged`](classify.md#is_untriaged--broad-untriaged)).
 
 The **Open PRs** card's sub-label is a two-line breakdown: the first line splits
 the total by draft state, the second line splits by author class (contributor
@@ -79,7 +79,7 @@ vs. collaborator). Both splits sum to the same total (modulo bot exclusion at
 fetch time).
 
 The **Untriaged non-drafts** card uses the refined `is_untriaged` predicate from
-[`classify.md`](classify.md#is_untriaged--refined-predicate) — bots, collaborator-
+[`classify.md`](classify.md#is_untriaged--broad-untriaged) — bots, collaborator-
 authored PRs, and PRs already carrying `ready for maintainer review` are NOT
 counted here.
 

--- a/.claude/skills/pr-management-stats/render.md
+++ b/.claude/skills/pr-management-stats/render.md
@@ -33,33 +33,59 @@ Tuesday, May 6, 2026 · 14:33 UTC · viewer @potiuk · 6-week window since 2026-
 
 The title is plain text. Context line includes `<weekday>, <month> <day>, <year> · <HH:MM> UTC · viewer @<login> · 6-week window since <cutoff>`. Use the fetch-start `<now>`, not render-end, so a slow run remains a single-moment snapshot.
 
-### 2. Hero cards (4-column grid)
+### 2. Hero cards — two-row grid
 
-Four equally-sized cards, each one big number with a sub-label:
+Two rows of four cards each:
+
+#### Row 1 — backlog state
 
 | Card | Big number | Sub-label | Colour rule |
 |---|---|---|---|
 | **Repo Health** | the rating label (`✅ Healthy` / `⚠️ Needs attention` / `🔥 Action needed`) | "based on triage backlog + queue size" | green / amber / red, per [`aggregate.md#health-rating`](aggregate.md#health-rating) |
-| **Open PRs (non-bot)** | total open count | `<total_non_drafts> non-draft · <total_drafts> draft` (line 1)<br>`<contrib_count> contributor · <collab_count> collaborator-authored` (line 2) | blue (informational) |
+| **Open PRs (non-bot)** | `total_contributors + total_collaborators` | `<total_non_drafts> non-draft · <total_drafts> draft` (line 1)<br>`<contrib_count> contributor · <collab_count> collaborator-authored` (line 2) | blue (informational) |
 | **Ready for review** | `len(ready_open)` | `<pct>% of contributor queue` | green |
-| **Untriaged non-drafts** | `len(untriaged_nondraft)` (uses [`is_untriaged`](classify.md#is_untriaged--refined-predicate) — contributor-only AND NOT ready-labelled) | `<X> are >4 weeks old` | red if >0 are >4w, amber if total > 30, green otherwise |
+| **Untriaged non-drafts** | `len(untriaged_nondraft)` (uses [`is_untriaged`](classify.md#is_untriaged--refined-predicate)) | `<X> are >4 weeks old` | red if >0 are >4w, amber if total > 30, green otherwise |
+
+#### Row 2 — triage coverage breakdown
+
+This row exposes the **gap between strict and broad triage coverage** so a
+maintainer can see at a glance how much triage is happening that the strict
+marker-based count misses.
+
+| Card | Big number | Sub-label | Colour rule |
+|---|---|---|---|
+| **Strict-triaged** | `triaged_waiting + triaged_responded` (literal marker present) | `<pct>% of contributor non-drafts` | blue (informational) |
+| **De-facto triaged** | [`defacto_triaged`](classify.md#is_defacto_triaged--engaged-but-no-marker) (engaged by a maintainer, no marker) | `<pct>% of contributor non-drafts` | amber (gap signal — the bigger this is vs strict, the more triage is happening invisibly) |
+| **AI-triaged** | [`ai_triaged`](classify.md#is_ai_triaged--received-an-ai-generated-triage-comment) (received an AI-assisted triage comment) | `<pct>% of strict-triaged` | grey (informational) |
+| **Bot PRs** | [`bot_authored`](classify.md#is_bot--author-is-a-recognised-bot) | `<dependabot> dependabot · <other> other` | grey (separate lifecycle, surfaced for accounting parity) |
+
+The **De-facto triaged** card is the key new signal: on a large `<upstream>`
+queue (~457 human-authored open PRs) the strict count typically captures ~21%
+of PRs but the broad `is_engaged` count captures ~59% — the gap (~38 percentage
+points) is PRs that maintainers engaged with through review threads, direct
+comments, or label-adds without leaving the templated `Pull Request quality
+criteria` marker. Surfacing the gap lets the maintainer team see how much
+queue health the strict counter under-states.
+
+The **Bot PRs** card is a separate accounting category — bot-authored PRs
+follow their own automated lifecycle and don't merge into the
+`contributors` / `collaborators` split. Their count is informational; the
+"Untriaged" hero card never includes them (bots are excluded via
+[`is_untriaged`](classify.md#is_untriaged--refined-predicate)).
 
 The **Open PRs** card's sub-label is a two-line breakdown: the first line splits
-the total by draft state (the user often wants to see "how much of the backlog
-is in review vs. still being worked on" at a glance), the second line splits by
-author class (contributor vs. collaborator). Both splits sum to the same total
-(modulo bot exclusion at fetch time), so a maintainer can quickly cross-check
-the numbers.
+the total by draft state, the second line splits by author class (contributor
+vs. collaborator). Both splits sum to the same total (modulo bot exclusion at
+fetch time).
 
 The **Untriaged non-drafts** card uses the refined `is_untriaged` predicate from
-[`classify.md`](classify.md#is_untriaged--refined-predicate) — collaborator-
-authored PRs and PRs already carrying `ready for maintainer review` are NOT
-counted here. Without this scope refinement, the card would over-count by
-including (a) committer parking-lot PRs the F1 pre-filter never lets the
-triage skill act on, and (b) reviewer-queue PRs that have already passed the
-triage bar by an alternate path.
+[`classify.md`](classify.md#is_untriaged--refined-predicate) — bots, collaborator-
+authored PRs, and PRs already carrying `ready for maintainer review` are NOT
+counted here.
 
-Card layout is responsive: 4-column on wide screens, 2-column on narrow, 1-column on mobile-width. The big number uses 32px font; sub-labels are 12px dim grey.
+Card layout is responsive: 4-column on wide screens (8 cards total in two rows),
+2-column on narrow, 1-column on mobile-width. The big number uses 32px font;
+sub-labels are 12px dim grey.
 
 ### 3. What needs attention (action panel)
 
@@ -175,18 +201,59 @@ A second hero grid, same layout as the top one, showing the funnel-health summar
 
 This grid completes the dashboard: hero cards at the top (queue size + immediate red flags), recommendations next (what to do), velocity + opened-vs-closed (momentum), pressure by area (where), and triage funnel (process health).
 
+### 9b. Triager activity panel
+
+Sourced from [`aggregate.md#triager-activity-per-triager-per-week`](aggregate.md#triager-activity-per-triager-per-week).
+A ranked table of the top 15 maintainers by **distinct PRs engaged** across
+the last 6 calendar weeks, with **AI/manual split per week**.
+
+Layout — one row per maintainer, columns:
+
+| Column | Content |
+|---|---|
+| `Triager` | `@<login>` with link to GitHub profile |
+| `Total` | Total distinct PRs across the 6-week window (`ai + manual` collapsed) |
+| `AI` | Sub-total of PRs where the maintainer's engagement included the AI-attribution footer |
+| `Manual` | Sub-total of PRs without AI footer |
+| `W-5`…`This wk` | One column per rolling week, each cell rendered as a small `ai / manual` split (e.g. `12/3` = 12 AI + 3 manual) |
+| `Trend` | Inline 6-bar sparkline of the per-week totals, AI portion stacked over manual |
+
+Sort by `Total` descending. Bot accounts excluded via
+[`is_bot`](classify.md#is_bot--author-is-a-recognised-bot).
+
+The AI / Manual split makes one specific question visible: of each maintainer's
+triage throughput, how much is going through the `pr-management-triage` skill
+(detected via the AI-attribution footer substring) vs. through direct
+review-thread typing. Both modes are *real triage* — the maintainer approved
+every AI-drafted comment before it posted — but the split surfaces where the
+skill is providing leverage vs. where the maintainer is doing the writing
+themselves. A high AI ratio for a maintainer typically means they ran a
+batched triage sweep; a high manual ratio means they did deep-review
+conversation.
+
+Below the table, a one-line summary:
+
+```text
+6-week throughput: <N_ai> AI-assisted / <N_manual> manual / <N_total> total
+                   across <N_triagers> active maintainers
+```
+
+Empty state: when there are zero engagements in the window (a quiet 6 weeks),
+render a single low-priority card with the message "No triager activity in
+the last 6 weeks — quiet window or fetch shape missing comment data."
+
 ### 10. Detailed tables (collapsed `<details>` blocks)
 
 Two `<details>` elements, each opening into a compact area-grouped table:
 
-- **Triaged PRs — Final State since `<cutoff>`** — same structure as the [Table 1](#table-1--triaged-prs-final-state) section below.
-- **Triaged PRs — Still Open** — same structure as [Table 2](#table-2--triaged-prs-still-open) below, possibly compact (drop the 8 age-bucket columns) for screen width.
+- **Triaged PRs — Final State since `<cutoff>`** — same structure as the Table 1 section below.
+- **Triaged PRs — Still Open** — same structure as the Table 2 section below, possibly compact (drop the 8 age-bucket columns) for screen width.
 
 Both tables are HTML-rendered with the same colour scheme as the dashboard. Maintainers who want the raw per-area numbers click to expand; the default view is the dashboard sections above.
 
 ### 11. Legend / methodology
 
-A bordered panel at the bottom explaining all the colours, columns, and computed values. Critical content because the dashboard packs a lot of distinct numbers into small footprints. See [`#legend`](#legend) below for the verbatim block.
+A bordered panel at the bottom explaining all the colours, columns, and computed values. Critical content because the dashboard packs a lot of distinct numbers into small footprints. See the Legend section below for the verbatim block.
 
 ---
 

--- a/.claude/skills/pr-management-stats/render.md
+++ b/.claude/skills/pr-management-stats/render.md
@@ -40,9 +40,24 @@ Four equally-sized cards, each one big number with a sub-label:
 | Card | Big number | Sub-label | Colour rule |
 |---|---|---|---|
 | **Repo Health** | the rating label (`✅ Healthy` / `⚠️ Needs attention` / `🔥 Action needed`) | "based on triage backlog + queue size" | green / amber / red, per [`aggregate.md#health-rating`](aggregate.md#health-rating) |
-| **Open PRs (non-bot)** | total open count | `<contrib_count> from contributors · <collab_count> collaborator-authored` | blue (informational) |
+| **Open PRs (non-bot)** | total open count | `<total_non_drafts> non-draft · <total_drafts> draft` (line 1)<br>`<contrib_count> contributor · <collab_count> collaborator-authored` (line 2) | blue (informational) |
 | **Ready for review** | `len(ready_open)` | `<pct>% of contributor queue` | green |
-| **Untriaged non-drafts** | `len(untriaged_nondraft)` | `<X> are >4 weeks old` | red if >0 are >4w, amber if total > 30, green otherwise |
+| **Untriaged non-drafts** | `len(untriaged_nondraft)` (uses [`is_untriaged`](classify.md#is_untriaged--refined-predicate) — contributor-only AND NOT ready-labelled) | `<X> are >4 weeks old` | red if >0 are >4w, amber if total > 30, green otherwise |
+
+The **Open PRs** card's sub-label is a two-line breakdown: the first line splits
+the total by draft state (the user often wants to see "how much of the backlog
+is in review vs. still being worked on" at a glance), the second line splits by
+author class (contributor vs. collaborator). Both splits sum to the same total
+(modulo bot exclusion at fetch time), so a maintainer can quickly cross-check
+the numbers.
+
+The **Untriaged non-drafts** card uses the refined `is_untriaged` predicate from
+[`classify.md`](classify.md#is_untriaged--refined-predicate) — collaborator-
+authored PRs and PRs already carrying `ready for maintainer review` are NOT
+counted here. Without this scope refinement, the card would over-count by
+including (a) committer parking-lot PRs the F1 pre-filter never lets the
+triage skill act on, and (b) reviewer-queue PRs that have already passed the
+triage bar by an alternate path.
 
 Card layout is responsive: 4-column on wide screens, 2-column on narrow, 1-column on mobile-width. The big number uses 32px font; sub-labels are 12px dim grey.
 

--- a/.claude/skills/pr-management-stats/render.md
+++ b/.claude/skills/pr-management-stats/render.md
@@ -48,24 +48,24 @@ Two rows of four cards each:
 
 #### Row 2 — triage coverage breakdown
 
-This row exposes the **gap between strict and broad triage coverage** so a
-maintainer can see at a glance how much triage is happening that the strict
-marker-based count misses.
+This row exposes the **gap between the literal Quality-Criteria marker and
+broad maintainer engagement** so a maintainer can see at a glance how much
+triage is happening that the marker-based count misses.
 
 | Card | Big number | Sub-label | Colour rule |
 |---|---|---|---|
-| **Strict-triaged** | `triaged_waiting + triaged_responded` (literal marker present) | `<pct>% of contributor non-drafts` | blue (informational) |
-| **De-facto triaged** | [`defacto_triaged`](classify.md#is_engaged--de-facto-triaged) (engaged by a maintainer, no marker) | `<pct>% of contributor non-drafts` | amber (gap signal — the bigger this is vs strict, the more triage is happening invisibly) |
-| **AI-triaged** | [`ai_triaged`](classify.md#is_ai_triaged--ai-assisted-triage) (received an AI-assisted triage comment) | `<pct>% of strict-triaged` | grey (informational) |
+| **Quality Criteria triaged** | `triaged_waiting + triaged_responded` (literal `Pull Request quality criteria` link present in a maintainer comment) | `<pct>% of contributor non-drafts` | blue (informational) |
+| **De-facto triaged** | [`defacto_triaged`](classify.md#is_engaged--de-facto-triaged) (engaged by a maintainer, no Quality-Criteria marker) | `<pct>% of contributor non-drafts` | amber (gap signal — the bigger this is vs the Quality-Criteria card, the more triage is happening invisibly to the marker counter) |
+| **AI-triaged** | [`ai_triaged`](classify.md#is_ai_triaged--ai-assisted-triage) (received an AI-assisted triage comment) | `<pct>% of Quality-Criteria-triaged` | grey (informational) |
 | **Bot PRs** | [`bot_authored`](classify.md#is_bot--author-is-a-recognised-bot) | `<dependabot> dependabot · <other> other` | grey (separate lifecycle, surfaced for accounting parity) |
 
 The **De-facto triaged** card is the key new signal: on a large `<upstream>`
-queue (~457 human-authored open PRs) the strict count typically captures ~21%
-of PRs but the broad `is_engaged` count captures ~59% — the gap (~38 percentage
-points) is PRs that maintainers engaged with through review threads, direct
-comments, or label-adds without leaving the templated `Pull Request quality
-criteria` marker. Surfacing the gap lets the maintainer team see how much
-queue health the strict counter under-states.
+queue (~457 human-authored open PRs) the Quality-Criteria count typically
+captures ~21% of PRs but the broad `is_engaged` count captures ~59% — the
+gap (~38 percentage points) is PRs that maintainers engaged with through
+review threads, direct comments, or label-adds without leaving the templated
+`Pull Request quality criteria` marker. Surfacing the gap lets the maintainer
+team see how much queue health the marker-based counter under-states.
 
 The **Bot PRs** card is a separate accounting category — bot-authored PRs
 follow their own automated lifecycle and don't merge into the


### PR DESCRIPTION
## Summary

The `pr-management-stats` dashboard's "Untriaged non-drafts" hero card was over-counting against `apache/airflow` (~475 open PRs):

- Reported: **266** untriaged non-drafts / **73** >4w old
- Actual actionable: **~38** contributor PRs

Breaking down the 73-figure showed two structural issues with the classifier:

- **26 PRs (35%)** were committer-authored — F1-skipped by `pr-management-triage`, never going to be acted on by the triage skill, but counted toward the hero card.
- **44 PRs (60%)** were already labelled `ready for maintainer review` — they had cleared the triage bar by an alternate path (direct reviewer promotion, pre-skill-era triage, etc.) but lacked the literal `Pull Request quality criteria` marker the classifier searches for, so they double-counted as "untriaged" while *also* appearing in the "Ready for review" hero card.

The recommendation rules and health rating fired on the inflated count, producing advice that didn't match the real state.

## Changes

This is a pure classification + documentation refinement. No fetch shape, no GraphQL changes, no breaking changes for adopters.

### `classify.md`
- Introduces an explicit **`is_untriaged` predicate** that combines the existing triage-marker scan with two missing exclusions: (a) author is not OWNER/MEMBER/COLLABORATOR, (b) PR does not carry `ready for maintainer review`.
- Documents the rationale for each exclusion.

### `aggregate.md`
- Adds `untriaged_nondraft` / `untriaged_old` / `untriaged_med` per-area counters that consume the refined predicate.
- Adds whole-repo `total_drafts` / `total_non_drafts` counters powering the dashboard's new draft/non-draft split.
- Updates the **health rating** thresholds to read from the refined counters (so a queue full of ready-labelled PRs without the literal marker doesn't false-positive into "Action needed").
- Adds two new invariants covering the new counter relationships.

### `render.md`
- Enhances the "Open PRs" hero card with a **two-line sub-label**:
  - Line 1: `<non-draft> non-draft · <draft> draft`
  - Line 2: `<contributor> contributor · <collaborator> collaborator-authored`

  This addresses a recurring maintainer question — *"how much of the backlog is in-review vs. still being worked on"* — at a glance.
- Updates the "Untriaged non-drafts" hero card spec to reference the refined `is_untriaged` predicate and explains why both exclusions matter.

## Note on `pressure_weight`

`classify.md#pressure-weight` was already correct — collaborator-authored PRs already scored 0, and ready-labelled PRs already got a fixed weight of 1 (regardless of triage state). So the **area-pressure ranking didn't need fixing** — only the global "untriaged" counters that feed the hero card, health rating, and recommendation rules needed the predicate refinement.

## Validation

Ran on `apache/airflow` (476 open PRs at fetch). Pre-fix dashboard reported 266 / 73; post-fix reads 38 / actual count after exclusions, matching the real backlog the maintainer is actually able to act on.

`prek run --all-files` passes on the changed files.

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code (Opus 4.7)

Generated-by: Claude Code (Opus 4.7)
