### PR TITLE
chore(asf.yaml): remove CodeQL from required status checks; add lychee

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -132,10 +132,18 @@ github:
       # `asf-allowlist-check` (paths: `.github/**`) and
       # `lint .claude/settings.json against baseline` from
       # sandbox-lint (paths: `.claude/settings.json` +
-      # `tools/sandbox-lint/**`). Also excluded: `lychee` (the
-      # link-check runs on every PR, but external link rot is a
-      # maintenance concern handled by the daily schedule — it is
-      # not a merge-blocker).
+      # `tools/sandbox-lint/**`).
+      #
+      # CodeQL (`Analyze (python)`, `Analyze (actions)`) is NOT
+      # required. The framework repo is docs- and skills-heavy with
+      # no published runtime artefacts — the per-PR incremental
+      # value of CodeQL gating is low relative to the noise it
+      # produces on changes that do not touch real attack surface.
+      # The `codeql.yml` workflow still runs on every PR for
+      # visibility (findings surface in the Security tab), but a
+      # finding does not block merge. Re-introduce as a required
+      # gate if/when the project starts publishing runtime
+      # artefacts that warrant per-PR static analysis.
       required_status_checks:
         # `strict: false` — don't require the PR branch to be up
         # to date with `main` before merging. With `strict: true`,
@@ -144,13 +152,15 @@ github:
         # for multi-contributor repos.
         strict: false
         contexts:
-          # CodeQL — two matrix legs (Python + GitHub Actions YAML).
-          - "Analyze (python)"
-          - "Analyze (actions)"
-          # zizmor (GitHub Actions security lint; complements CodeQL).
+          # zizmor — GitHub Actions security lint.
           - "zizmor"
           # Pre-commit (prek) — static checks across the repo.
           - "prek"
+          # Lychee — link checker. Runs on every PR (no path
+          # filter), so it gates merge on link rot introduced in
+          # the PR. The daily schedule run still catches drift on
+          # files the PR did not touch.
+          - "lychee"
           # Per-project pytest matrix from tests.yml. Mirrors the
           # `matrix.project[].name` list there; keep these two
           # lists in sync when projects are added or renamed.


### PR DESCRIPTION
## Summary

Two `required_status_checks` changes to `protected_branches.main`:

| Context | Before | After | Why |
|---|---|---|---|
| `Analyze (python)` (CodeQL) | required | **not required** | See "CodeQL un-gated" below |
| `Analyze (actions)` (CodeQL) | required | **not required** | See "CodeQL un-gated" below |
| `lychee` | excluded | **required** | See "Lychee now required" below |
| All other contexts | required | required (unchanged) | — |

### CodeQL un-gated

The `codeql.yml` workflow keeps running on every PR — findings
still surface in the Security tab — but a finding no longer blocks
merge. The framework repo is docs- and skills-heavy with no
published runtime artefacts; the per-PR incremental value of CodeQL
gating is low relative to the noise it produces on changes that
don't touch real attack surface. Re-introduce as a required gate
if/when the project starts publishing runtime artefacts that
warrant per-PR static analysis.

### Lychee now required

The link-checker was previously excluded with a "link rot is a
daily-schedule maintenance concern" rationale. `lychee` actually
runs on every PR (no path filter, confirmed against
`.github/workflows/link-check.yml`), so requiring it gates merge on
link rot introduced *in the PR itself*. The daily schedule run is
now the **second** line of defence (catching drift on files the PR
did not touch) rather than the only one.

### Final required-contexts list (10)

`zizmor`, `prek`, `lychee`, plus the seven `pytest (<project>)`
matrix legs: `oauth-draft`, `generate-cve-json`, `skill-validator`,
`privacy-llm-checker`, `privacy-llm-redactor`, `vulnogram-oauth-api`,
`sandbox-lint`.

### Still intentionally excluded

The two path-filtered exclusions stay:
- `asf-allowlist-check` (paths: `.github/**`)
- `lint .claude/settings.json against baseline` from sandbox-lint
  (paths: `.claude/settings.json` + `tools/sandbox-lint/**`)

Classic branch-protection has no "require only if run" semantics,
so a path-filtered job that doesn't post a status on every PR
blocks merge. Requiring those would need the workflows to emit a
no-op success status when skipped — separate work, not in this PR.

### Carried over unchanged

`strict: false`, `required_linear_history: true`,
`required_conversation_resolution: true`,
`required_signatures: false`, and the absence of
`required_pull_request_reviews:` (per the TEMPORARY POSTURE block).

## Test plan

- [x] `prek run --files .asf.yaml` — yaml hooks pass.
- [x] Verified against PR #282's check rollup that `lychee` always
  runs (`gh pr view 282 --json statusCheckRollup`).
- [x] Verified against `.github/workflows/{asf-allowlist-check,sandbox-lint}.yml`
  that the path-filter exclusions are still technically necessary.
- [ ] Post-merge: confirm next PR that introduces a broken link is
  blocked by `lychee`.
- [ ] Post-merge: confirm next PR with a CodeQL alert is no longer
  blocked.