### PR TITLE
feat(pr-management-triage): maintainer-sweep handback variant

### DIFF
--- a/.claude/skills/pr-management-triage/comment-templates.md
+++ b/.claude/skills/pr-management-triage/comment-templates.md
@@ -420,6 +420,58 @@ If the author is silent past the cooldown, the
 [stale author-confirm-request sweep](stale-sweeps.md#sweep-5--stale-author-confirm-request)
 takes over.
 
+### Variant: maintainer-sweep handback
+
+Use when
+[`<project-config>/pr-management-config.md`](../../../projects/_template/pr-management-config.md)
+sets `confirmation_handback_mode: maintainer-sweep` (see the
+"Workflow choices" section of that file).
+
+In this variant the "If yes" branch directs the author to
+reply with a short `yes / ready` rather than to ping the
+reviewer. The next triage sweep then classifies the PR via
+[`author_confirmation_received`](classify-and-act.md#author_confirmation_received)
+and offers the triaging maintainer the
+[`mark-ready`](actions.md#mark-ready--add-ready-for-maintainer-review-label)
+action — same downstream flow as the default mode, just
+initiated by a short author confirmation instead of an
+author-led reviewer ping.
+
+```markdown
+@<author> — There are <N> unresolved review thread(s) on this PR, and you have engaged with each one (post-review commits and/or in-thread replies). Could you confirm whether you believe the feedback is fully addressed and the PR is ready for maintainer review confirmation?
+
+If yes, reply here (a short `yes / ready` is fine) and a <PROJECT> maintainer will pick the PR up from the review queue on the next sweep.
+
+If you are still working on a thread, please reply with what is outstanding so the threads stay unresolved on purpose.
+
+<ai_attribution_footer>
+```
+
+Notes on the variant:
+
+- **No `<reviewer_logins>` in the first paragraph.** In this
+  variant the reviewers are not part of the next-action loop —
+  the maintainer sweep is — so mentioning them by name adds
+  noise without changing what the author needs to do.
+- **The marker string `ready for maintainer review
+  confirmation`** still appears verbatim. Both variants rely
+  on the same
+  [`viewer_confirmation_request_present`](classify-and-act.md#viewer_confirmation_request_present)
+  detector on subsequent sweeps.
+- **`<PROJECT>` placeholder** in the "If yes" sentence — read
+  from
+  [`<project-config>/pr-management-triage-comment-templates.md`](../../../projects/_template/pr-management-triage-comment-templates.md)
+  (same source as the AI-attribution footer's `<PROJECT>`).
+
+When to pick this variant: your project runs a regular
+maintainer triage cadence that scans for `yes / ready`
+replies, and you prefer the contributor's confirmation cost
+to be a short reply rather than thread bookkeeping plus a
+reviewer ping. The default `reviewer-ping` variant is the
+right choice when reviewers themselves apply the
+ready-for-maintainer-review label or no maintainer-sweep
+cadence exists.
+
 ---
 
 ## Stale draft close

--- a/projects/_template/pr-management-config.md
+++ b/projects/_template/pr-management-config.md
@@ -6,6 +6,7 @@
   - [Identifiers](#identifiers)
   - [Project-specific labels](#project-specific-labels)
   - [Grace windows](#grace-windows)
+  - [Workflow choices](#workflow-choices)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
 
@@ -67,3 +68,14 @@ chance to look at yet.
 | Stale-review-ping cooldown | 7 days | 7 days |
 | Stale-workflow-approval threshold | 28 days | 28 days |
 | Stale-Copilot-review threshold | 7 days | 7 days |
+
+## Workflow choices
+
+Some triage actions branch on a project-specific workflow
+preference rather than a quantitative threshold. Each key
+below picks one of the documented variants; leave at the
+default to use the standard variant.
+
+| Key | Default | Notes |
+|---|---|---|
+| `confirmation_handback_mode` | `reviewer-ping` | `request-author-confirmation` action's "If yes" branch. `reviewer-ping`: the author marks threads resolved and `@`-pings the reviewer for a final look + label. `maintainer-sweep`: the author replies with a short `yes / ready` and the next triage sweep promotes the PR to the maintainer review queue. Pick `maintainer-sweep` if your project runs a regular maintainer triage cadence and prefers a lightweight contributor confirmation over a reviewer-driven hand-back. See [`comment-templates.md#request-author-confirmation`](../../.claude/skills/pr-management-triage/comment-templates.md) for both bodies. |


### PR DESCRIPTION
## Summary

Adds an optional variant of the `request-author-confirmation`
template body for projects that prefer a maintainer-sweep
handback over the default reviewer-ping handback. Selected via
a new `confirmation_handback_mode` key in
`<project-config>/pr-management-config.md` (default
`reviewer-ping`, current behaviour unchanged).

## The two flows side-by-side

| | `reviewer-ping` (default) | `maintainer-sweep` (new) |
|---|---|---|
| What the author does | Marks threads resolved + `@`-pings the reviewer for a final look | Replies with a short `yes / ready` |
| Who advances the PR next | The reviewer applies the `ready for maintainer review` label | The next triage sweep promotes via `author_confirmation_received` → `mark-ready` |
| Best fit | Reviewers themselves apply the label, or no maintainer-sweep cadence exists | Project runs a regular maintainer triage cadence and prefers lightweight contributor confirmation |

The downstream flow (sweep detects the author's affirmative
reply via `author_confirmation_received` and offers the
maintainer the `mark-ready` action) is identical between the
variants.

## What changed

- **`.claude/skills/pr-management-triage/comment-templates.md`**
  — adds a `### Variant: maintainer-sweep handback` subsection
  under the existing `## Request author confirmation` section.
  Documents the alternative body + notes on why it differs
  (no `<reviewer_logins>` in para 1; `<PROJECT>` placeholder in
  the "If yes" sentence; same marker string).
- **`projects/_template/pr-management-config.md`** — adds a new
  `## Workflow choices` section with the
  `confirmation_handback_mode` key. Default `reviewer-ping` so
  existing adopters keep the current behaviour.

No changes to `actions.md`, `classify-and-act.md`, or
`stale-sweeps.md`. The action name (`request-author-confirmation`)
is the same; the agent picks which body to render based on the
config value.

## Motivation

The apache/airflow project's
`.apache-steward-overrides/pr-management-triage-comment-templates.md`
has been carrying a custom `request-author-confirmation` body
with the maintainer-sweep "if yes" branch, working as a
project-local hack since the two-sweep flow landed. Promoting
it to an optional framework variant lets airflow (and any
adopter with a similar triage cadence) configure rather than
override.

## Test plan

- [x] prek passes (markdownlint, skill-validator, doctoc,
  typos, check-placeholders)
- Post-merge follow-up (apache/airflow side): set
  `confirmation_handback_mode: maintainer-sweep` in its
  pr-management-config override and drop the airflow-specific
  body from
  `.apache-steward-overrides/pr-management-triage-comment-templates.md`

Generated-by: Claude (Opus 4.7)