### PR TITLE
fix(skill-validator): preserve blank lines inside block scalars in parse_frontmatter

### DIFF
--- a/tools/skill-validator/src/skill_validator/__init__.py
+++ b/tools/skill-validator/src/skill_validator/__init__.py
@@ -226,12 +226,15 @@ def parse_frontmatter(text: str) -> dict[str, str] | None:
         # Strip trailing whitespace but keep leading (for folded scalars)
         line = raw_line.rstrip()
 
-        # Empty line ends a folded scalar
+        # Blank line: in real YAML, a blank line inside a block scalar
+        # is part of the value, not a terminator. Only a new top-level
+        # key finalises the current value. Preserve the blank so
+        # multi-paragraph descriptions are measured and validated in
+        # full; a trailing/leading blank is removed by `.strip()` at
+        # finalisation, so single-line values are unaffected.
         if line == "":
             if current_key is not None:
-                result[current_key] = "\n".join(current_value_lines).strip()
-                current_key = None
-                current_value_lines = []
+                current_value_lines.append("")
             continue
 
         # New top-level key?

--- a/tools/skill-validator/tests/test_validator.py
+++ b/tools/skill-validator/tests/test_validator.py
@@ -73,6 +73,30 @@ class TestParseFrontmatter:
         assert "First line" in fm["description"]
         assert "Second line" in fm["description"]
 
+    def test_block_scalar_preserves_internal_blank_line(self) -> None:
+        """Blank lines inside a ``|`` block scalar are part of the value.
+
+        Regression: the parser used to treat any blank line as a
+        terminator, silently dropping everything after the first
+        paragraph break. That made ``MAX_METADATA_CHARS`` measurement
+        and principle/trigger validation operate on truncated text.
+        """
+        text = (
+            "---\n"
+            "name: my-skill\n"
+            "description: |\n"
+            "  Paragraph one.\n"
+            "\n"
+            "  Paragraph two, which used to be dropped.\n"
+            "license: Apache-2.0\n"
+            "---\n"
+        )
+        fm = parse_frontmatter(text)
+        assert fm is not None
+        assert "Paragraph one." in fm["description"]
+        assert "Paragraph two" in fm["description"]
+        assert fm["license"] == "Apache-2.0"
+
     def test_missing_frontmatter(self) -> None:
         assert parse_frontmatter("# no frontmatter\n") is None
 


### PR DESCRIPTION
## What

Fixes a latent correctness bug in `skill-validator`'s `parse_frontmatter`, surfaced by a code review.

### The bug

`parse_frontmatter` treated any blank line as a terminator for the current key. A YAML block scalar (`|` or `>`) with a paragraph break (a blank line between two indented paragraphs) silently lost everything after the first paragraph.

Two consequences:

1. `validate_frontmatter` measures `len(fm["description"]) + len(fm["when_to_use"])` against `MAX_METADATA_CHARS` (the Claude Code truncation budget). With the dropped paragraphs the measurement was too small, so frontmatter that actually exceeded the budget could pass the check.
2. `validate_principle_compliance` and `validate_trigger_preservation` only saw the truncated string, missing forbidden patterns or trigger phrasing that lived in the dropped paragraphs.

### Why latent

No existing SKILL.md frontmatter currently uses a paragraph break in a block scalar, so nothing in-tree exercised the bug. But `init_skill.py` scaffolding emits multi-line `description` and `when_to_use` blocks, and any author writing a two-paragraph description would have been silently mis-validated.

### The fix

In real YAML, a blank line inside a block scalar is part of the value, not a terminator. Only a new top-level key finalises the current value. The parser now appends blank lines to the value lines and lets `.strip()` at finalisation discard leading/trailing blanks so single-line values are unaffected.

## Changes

- `src/skill_validator/__init__.py` — `parse_frontmatter`: blank line is content, not terminator
- `tests/test_validator.py` — regression test for a `|` block scalar with an internal blank line

## Validation

- `pytest`: 77 passed
- `ruff check` / `ruff format` / `mypy`: clean
- `prek` including `skill-validate (.claude/skills/**)`: all hooks pass — every existing SKILL.md still validates after the parser change