### PR TITLE
docs(pr-management-triage): drop stale mark-ready-with-ping refs

### DIFF
--- a/.claude/skills/pr-management-triage/comment-templates.md
+++ b/.claude/skills/pr-management-triage/comment-templates.md
@@ -20,9 +20,9 @@ Placeholders:
 - `<flagged_count>` — number of currently-flagged PRs by this
   author (for the `close` template)
 - `<reviewers>` — space-separated `@login` mentions. **Use in
-  reviewer-re-review variants and `mark-ready-with-ping` only**
-  — those templates address the reviewer as the next-action
-  recipient, so `@`-pinging them is appropriate.
+  reviewer-re-review variants only** — those templates address
+  the reviewer as the next-action recipient, so `@`-pinging
+  them is appropriate.
 - `<reviewer_logins>` — comma-separated backtick-quoted logins
   (e.g. `` `phanikumv` ``, `` `phanikumv`, `eladkal` ``) —
   **no `@`-pings**. Use in author-primary templates
@@ -57,9 +57,9 @@ When a comment's only addressee is the PR author (the
 and `review-nudge` author-primary templates), the body references
 the reviewer **without** `@`-mentioning them. The default
 `<reviewers>` placeholder renders as `@login` and is appropriate
-when the reviewer is one of the message's addressees (e.g. the
-reviewer-re-review variants and `mark-ready-with-ping`). In
-author-primary templates we use a different placeholder,
+when the reviewer is one of the message's addressees (the
+reviewer-re-review variants). In author-primary templates we
+use a different placeholder,
 `<reviewer_logins>`, that renders the same logins **as
 backtick-quoted code** (e.g. `` `phanikumv` ``,
 `` `phanikumv`, `eladkal` ``) — recognisable as a GitHub handle
@@ -75,7 +75,7 @@ than by the bot.
 
 | Placeholder | Renders as | Use in |
 |---|---|---|
-| `<reviewers>` | `@login [, @login ...]` | reviewer-re-review variants, `mark-ready-with-ping` |
+| `<reviewers>` | `@login [, @login ...]` | reviewer-re-review variants |
 | `<reviewer_logins>` | `` `login` [, `login` ...] `` (no `@`) | `request-author-confirmation`, `reviewer-ping` (author-primary), `review-nudge` (author-primary) |
 
 ---


### PR DESCRIPTION
## Summary

Drops three stale references to the deprecated
`mark-ready-with-ping` action in
`.claude/skills/pr-management-triage/comment-templates.md`.

The action itself was retired when the two-sweep
`request-author-confirmation` → `mark-ready` (label-only) flow
landed — `actions.md` and `classify-and-act.md` no longer
reference it, and `comment-templates.md` no longer defines a
body for it. Three text references survived the deprecation:

| Line | Context |
|---|---|
| 23 | `<reviewers>` placeholder bullet |
| 61 | Reviewer-mention policy prose |
| 78 | Placeholder-reference table's "Use in" column |

Each is a pointer to a template that no longer exists in this
file. Removing the references shortens each line without losing
information — the remaining context ("reviewer-re-review
variants") is the complete and accurate list of where
`<reviewers>` (the `@login`-mentioning placeholder) applies.

The intentional historical mention in `rationale.md` (section
"Why a two-sweep gate at all") stays — it explains the
deprecation rationale and is load-bearing context.

## Test plan

- [x] prek passes (markdownlint, skill-validator, doctoc, typos,
  check-placeholders)
- [x] No other framework file references `mark-ready-with-ping`
  except `rationale.md` (verified via `grep -rn`)

Generated-by: Claude (Opus 4.7)