### PR TITLE
fix(gmail-oauth-draft): wrap api_get with HTTPError handler for clean failure surface

### DIFF
--- a/tools/gmail/oauth-draft/src/oauth_draft/create_draft.py
+++ b/tools/gmail/oauth-draft/src/oauth_draft/create_draft.py
@@ -61,8 +61,11 @@ def api_get(access_token: str, path: str) -> dict:
         f"{GMAIL_API}{path}",
         headers={"Authorization": f"Bearer {access_token}"},
     )
-    with urllib.request.urlopen(req, timeout=15) as r:
-        return json.loads(r.read())
+    try:
+        with urllib.request.urlopen(req, timeout=15) as r:
+            return json.loads(r.read())
+    except urllib.error.HTTPError as e:
+        raise SystemExit(f"Gmail API {path} failed ({e.code}): {e.read().decode(errors='replace')}") from e
 
 
 def api_post(access_token: str, path: str, payload: dict) -> dict:

--- a/tools/gmail/oauth-draft/tests/test_create_draft.py
+++ b/tools/gmail/oauth-draft/tests/test_create_draft.py
@@ -250,6 +250,29 @@ def test_api_post_parses_json_response():
     assert json.loads(request.data) == {"message": {"raw": "X"}}
 
 
+def test_api_get_raises_on_http_error():
+    """``api_get`` must surface HTTP errors as a clean ``SystemExit``.
+
+    Regression: ``api_get`` was the only ``urlopen`` call in the
+    package without a ``try/except HTTPError``, so a 401/403/404 from
+    ``threads.get`` (the path exercised on every ``oauth-draft-create
+    --thread-id <X>`` invocation) produced a raw Python traceback
+    instead of a one-line error matching the rest of the tool.
+    """
+    err = urllib.error.HTTPError(
+        url="https://x",
+        code=404,
+        msg="Not Found",
+        hdrs=None,  # type: ignore[arg-type]
+        fp=io.BytesIO(b'{"error": "thread missing"}'),
+    )
+    with patch("oauth_draft.create_draft.urllib.request.urlopen", side_effect=err):
+        with pytest.raises(SystemExit) as excinfo:
+            api_get("token", "/threads/missing-thread")
+    assert "failed (404)" in str(excinfo.value)
+    assert "thread missing" in str(excinfo.value)
+
+
 def test_api_post_raises_on_http_error():
     err = urllib.error.HTTPError(
         url="https://x",


### PR DESCRIPTION
## What

`api_get` was the only `urllib.request.urlopen` call in the `oauth-draft` package without a `try/except urllib.error.HTTPError`. `api_post`, both calls in `mark_threads_read`, and the token refresh in `credentials.py` all wrap the call and raise `SystemExit` with a one-line `"Gmail API <path> failed (<code>): <body>"` message.

### Impact

`api_get` is the path that `latest_reply_headers` uses, so any 401 / 403 / 404 from `GET /threads/{id}?format=full` (token expired, thread missing, missing scope) surfaced as a raw Python traceback instead of the clean error the rest of the tool produces. That path is exercised on every `oauth-draft-create --thread-id <X>` invocation that does not pass `--no-reply-headers`.

### Fix

Wraps `api_get` with the same handler as `api_post` and adds a regression test mirroring `test_api_post_raises_on_http_error`.

## Changes

- `src/oauth_draft/create_draft.py` — `api_get` wrapped with `try/except urllib.error.HTTPError`
- `tests/test_create_draft.py` — regression test asserting `api_get` raises `SystemExit` with the `failed (<code>)` shape on a Gmail 404

## Validation

- `pytest`: 59 passed
- `ruff check` / `ruff format` / `mypy`: clean
- `prek`: all hooks pass