### PR TITLE
docs(governance): refresh Board resolution draft (roster, scope, source thread)

### DIFF
--- a/docs/board-resolution-draft.md
+++ b/docs/board-resolution-draft.md
@@ -25,66 +25,63 @@
 
 ## Resolution text
 
-> **B. Establish the Apache Magpie Project**
+> WHEREAS, the Board of Directors deems it to be in the best interests of the
+> Foundation and consistent with the Foundation's purpose to establish a Project
+> Management Committee charged with the creation and maintenance of open-source
+> software, for distribution at no charge to the public, related to creation and
+> maintenance of software related to agent-assisted repository maintainership
+> and development, including issue and pull- request triage, contributor
+> mentoring, agent-drafted remediation, developer-side development-cycle skills,
+> and narrowly-scoped fix-and- merge automation.
 >
-> WHEREAS, the Board of Directors deems it to be in the best interests of
-> the Foundation and consistent with the Foundation's purpose to establish
-> a Project Management Committee charged with the creation and maintenance
-> of open-source software, for distribution at no charge to the public,
-> related to agent-assisted maintenance and development of open-source
-> software projects.
+> NOW, THEREFORE, BE IT RESOLVED, that a Project Management Committee (PMC), to
+> be known as the "Apache Magpie Project", be and hereby is established pursuant
+> to Bylaws of the Foundation; and be it further
 >
-> NOW, THEREFORE, BE IT RESOLVED, that a Project Management Committee
-> (PMC), to be known as the "Apache Magpie Project", be and hereby is
-> established pursuant to Bylaws of the Foundation; and be it further
+> RESOLVED, that the Apache Magpie be and hereby is responsible for the creation
+> and maintenance of software related to creation and maintenance of software
+> related to agent-assisted repository maintainership and development, including
+> issue and pull- request triage, contributor mentoring, agent-drafted
+> remediation, developer-side development-cycle skills, and narrowly-scoped
+> fix-and- merge automation; and be it further
 >
-> RESOLVED, that the Apache Magpie Project be and hereby is responsible
-> for the creation and maintenance of software related to agent-assisted
-> repository maintainership and development, including issue and pull-
-> request triage, contributor mentoring, agent-drafted remediation,
-> developer-side development-cycle skills, and narrowly-scoped fix-and-
-> merge automation; and be it further
->
-> RESOLVED, that the office of "Vice President, Apache Magpie" be and
-> hereby is created, the person holding such office to serve at the
-> direction of the Board of Directors as the chair of the Apache Magpie
-> Project, and to have primary responsibility for management of the
-> projects within the scope of responsibility of the Apache Magpie
-> Project; and be it further
+> RESOLVED, that the office of "Vice President, Apache Magpie" be and hereby is
+> created, the person holding such office to serve at the direction of the Board
+> of Directors as the chair of the Apache Magpie Project, and to have primary
+> responsibility for management of the projects within the scope of
+> responsibility of the Apache Magpie Project; and be it further
 >
 > RESOLVED, that the persons listed immediately below be and hereby are
 > appointed to serve as the initial members of the Apache Magpie Project:
 >
-> ```text
-> * Andrew Musselman            <akm@apache.org>
-> * Amogh Desai                 <amoghdesai@apache.org>
-> * Craig L. Russell            <clr@apache.org>
-> * Elad Kalif                  <eladkal@apache.org>
-> * Pavan Kumar Gopidesu        <gopidesu@apache.org>
-> * Ismael Mejia                <iemejia@apache.org>
-> * James Fredley               <jamesfredley@apache.org>
-> * Jean-Baptiste Onofré        <jbonofre@apache.org>
-> * Justin Mclean               <jmclean@apache.org>
-> * Calvin Kirs                 <kirs@apache.org>
-> * Mike Drob                   <mdrob@apache.org>
-> * Paul King                   <paulk@apache.org>
-> * Piotr Karwasz               <pkarwasz@apache.org>
-> * Jarek Potiuk                <potiuk@apache.org>
-> * Rich Bowen                  <rbowen@apache.org>
-> * Evan Rusackas               <rusackas@apache.org>
-> * Russell Spitzer             <russellspitzer@apache.org>
-> * Zili Chen                   <tison@apache.org>
-> * Matthew Topol               <zeroshade@apache.org>
-> ```
+> * Amogh Desai <amoghdesai@apache.org>
+> * Andrew Musselman <akm@apache.org>
+> * Calvin Kirs <kirs@apache.org>
+> * Coty Sutherland <csutherl@apache.org>
+> * Craig L Russell <clr@apache.org>
+> * Elad Kalif <eladkal@apache.org>
+> * Evan Rusackas <rusackas@apache.org>
+> * Ismaël Mejía <iemejia@apache.org>
+> * James Fredley <jamesfredley@apache.org>
+> * Jarek Potiuk <potiuk@apache.org>
+> * Jean-Baptiste Onofré <jbonofre@apache.org>
+> * Justin Mclean <jmclean@apache.org>
+> * Matthew Topol <zeroshade@apache.org>
+> * Mike Drob <mdrob@apache.org>
+> * Paul King <paulk@apache.org>
+> * Pavan Kumar <gopidesu@apache.org>
+> * Piotr Karwasz <pkarwasz@apache.org>
+> * Rich Bowen <rbowen@apache.org>
+> * Richard Zowalla <rzo1@apache.org>
+> * Russell Spitzer <russellspitzer@apache.org>
+> * Rémy Maucherat <remm@apache.org>
+> * Zili Chen <tison@apache.org>
 >
-> NOW, THEREFORE, BE IT FURTHER RESOLVED, that Jarek Potiuk be appointed
-> to the office of Vice President, Apache Magpie, to serve in accordance
-> with and subject to the direction of the Board of Directors and the
-> Bylaws of the Foundation until death, resignation, retirement, removal
-> or disqualification, or until a successor is appointed.
->
-> Special Order *[NN]*, Establish the Apache Magpie Project, was
-> approved by *[Unanimous]* Vote of the directors present.
+> NOW, THEREFORE, BE IT FURTHER RESOLVED, that Jarek Potiuk be appointed to the
+> office of Vice President, Apache Magpie, to serve in accordance with and
+> subject to the direction of the Board of Directors and the Bylaws of the
+> Foundation until death, resignation, retirement, removal or disqualification,
+> or until a successor is appointed.
 
 ## Notes for the chair / proposer
 
@@ -110,7 +107,7 @@ to land them in the right place at the right time:
 
 - **Membership coordination** — the named roster must be cleared with
   `members@apache.org` and `secretary@apache.org` before the resolution
-  goes to the agenda. The 19-member list above reflects MISSION.md's
+  goes to the agenda. The 22-member list above reflects MISSION.md's
   *"7 or more members"* size criterion and the diversity / developer-
   experience criteria in MISSION.md § Initial PMC composition.
 
@@ -129,3 +126,6 @@ to land them in the right place at the right time:
 - **Supporting document attachment** — `MISSION.md` itself is the
   supporting document the Board reads alongside this resolution. Confirm
   it is included in the agenda packet under the proposing director's name.
+
+- **Discussion about project's scope and mission** - can be found in the board@ mailing list archives,
+starting with the initial proposal thread at https://lists.apache.org/thread/5zdgm9d55lzkhq6lx96dj5b699smbm1f


### PR DESCRIPTION
## Summary

- Expanded WHEREAS scope to match `MISSION.md` (issue/PR triage,
  contributor mentoring, agent-drafted remediation, developer-side
  development-cycle skills, fix-and-merge automation) — replaces the
  earlier generic phrasing.
- Refreshed initial PMC roster to 22 members (was 19), alphabetised
  by first name; adds Coty Sutherland, Richard Zowalla, Rémy Maucherat.
- Dropped redundant "B. Establish the Apache Magpie Project" header
  and the Special Order / Vote closing lines (Secretary formats those
  on the agenda).
- Added a chair-notes pointer to the board@ scope/mission discussion
  thread on lists.apache.org.

## Test plan
- [ ] Render the document and confirm the resolution text reads cleanly.
- [ ] Cross-check the 22-member roster against the board@ thread for
      late additions/removals before the resolution goes on the agenda.

## Generative-AI disclosure
This change was drafted with Claude Code (Opus 4.7) on the author's
machine; the author reviewed the diff before pushing.