### PR TITLE
feat(title-normalization): broader leading bracket + external-ID strip

### DIFF
--- a/.claude/skills/security-cve-allocate/SKILL.md
+++ b/.claude/skills/security-cve-allocate/SKILL.md
@@ -294,7 +294,9 @@ t = subprocess.check_output(
 ).strip()
 
 patterns_leading = [
-    r"^[ \t]*\[ ?Security (?:Report|Issue|Vulnerability|Bug) ?\][ \t:|\-–—]*",
+    # Any [...] or (...) leading tag whose body contains "security"
+    # or "important" (case-insensitive).
+    r"^[ \t]*(?:\[[^\]]*\b(?:Security|Important)\b[^\]]*\]|\([^)]*\b(?:Security|Important)\b[^)]*\))[ \t:|\-–—]*",
     r"^[ \t]*Security (?:Report|Issue|Vulnerability|Bug)[ \t:|\-–—]+",
     r"^[ \t]*Apache[ \t]+Airflow(?:[ \t]+v?\d+(?:\.\d+)*(?:\.x)?)?[ \t]*[:|\-–—]?[ \t]*",
     r"^[ \t]*Airflow(?:[ \t]+v?\d+(?:\.\d+)*(?:\.x)?)?[ \t]*[:|\-–—][ \t]*",
@@ -303,6 +305,9 @@ patterns_trailing = [
     r"[ \t]+in[ \t]+(?:Apache[ \t]+)?Airflow[ \t]*\.?$",
     r"[ \t]*\((?:Apache[ \t]+)?Airflow(?:[ \t]+v?\d+(?:\.\d+)*(?:\.x)?)?\)\.?[ \t]*$",
     r"[ \t]*\(GHSA-[\w-]+\)\.?[ \t]*$",
+    # Trailing IDs from known external trackers, square or round
+    # brackets. Extend the alternation per project.
+    r"[ \t]*(?:\[(?:ZDRES|HUNTR|GHSL)-[\w-]+\]|\((?:ZDRES|HUNTR|GHSL)-[\w-]+\))\.?[ \t]*$",
     r"[ \t]*\([^)]*split from #\d+[^)]*\)\.?[ \t]*$",
 ]
 

--- a/projects/_template/title-normalization.md
+++ b/projects/_template/title-normalization.md
@@ -34,7 +34,13 @@ stripping step. Otherwise, list the regex cascade below.
 
 TODO: one rule per bullet, applied in order. Typical patterns:
 
-1. Leading bracketed tags — e.g. `^[ \t]*\[ ?Security (Report|Issue|Vulnerability|Bug) ?\][ \t:|\-–—]*`
+1. Leading bracketed `security` / `important` tag —
+   `^[ \t]*(?:\[[^\]]*\b(?:Security|Important)\b[^\]]*\]|\([^)]*\b(?:Security|Important)\b[^)]*\))[ \t:|\-–—]*`
+   Matches any square- or round-bracketed leading tag whose body
+   contains the word *security* or *important* (case-insensitive) —
+   e.g. `[Security Report]`, `(Security Issue)`, `[ Security
+   Vulnerability ]`, `[IMPORTANT]`, `(Important — please read)`.
+   Followed by an optional separator. Apply with `re.IGNORECASE`.
 2. Leading plain tags — `^[ \t]*Security (Report|Issue|Vulnerability|Bug)[ \t:|\-–—]+`
 3. Leading `<Project Name>` (optional version, optional separator) — TODO
 4. Leading bare product name (optional version) — TODO
@@ -43,10 +49,16 @@ TODO: one rule per bullet, applied in order. Typical patterns:
 6. Trailing `in <Project Name>` — TODO
 7. Trailing bare version parens — TODO
 8. Trailing GHSA ID paren — `[ \t]*\(GHSA-[\w-]+\)\.?[ \t]*$`
-9. Trailing *"split from #NNN"* paren — `[ \t]*\([^)]*split from #\d+[^)]*\)\.?[ \t]*$`
-10. Trailing trivia — strip trailing whitespace, trailing `.`,
+9. Trailing known external-tracker IDs (square or round brackets) —
+   `[ \t]*(?:\[(?:ZDRES|HUNTR|GHSL)-[\w-]+\]|\((?:ZDRES|HUNTR|GHSL)-[\w-]+\))\.?[ \t]*$`
+   Strips trailing IDs from known external trackers — `(ZDRES-223)`,
+   `[HUNTR-456]`, `(GHSL-2024-001)` — in either bracket style. Extend
+   the alternation per project when a new reporter brand surfaces
+   (e.g. `SNYK-…`, `BDSA-…`, internal bug-bounty platforms).
+10. Trailing *"split from #NNN"* paren — `[ \t]*\([^)]*split from #\d+[^)]*\)\.?[ \t]*$`
+11. Trailing trivia — strip trailing whitespace, trailing `.`,
     collapse internal whitespace.
-11. Capitalise — upper-case the first letter; leave the rest alone
+12. Capitalise — upper-case the first letter; leave the rest alone
     so acronyms stay intact.
 
 ## Implementation recipe


### PR DESCRIPTION
## Summary

- **Pattern #1 (leading bracketed tag) broadened.** Old form matched only `[Security Report|Issue|Vulnerability|Bug]` with square brackets. New form matches any `[...]` *or* `(...)` leading tag whose body contains the word *security* or *important*, applied case-insensitive. Catches `(Security Issue)`, `[ Security Vulnerability ]`, `[IMPORTANT]`, `(Important — please read)`, etc.
- **Pattern #9 (new) — trailing external-tracker IDs.** Strips trailing IDs from common public-disclosure tracker brands — `(ZDRES-…)`, `[HUNTR-…]`, `(GHSL-…)` — in either square- or round-bracket form. Documented as a per-project-extensible alternation (`SNYK-…`, `BDSA-…`, internal bug-bounty platforms).
- Both changes land in two places kept in sync: the adopter-facing template `projects/_template/title-normalization.md` and the example cascade in `.claude/skills/security-cve-allocate/SKILL.md`.

## Motivation

Real airflow-s tracker subject: `[ Security Report ] LDAP Filter Injection in FAB Auth Manager _search_ldap reachable via /auth/token (ZDRES-223)`. The leading `[ Security Report ]` *did* match the old pattern, but no pattern covered the trailing `(ZDRES-223)` — the cleaned CVE title still carried the reporter-internal tracker ID. The broader leading regex also future-proofs the cascade against `(...)`-style and `[IMPORTANT]`-style reporter prefixes, which the old form silently skipped.

Verified locally — the new cascade collapses the example to `LDAP Filter Injection in FAB Auth Manager _search_ldap reachable via /auth/token`.

## Test plan

- [ ] Pattern #1 strips `[Security X]`, `(Security X)`, `[IMPORTANT]`, `(Important …)` in any casing.
- [ ] Pattern #1 leaves `[NotSecurity]` / `[Securityish]` alone (word-boundary required).
- [ ] Pattern #9 strips `(ZDRES-NNN)`, `[HUNTR-NNN]`, `(GHSL-YYYY-NNN)` and leaves `(CVE-…)` / `(Apache Airflow 2.5)` / `(GHSA-…)` / `(split from #N)` untouched (handled by other patterns).
- [ ] Skill-validator suite passes (no fixture updates needed; the template's regex is referenced as documentation).

🤖 Generated with [Claude Code](https://claude.com/claude-code)