### PR TITLE
feat(sandbox): allow cveawg.mitre.org for cve.org publication checks

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -3,7 +3,9 @@
   "sandbox": {
     "enabled": true,
     "filesystem": {
-      "denyRead": ["~/"],
+      "denyRead": [
+        "~/"
+      ],
       "allowRead": [
         ".",
         "~/.gitconfig",
@@ -35,6 +37,7 @@
         "cveprocess.apache.org",
         "cve.org",
         "www.cve.org",
+        "cveawg.mitre.org",
         "oauth2.googleapis.com",
         "gmail.googleapis.com"
       ]

--- a/tools/sandbox-lint/expected.json
+++ b/tools/sandbox-lint/expected.json
@@ -3,7 +3,9 @@
   "sandbox": {
     "enabled": true,
     "filesystem": {
-      "denyRead": ["~/"],
+      "denyRead": [
+        "~/"
+      ],
       "allowRead": [
         ".",
         "~/.gitconfig",
@@ -35,6 +37,7 @@
         "cveprocess.apache.org",
         "cve.org",
         "www.cve.org",
+        "cveawg.mitre.org",
         "oauth2.googleapis.com",
         "gmail.googleapis.com"
       ]


### PR DESCRIPTION
## Summary

Adds `cveawg.mitre.org` to the sandbox `allowedDomains` baseline so `security-issue-sync` Step 1g (cve.org publication-state check on recently-closed `announced` trackers) doesn't trip the macOS sandbox TLS interaction.

## Why

`security-issue-sync` Step 1g hits the MITRE CVE Services API at `https://cveawg.mitre.org/api/cve/<CVE-ID>` to detect the `RESERVED → PUBLISHED` transition on cve.org. The host was missing from `allowedDomains` in the baseline (`tools/sandbox-lint/expected.json`). On macOS the sandbox's interaction with the system trust store produces an `OSStatus -26276` cert verification failure for any host not in the allowlist, so every sync run that touched the closed-announced bucket required per-call `dangerouslyDisableSandbox: true` bypasses. For subagent fanouts on large sweeps (e.g. `sync all` across ~50 trackers) this became a prompt storm.

Adding the host eliminates the bypass in the common case.

## Files changed

- **`tools/sandbox-lint/expected.json`** — the baseline every adopter's `.claude/settings.json` is linted against. Adding here means all adopters get the fix on snapshot refresh.
- **`.claude/settings.json`** — the steward repo's own live settings, kept in lockstep with `expected.json` by the sandbox-lint invariant.

## Verification

```bash
$ uv run --directory tools/sandbox-lint --group dev sandbox-lint \
    --settings .claude/settings.json \
    --expected tools/sandbox-lint/expected.json
sandbox-lint: OK (.claude/settings.json matches tools/sandbox-lint/expected.json)
```

## Scope

This PR adds **only** the generic host — every adopter that uses the CVE-tracking skills hits the same cve.org API for the post-publication propagation check. Adopter-specific paths (sibling repos, scratch directories, personal allowlists) stay out of the baseline and live in user-level `~/.claude/settings.json` only.

## Related

- The wider RM-handoff state-gate work in [#255](https://github.com/apache/airflow-steward/pull/255) is what surfaced this gap (the `vulnogram-api-record-fetch` Step 5b.6 check hits cve.org during sync verification).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
