### PR TITLE
setup-steward: generic _template/mentoring-config

### DIFF
--- a/projects/_template/mentoring-config.md
+++ b/projects/_template/mentoring-config.md
@@ -2,7 +2,7 @@
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
 **Table of Contents**  *generated with [DocToc](https://github.com/thlorenz/doctoc)*
 
-- [Apache Airflow — mentoring (Mentoring) configuration](#apache-airflow--mentoring-mentoring-configuration)
+- [TODO: `<Project Name>` — mentoring (Mentoring) configuration](#todo-project-name--mentoring-mentoring-configuration)
   - [Identifiers](#identifiers)
   - [Convention pointers](#convention-pointers)
   - [Out-of-scope topics](#out-of-scope-topics)
@@ -13,54 +13,64 @@
 <!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->
 
-# Apache Airflow — mentoring (Mentoring) configuration
+# TODO: `<Project Name>` — mentoring (Mentoring) configuration
 
 **This file is a placeholder ahead of the Mentoring skill landing.**
 The skill does not exist yet (Mentoring is proposed per
 [`docs/modes.md`](../../docs/modes.md#mentoring)).
 The keys below match the
 [Mentoring spec](../../docs/mentoring/spec.md#adopter-contract)
-and are the values the future skill will read. New adopters
-should copy this file into their own
+and are the values the future skill will read.
+
+Copy this file into your own
 `<project-config>/mentoring-config.md` and replace every
-Airflow-specific value with their project's equivalents.
+`<placeholder>` with your project's value.
 
 ## Identifiers
 
-| Key | Value |
-|---|---|
-| `mentoring_invocation_command` | `/pr-management-mentor` |
-| `maintainer_team_handle` | `@apache/airflow-committers` |
-| `max_agent_turns` | `2` |
+| Key | Value | Notes |
+|---|---|---|
+| `mentoring_invocation_command` | `/pr-management-mentor` | Slash command the mentoring sweep invokes. Leave as-is unless your project has renamed the skill. |
+| `maintainer_team_handle` | `@<github-org>/<maintainer-team-slug>` | GitHub team the skill `@`-mentions when handing off. Example: `@apache/airflow-committers`. |
+| `max_agent_turns` | `2` | Hard cap on automated reply turns before forced hand-off. Tune up only if your project has a verified-low false-positive rate on the trigger heuristics. |
 
 ## Convention pointers
 
 Triggers that the future skill will detect, mapped to the docs
 link the comment should reference instead of paraphrasing.
+Replace the example links with the equivalent docs in your
+project — keep the trigger names if they apply, drop the row
+if a particular trigger isn't relevant to your project.
 
 | Trigger | Link | One-line label |
 |---|---|---|
-| Missing version on bug report | https://airflow.apache.org/docs/apache-airflow/stable/start.html | "How to find your Airflow version" |
-| Missing repro | https://github.com/apache/airflow/blob/main/contributing-docs/03_contributors_quick_start.rst | "Contributors quick start" |
-| First-time contributor PR setup | https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst | "How to open a PR" |
+| Missing version on bug report | `<version-discovery-doc-url>` | Short link text describing how to find a release version |
+| Missing repro | `<contributor-quickstart-doc-url>` | Short link text for "how to file a reproducible report" |
+| First-time contributor PR setup | `<pr-opening-doc-url>` | Short link text for "how to open a PR" |
 
 ## Out-of-scope topics
 
-The skill always hands off to a human when the thread touches:
+The skill always hands off to a human when the thread touches
+topics where AI judgement is inappropriate. Adjust the list
+for your project; the defaults below are typical of an Apache
+project.
 
 - Security-sensitive design (CVE-adjacent, embargoed work)
 - Deprecation timing (which release will drop X)
 - License questions (compatibility, header policy)
-- Provider-specific architectural taste
+- Architectural taste on a project-specific subsystem (e.g.
+  for a project with a plugin / extension model, decisions
+  about how a specific plugin should be structured)
 
 ## AI-attribution footer
 
 ```markdown
 ---
 
-_Note: This comment was drafted by an AI-assisted mentoring tool and may contain mistakes. Once you have addressed the points above, an Apache Airflow maintainer — a real person — will take the next look. We use this [two-stage process](https://github.com/apache/airflow/blob/main/PROCESS.md) so that our maintainers' limited time is spent where it matters most: the conversation with you._
+_Note: This comment was drafted by an AI-assisted mentoring tool and may contain mistakes. Once you have addressed the points above, a <PROJECT> maintainer — a real person — will take the next look. We use this [two-stage process](<two_stage_process_doc_url>) so that our maintainers' limited time is spent where it matters most: the conversation with you._
 ```
 
-Replace the two-stage-process URL with the project's documented
-mentoring/triage policy. Replace `Apache Airflow` with the
-project name.
+Replace `<two_stage_process_doc_url>` with the project's
+documented mentoring / triage policy and `<PROJECT>` with the
+project's display name (read from
+[`<project-config>/project.md`](project.md)).


### PR DESCRIPTION
## Summary

Same cleanup pattern as #280 / #283 — the Step 6d audit
(added in #280) flags `projects/_template/mentoring-config.md`
as adopter-specific on every upgrade. This PR fixes it.

The template was seeded from one adopter's mentoring config:
title hardcoded to "Apache Airflow — mentoring", concrete
`@apache/airflow-committers` as `maintainer_team_handle`,
convention-pointer URLs pointing at one project's docs,
AI-attribution footer hardcoding "Apache Airflow maintainer"
and a project-specific PROCESS.md URL.

## What changed

- Title → `# TODO: \`<Project Name>\` — ...`.
- `maintainer_team_handle` → `@<github-org>/<maintainer-team-slug>`
  with `Example: @apache/airflow-committers`.
- Convention-pointer URLs → `<placeholder>` form.
- AI-attribution footer uses `<PROJECT>` and
  `<two_stage_process_doc_url>` placeholders.
- "Out-of-scope topics" list keeps the Apache-typical
  categories (security / deprecation / license) since those
  are generic; the airflow-specific "provider-specific
  architectural taste" becomes a neutral "project-specific
  subsystem" example.

## Test plan

- [x] prek passes (markdownlint, doctoc, typos, check-placeholders)
- [x] Step 6d audit on this file would now find nothing

Generated-by: Claude (Opus 4.7)