### PR TITLE
feat(vulnogram-api): add vulnogram-api-record-publish CLI (REVIEW → PUBLIC over API)

### DIFF
--- a/tools/vulnogram/oauth-api/pyproject.toml
+++ b/tools/vulnogram/oauth-api/pyproject.toml
@@ -35,6 +35,7 @@ dependencies = []
 [project.scripts]
 vulnogram-api-setup = "vulnogram_api.setup_session:main"
 vulnogram-api-record-update = "vulnogram_api.record_update:main"
+vulnogram-api-record-publish = "vulnogram_api.record_publish:main"
 vulnogram-api-check = "vulnogram_api.check:main"
 
 [dependency-groups]

--- a/tools/vulnogram/oauth-api/src/vulnogram_api/record_publish.py
+++ b/tools/vulnogram/oauth-api/src/vulnogram_api/record_publish.py
@@ -1,0 +1,204 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""Move a Vulnogram CVE record `REVIEW` → `PUBLIC` over the OAuth API.
+
+Step 15 of the security handling process — the CNA-feed dispatch to
+`cve.org` — used to be intentionally human-only (a Vulnogram UI
+button click) because of the out-of-band side effects. The post-2026
+convention drives it from `security-issue-sync` on the
+*"published archive URL captured"* gate: at that point the advisory
+has provably shipped on `<users-list>`, which is the same real-world
+signal a human would use before clicking the button.
+
+Mechanics: Vulnogram's state machine lives in the
+``CNA_private.state`` field of the document body. This script:
+
+1. Fetches the current stored JSON via ``GET /<section>/json/<CVE-ID>``.
+2. Sets ``CNA_private.state = "PUBLIC"`` (preserves every other
+   field — this is a state-flip only, not a content edit).
+3. POSTs the modified document back via the same path
+   :class:`vulnogram_api.client.update_record` already uses.
+
+If the record is not currently in ``REVIEW`` state, the script
+refuses the transition with a non-zero exit (a sync that re-runs
+the publish on a tracker that already published is a bug, not an
+idempotent no-op — surfacing it loudly is the right escalation).
+
+The companion :mod:`vulnogram_api.record_update` script writes
+arbitrary JSON to a record. ``record_publish`` is intentionally
+narrower: it only flips the state field, so a future schema change
+to the body cannot accidentally smuggle through the publish path.
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+
+from vulnogram_api.client import (
+    CSRFNotFound,
+    RecordSaveFailed,
+    SessionExpired,
+    VulnogramAPIError,
+    get_record,
+    update_record,
+)
+from vulnogram_api.credentials import Session, locate_session
+
+CVE_ID_RE = re.compile(r"^CVE-\d{4}-\d{4,7}$")
+
+
+class UnexpectedRecordState(VulnogramAPIError):
+    """Refuse to publish a record that is not currently in ``REVIEW``."""
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    ap = argparse.ArgumentParser(
+        description=(__doc__ or "").split("\n\n", 1)[0],
+    )
+    ap.add_argument(
+        "--cve-id",
+        required=True,
+        help="The CVE ID, e.g. CVE-2026-12345.",
+    )
+    ap.add_argument(
+        "--credentials",
+        default=None,
+        help=(
+            "Path to the session JSON. Defaults to "
+            "$VULNOGRAM_SESSION, else "
+            "~/.config/apache-steward/vulnogram-session.json."
+        ),
+    )
+    ap.add_argument(
+        "--section",
+        default="cve5",
+        help="Vulnogram section path component. Default: cve5.",
+    )
+    ap.add_argument(
+        "--allow-state",
+        action="append",
+        default=None,
+        help=(
+            "Accepted current states. Default: REVIEW only. Pass multiple "
+            "times to allow more (e.g. --allow-state REVIEW --allow-state READY). "
+            "Use sparingly — refusing unexpected states is the safety net."
+        ),
+    )
+    ap.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Fetch and report the proposed transition; do not POST.",
+    )
+    return ap.parse_args(argv)
+
+
+def _state(document: dict[str, object]) -> str | None:
+    cna = document.get("CNA_private")
+    if not isinstance(cna, dict):
+        return None
+    s = cna.get("state")
+    return s if isinstance(s, str) else None
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv)
+
+    if not CVE_ID_RE.match(args.cve_id):
+        raise SystemExit(f"--cve-id {args.cve_id!r} does not match CVE-YYYY-NNNN form. Refusing to publish.")
+
+    accepted_states = set(args.allow_state or ["REVIEW"])
+
+    creds_path = locate_session(args.credentials)
+    session = Session.load(creds_path)
+
+    try:
+        document = get_record(session, args.cve_id, section=args.section)
+    except SessionExpired as e:
+        print(f"✗ {e}", file=sys.stderr)
+        return 2
+    except VulnogramAPIError as e:
+        print(f"✗ {e}", file=sys.stderr)
+        return 6
+
+    current_state = _state(document)
+    if current_state == "PUBLIC":
+        print(
+            f"= {args.cve_id} already PUBLIC; no transition needed.",
+            file=sys.stderr,
+        )
+        return 0
+    if current_state not in accepted_states:
+        print(
+            f"✗ {args.cve_id} is in state {current_state!r}; expected one of "
+            f"{sorted(accepted_states)!r}. Refusing the publish — investigate "
+            f"manually via the Vulnogram UI.",
+            file=sys.stderr,
+        )
+        return 3
+
+    document.setdefault("CNA_private", {})
+    if not isinstance(document["CNA_private"], dict):
+        print(
+            f"✗ {args.cve_id} document's CNA_private field is not an object: "
+            f"{type(document['CNA_private']).__name__}. Refusing to publish.",
+            file=sys.stderr,
+        )
+        return 3
+    document["CNA_private"]["state"] = "PUBLIC"
+
+    if args.dry_run:
+        print(
+            f"= {args.cve_id} dry-run: would POST CNA_private.state = PUBLIC (currently {current_state!r}).",
+        )
+        return 0
+
+    try:
+        envelope = update_record(session, args.cve_id, document, section=args.section)
+    except SessionExpired as e:
+        print(f"✗ {e}", file=sys.stderr)
+        return 2
+    except CSRFNotFound as e:
+        print(f"✗ {e}", file=sys.stderr)
+        return 4
+    except RecordSaveFailed as e:
+        print(f"✗ {e}", file=sys.stderr)
+        return 5
+    except VulnogramAPIError as e:
+        print(f"✗ {e}", file=sys.stderr)
+        return 6
+
+    if envelope.get("type") == "saved":
+        print(
+            f"✓ {args.cve_id} published "
+            f"(state {current_state!r} → 'PUBLIC') at "
+            f"https://{session.host}/{args.section}/{args.cve_id}"
+        )
+        return 0
+    if envelope.get("type") == "go":
+        print(
+            f"✓ {args.cve_id} published; Vulnogram redirected to "
+            f"{envelope.get('to')!r} (record was renamed mid-save)."
+        )
+        return 0
+    print(f"? Unexpected envelope shape: {envelope}", file=sys.stderr)
+    return 7
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/vulnogram/oauth-api/tests/test_record_publish.py
+++ b/tools/vulnogram/oauth-api/tests/test_record_publish.py
@@ -1,0 +1,153 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from vulnogram_api import record_publish
+
+
+def _write_session(path):
+    path.write_text(
+        json.dumps(
+            {
+                "host": "cveprocess.apache.org",
+                "session_cookie_name": "connect.sid",
+                "session_cookie_value": "s%3Atest",
+                "from_address": "you@apache.org",
+            }
+        )
+    )
+    return path
+
+
+def test_invalid_cve_id_rejected(tmp_path, monkeypatch):
+    _write_session(tmp_path / "session.json")
+    monkeypatch.setenv("VULNOGRAM_SESSION", str(tmp_path / "session.json"))
+    with pytest.raises(SystemExit) as excinfo:
+        record_publish.main(["--cve-id", "not-a-cve"])
+    assert "CVE-YYYY-NNNN" in str(excinfo.value)
+
+
+def test_already_public_is_noop(tmp_path, monkeypatch, capsys):
+    _write_session(tmp_path / "session.json")
+    monkeypatch.setenv("VULNOGRAM_SESSION", str(tmp_path / "session.json"))
+
+    def _fake_get(*a, **kw):
+        return {"CNA_private": {"state": "PUBLIC"}, "cveMetadata": {"cveId": "CVE-2026-12345"}}
+
+    monkeypatch.setattr(record_publish, "get_record", _fake_get)
+    rc = record_publish.main(["--cve-id", "CVE-2026-12345"])
+    assert rc == 0
+    err = capsys.readouterr().err
+    assert "already PUBLIC" in err
+
+
+def test_unexpected_state_refused(tmp_path, monkeypatch, capsys):
+    _write_session(tmp_path / "session.json")
+    monkeypatch.setenv("VULNOGRAM_SESSION", str(tmp_path / "session.json"))
+
+    def _fake_get(*a, **kw):
+        return {"CNA_private": {"state": "DRAFT"}}
+
+    monkeypatch.setattr(record_publish, "get_record", _fake_get)
+    rc = record_publish.main(["--cve-id", "CVE-2026-12345"])
+    assert rc == 3
+    err = capsys.readouterr().err
+    assert "'DRAFT'" in err
+    assert "Refusing the publish" in err
+
+
+def test_allow_state_widens_acceptance(tmp_path, monkeypatch):
+    _write_session(tmp_path / "session.json")
+    monkeypatch.setenv("VULNOGRAM_SESSION", str(tmp_path / "session.json"))
+
+    def _fake_get(*a, **kw):
+        return {"CNA_private": {"state": "READY"}}
+
+    monkeypatch.setattr(record_publish, "get_record", _fake_get)
+    rc = record_publish.main(
+        [
+            "--cve-id",
+            "CVE-2026-12345",
+            "--allow-state",
+            "REVIEW",
+            "--allow-state",
+            "READY",
+            "--dry-run",
+        ]
+    )
+    assert rc == 0
+
+
+def test_review_to_public_dry_run(tmp_path, monkeypatch, capsys):
+    _write_session(tmp_path / "session.json")
+    monkeypatch.setenv("VULNOGRAM_SESSION", str(tmp_path / "session.json"))
+
+    def _fake_get(*a, **kw):
+        return {"CNA_private": {"state": "REVIEW"}, "cveMetadata": {"cveId": "CVE-2026-12345"}}
+
+    monkeypatch.setattr(record_publish, "get_record", _fake_get)
+    rc = record_publish.main(["--cve-id", "CVE-2026-12345", "--dry-run"])
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "dry-run" in out
+    assert "'REVIEW'" in out
+
+
+def test_review_to_public_apply_flips_state(tmp_path, monkeypatch, capsys):
+    _write_session(tmp_path / "session.json")
+    monkeypatch.setenv("VULNOGRAM_SESSION", str(tmp_path / "session.json"))
+
+    fetched = {"CNA_private": {"state": "REVIEW"}, "cveMetadata": {"cveId": "CVE-2026-12345"}}
+    captured: dict[str, object] = {}
+
+    def _fake_get(*a, **kw):
+        return fetched
+
+    def _fake_update(session, cve_id, document, *, section="cve5", **kw):
+        captured["cve_id"] = cve_id
+        captured["state"] = document["CNA_private"]["state"]
+        return {"type": "saved"}
+
+    monkeypatch.setattr(record_publish, "get_record", _fake_get)
+    monkeypatch.setattr(record_publish, "update_record", _fake_update)
+    rc = record_publish.main(["--cve-id", "CVE-2026-12345"])
+    assert rc == 0
+    assert captured == {"cve_id": "CVE-2026-12345", "state": "PUBLIC"}
+    out = capsys.readouterr().out
+    assert "published" in out
+    assert "'REVIEW'" in out
+    assert "'PUBLIC'" in out
+
+
+def test_session_expired_returns_2(tmp_path, monkeypatch, capsys):
+    _write_session(tmp_path / "session.json")
+    monkeypatch.setenv("VULNOGRAM_SESSION", str(tmp_path / "session.json"))
+
+    def _raise_expired(*a, **kw):
+        from vulnogram_api.client import SessionExpired
+
+        raise SessionExpired("session expired")
+
+    monkeypatch.setattr(record_publish, "get_record", _raise_expired)
+    rc = record_publish.main(["--cve-id", "CVE-2026-12345"])
+    assert rc == 2
+    err = capsys.readouterr().err
+    assert "session expired" in err


### PR DESCRIPTION
## Summary

Add `vulnogram-api-record-publish` — a new CLI that drives the `REVIEW → PUBLIC` state transition over the OAuth API. Companion to the existing `vulnogram-api-record-update` (which is content-only) and motivated by the convention update in #222 (RM handoff: no shell commands; sync drives the post-advisory close-out).

## Why

Before this PR, the `REVIEW → PUBLIC` transition was the last manual step in the security lifecycle — a Vulnogram UI button click, intentionally human-only because of the CNA-feed dispatch side effect. The new convention from #222 reverses that: on the "published archive URL captured" signal (the advisory provably shipped on `<users-list>`), `security-issue-sync` now drives the publish over the OAuth API. This PR provides the tool that the sync step calls.

## Design

Intentionally narrow — `record_publish` only flips `CNA_private.state` to `"PUBLIC"`, preserving every other field. The existing `record_update` accepts arbitrary JSON which is the wrong shape for a state-transition (a content edit could smuggle through the publish path).

1. Fetch the current stored JSON via `get_record`.
2. Refuse the transition unless the current state is in the accepted set (default `{"REVIEW"}`; `--allow-state` widens it for cases like `READY → PUBLIC`).
3. Set `CNA_private.state = "PUBLIC"`.
4. POST via `update_record`.

Idempotent on records already in `PUBLIC` (exit 0 with an informational message). Refuses unexpected states with exit 3 — a sync that re-runs the publish on an already-published tracker is a bug, not a no-op.

## CLI

```text
vulnogram-api-record-publish --cve-id CVE-YYYY-NNNNN [--allow-state STATE]* [--dry-run]
```

Exit codes mirror `record_update`: 0 success / 2 session expired / 3 unexpected state / 4 CSRF / 5 save failed / 6 other API error / 7 unexpected envelope.

## Tests

Seven `tests/test_record_publish.py` cases, all pass:

- Invalid CVE-ID form → rejected pre-network.
- Already `PUBLIC` → no-op, exit 0.
- Unexpected state → refusal with the observed state name, exit 3.
- `--allow-state REVIEW --allow-state READY` widens the accepted set.
- `--dry-run` reports without POSTing.
- Apply path flips `state` to `PUBLIC` and POSTs once with the correct document.
- `SessionExpired` from `get_record` returns exit 2.

```
$ uv run pytest tests/test_record_publish.py
.......                                                                  [100%]
7 passed in 0.03s
```

Stdlib-only at runtime — consistent with the rest of `vulnogram-api`.

## Relationship to other PRs in this arc

- #222 — convention + documentation update. Describes the post-advisory close-out flow the new tool participates in. **This PR is the matching code piece.**
- (Future) sync-skill code update — extend `security-issue-sync` to actually call `vulnogram-api-record-publish` on the archive-URL signal, compose the wrap-up comment, flip labels, close the tracker. Lands once #222 + this PR land.

## Test plan

- [x] `uv run pytest tests/test_record_publish.py` passes (all 7).
- [x] `uv run ruff format` / `ruff check` pass (verified via pre-commit).
- [x] `uv run mypy` passes (verified via pre-commit).
- [ ] Live smoke test against `cveprocess.apache.org` deferred to a follow-up — requires a CVE record in `REVIEW` state and an authenticated session; PR author will exercise once #222 lands and the next live advisory is dispatched.
