### PR TITLE
setup-steward: generic _template/pr-management-triage-ci-check-map

### DIFF
--- a/projects/_template/pr-management-triage-ci-check-map.md
+++ b/projects/_template/pr-management-triage-ci-check-map.md
@@ -2,7 +2,7 @@
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
 **Table of Contents**  *generated with [DocToc](https://github.com/thlorenz/doctoc)*
 
-- [Apache Airflow — pr-management-triage CI-check to doc-URL map](#apache-airflow--pr-management-triage-ci-check-to-doc-url-map)
+- [TODO: `<Project Name>` — pr-management-triage CI-check to doc-URL map](#todo-project-name--pr-management-triage-ci-check-to-doc-url-map)
   - [Table](#table)
   - [Notes](#notes)
 
@@ -11,15 +11,18 @@
 <!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->
 
-# Apache Airflow — pr-management-triage CI-check to doc-URL map
+# TODO: `<Project Name>` — pr-management-triage CI-check to doc-URL map
 
 This file is the **CI-check categorisation table** for the
 [`pr-management-triage`](../../.claude/skills/pr-management-triage/SKILL.md) skill's
-violations comments.  It contains the concrete mapping for the
-Apache Airflow project.  New adopters should copy this file into
-their own `<project-config>/pr-management-triage-ci-check-map.md`
-and replace every Airflow-specific pattern and URL with their
-project's equivalents.
+violations comments. It holds the concrete mapping for your
+adopter project.
+
+Copy this file into your own
+`<project-config>/pr-management-triage-ci-check-map.md` and
+replace the `<placeholder>` URLs with your project's
+documentation paths. Add or adjust rows so the patterns match
+the GitHub check names your CI actually emits.
 
 ## Table
 
@@ -28,31 +31,48 @@ substring match) to a **human-readable category name** the skill
 prints in the violations comment, plus a **doc URL** the skill
 links to.
 
+The rows below are common starting points across Python / cloud-
+native projects. Add project-specific rows above the catch-all
+(`*`) row, and order more-specific patterns above broader ones —
+the skill matches first-found, so a row scoped to a sub-project
+must precede the generic prefix row if you want them split out
+in the violations comment.
+
 | Pattern | Category | Doc URL |
 |---|---|---|
-| `static checks`, `pre-commit`, `prek` | Pre-commit / static checks | `https://github.com/apache/airflow/blob/main/contributing-docs/08_static_code_checks.rst` |
-| `ruff` | Ruff (linting / formatting) | `https://github.com/apache/airflow/blob/main/contributing-docs/08_static_code_checks.rst` |
-| `mypy-` | mypy (type checking) | `https://github.com/apache/airflow/blob/main/contributing-docs/08_static_code_checks.rst` |
-| `unit test`, `test-` | Unit tests | `https://github.com/apache/airflow/blob/main/contributing-docs/09_testing.rst` |
-| `docs`, `spellcheck-docs`, `build-docs` | Build docs | `https://github.com/apache/airflow/blob/main/contributing-docs/11_documentation_building.rst` |
-| `helm` | Helm tests | `https://github.com/apache/airflow/blob/main/contributing-docs/testing/helm_unit_tests.rst` |
-| `k8s`, `kubernetes` | Kubernetes tests | `https://github.com/apache/airflow/blob/main/contributing-docs/testing/k8s_tests.rst` |
-| `build ci image`, `build prod image`, `ci-image`, `prod-image` | Image build | `https://github.com/apache/airflow/blob/main/contributing-docs/08_static_code_checks.rst` |
-| `provider` | Provider tests | `https://github.com/apache/airflow/blob/main/contributing-docs/12_provider_distributions.rst` |
-| `*` (catch-all) | Other failing CI checks | `https://github.com/apache/airflow/blob/main/contributing-docs/08_static_code_checks.rst` |
+| `static checks`, `pre-commit`, `prek` | Pre-commit / static checks | `<static-checks-doc-url>` |
+| `ruff` | Ruff (linting / formatting) | `<static-checks-doc-url>` |
+| `mypy-` | mypy (type checking) | `<static-checks-doc-url>` |
+| `unit test`, `test-` | Unit tests | `<unit-tests-doc-url>` |
+| `docs`, `spellcheck-docs`, `build-docs` | Build docs | `<docs-building-doc-url>` |
+| `helm` | Helm tests | `<helm-tests-doc-url>` |
+| `k8s`, `kubernetes` | Kubernetes tests | `<k8s-tests-doc-url>` |
+| `build ci image`, `build prod image`, `ci-image`, `prod-image` | Image build | `<image-build-doc-url>` |
+| `*` (catch-all) | Other failing CI checks | `<static-checks-doc-url>` |
+
+Add additional rows for project-specific check-name patterns
+above the catch-all. For example, a project with a plugin /
+extension subsystem typically wants a row matching the relevant
+GitHub check names (`<your-plugin-tag>`, `<extension-name>`,
+etc.) pointing at the corresponding contributing doc:
+
+```markdown
+| `<your-check-name-substring>` | <Human category> | <doc-url> |
+```
 
 ## Notes
 
 - **Order matters.** The skill matches first-found; more-specific
-  patterns are listed above broader ones (e.g. `mypy-airflow-core`
-  matches the `mypy-` row).
+  patterns are listed above broader ones (e.g. `mypy-<sub-project>`
+  matches the `mypy-` row, so put `<sub-project>`-scoped patterns
+  above the generic `mypy-` row if you want them split out).
 - **Mergeability fallback.** If the PR has `mergeable ==
   CONFLICTING`, the skill emits a separate "Merge conflicts"
-  category linking to the project's git/rebase doc:
+  category linking to the project's git / rebase doc:
 
 | Concept | Doc URL |
 |---|---|
-| Merge conflicts (rebase guide) | `https://github.com/apache/airflow/blob/main/contributing-docs/10_working_with_git.rst` |
+| Merge conflicts (rebase guide) | `<git-rebase-doc-url>` |
 
 - **Failing-CI fallback.** If `checks_state == FAILURE` but no
   failed check names are extractable, the skill emits a generic


### PR DESCRIPTION
## Summary

Follow-up to #280, which added a `Step 6d` template-genericity check
on `/setup-steward upgrade` and fixed the first concrete instance
(`_template/pr-management-config.md`). This PR fixes the second one
the check would flag.

`projects/_template/pr-management-triage-ci-check-map.md` was a
byte-for-byte copy of one adopter's CI mapping. Anyone copying it as
a scaffold inherited:

- A title hardcoded to that project's name (no `<Project Name>`
  placeholder).
- Every doc URL pointing at `apache/airflow/blob/main/contributing-
  docs/...` paths that 404 for any other adopter.
- A `provider` pattern row tied to that project's plugin architecture.

## What changed

- Title becomes `# TODO: \`<Project Name>\` — ...` matching the
  convention used in `project.md` / `canned-responses.md` / the
  `pr-management-config.md` cleanup from #280.
- Every doc URL becomes a `<...-doc-url>` placeholder
  (`<static-checks-doc-url>`, `<unit-tests-doc-url>`,
  `<docs-building-doc-url>`, etc.). Adopters fill them in by hand —
  one substitution per row.
- The `provider` row is dropped; its slot is replaced by a snippet
  showing the row format so adopters can add their own subsystem
  patterns above the catch-all.
- Pattern strings (`mypy-`, `ruff`, `helm`, `k8s`, `unit test`,
  `pre-commit`, `prek`, etc.) stay — they're widely-used CI-check
  naming conventions, useful as starting defaults.
- The `mypy-airflow-core` example in the Notes section becomes
  `mypy-<sub-project>` (illustrates the same "more-specific above
  broader" rule without naming a particular project).

## Test plan

- [x] prek passes (markdownlint, doctoc, typos, check-placeholders)
- [x] Step 6d audit on this file would now find nothing — scans
  clean against the heuristics introduced in #280

Generated-by: Claude (Opus 4.7)