### PR TITLE
setup-steward: generic _template/pr-management-code-review-criteria

### DIFF
--- a/projects/_template/pr-management-code-review-criteria.md
+++ b/projects/_template/pr-management-code-review-criteria.md
@@ -2,7 +2,7 @@
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
 **Table of Contents**  *generated with [DocToc](https://github.com/thlorenz/doctoc)*
 
-- [Apache Airflow — pr-management-code-review criteria](#apache-airflow--pr-management-code-review-criteria)
+- [TODO: `<Project Name>` — pr-management-code-review criteria](#todo-project-name--pr-management-code-review-criteria)
   - [Repo-wide source files](#repo-wide-source-files)
   - [Per-area source files](#per-area-source-files)
   - [Security-model calibration](#security-model-calibration)
@@ -14,48 +14,54 @@
 <!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->
 
-# Apache Airflow — pr-management-code-review criteria
+# TODO: `<Project Name>` — pr-management-code-review criteria
 
-This file is the **navigation map** for the Apache Airflow
-project's review criteria — the source files the
+This file is the **navigation map** for your adopter project's
+review criteria — the source files the
 [`pr-management-code-review`](../../.claude/skills/pr-management-code-review/SKILL.md)
-skill reads when forming its findings.  New adopters should copy
-this file into their own
-`<project-config>/pr-management-code-review-criteria.md` and
-replace every Airflow-specific path with their project's
-equivalents.
+skill reads when forming its findings.
 
-The skill's review pass reads each source file at session start
-(and re-reads per-area files as PRs route into different trees)
-and quotes the **source rule verbatim** in any finding it raises.
-If the file is missing or unreadable, the skill warns and falls
-back to a smaller default rule set.
+Copy this file into your own
+`<project-config>/pr-management-code-review-criteria.md` and
+replace every `<placeholder>` with your project's value. Drop
+or add rows so the per-area entries match your project's
+tree structure.
+
+The skill's review pass reads each source file at session
+start (and re-reads per-area files as PRs route into
+different trees) and quotes the **source rule verbatim** in
+any finding it raises. If the file is missing or unreadable,
+the skill warns and falls back to a smaller default rule set.
 
 ## Repo-wide source files
 
-These apply to every PR regardless of which subtree it touches.
-At least one entry is required.
+These apply to every PR regardless of which subtree it
+touches. At least one entry is required.
 
 | File | What it covers | Notes |
 |---|---|---|
-| `.github/instructions/code-review.instructions.md` | The rule set every Apache Airflow PR is reviewed against (architecture / DB / quality / testing / API / UI / generated files / AI-generated-code signals / quality signals). | |
-| `AGENTS.md` | Repo-wide AI/agent instructions (architecture boundaries, security model, coding standards, testing standards, commits & PR conventions). | |
+| `.github/instructions/code-review.instructions.md` | The rule set every PR is reviewed against (architecture / DB / quality / testing / API / UI / generated files / AI-generated-code signals / quality signals). | Standard location for GitHub Copilot-style instructions; reuse this path if your project already uses it. |
+| `AGENTS.md` | Repo-wide AI / agent instructions (architecture boundaries, security model, coding standards, testing standards, commit & PR conventions). | Standard location for agentic instructions; reuse if your project already uses it. |
 
 ## Per-area source files
 
 Files that apply only when the PR touches a specific subtree.
-The skill auto-discovers any `AGENTS.md` under the touched paths
-via `git ls-files`, but rows listed here are **always** loaded
-even if the PR doesn't directly touch the area.
+The skill auto-discovers any `AGENTS.md` under the touched
+paths via `git ls-files`, but rows listed here are **always**
+loaded even if the PR doesn't directly touch the area.
+
+The rows below are illustrative — replace with the subtrees
+relevant to your project (a plugins / extensions / providers
+directory, a `dev/` scripts tree, an IDE bootstrap tree,
+language-specific subtrees like `<language>/AGENTS.md`,
+etc.). Drop rows that don't apply; add rows for each subtree
+where the project has its own conventions.
 
 | File | When it applies | Notes |
 |---|---|---|
-| `registry/AGENTS.md` | PR touches `registry/` | Registry-tree-specific rules. |
-| `dev/AGENTS.md` | PR touches `dev/` | `dev/` scripts conventions. |
-| `dev/ide_setup/AGENTS.md` | PR touches `dev/ide_setup/` | IDE bootstrap conventions. |
-| `providers/AGENTS.md` | PR touches `providers/<name>/` | Provider-tree boundary, compat-layer, and provider-yaml expectations. |
-| `providers/elasticsearch/AGENTS.md` | PR touches `providers/elasticsearch/` | Elasticsearch-specific rules. |
-| `providers/opensearch/AGENTS.md` | PR touches `providers/opensearch/` | OpenSearch-specific rules. |
+| `<subtree>/AGENTS.md` | PR touches `<subtree>/` | Subtree-specific rules. Replace `<subtree>` with a real path (e.g. `dev`, `docs`, `<plugins-dir>`, a per-language tree). |
+| `<plugins-dir>/AGENTS.md` | PR touches `<plugins-dir>/<plugin-name>/` | Plugin / extension tree boundary, compat-layer, and per-plugin conventions. Drop if your project has no plugin model. |
+| `<plugins-dir>/<specific-plugin>/AGENTS.md` | PR touches `<plugins-dir>/<specific-plugin>/` | Per-plugin rules. Add one row per plugin that has its own conventions doc. |
 
 ## Security-model calibration
 
@@ -66,17 +72,17 @@ deployment-hardening opportunities.
 
 | File | Used by |
 |---|---|
-| `airflow-core/docs/security/security_model.rst` | The `Security model — calibration` section of the skill's review-flow.md |
+| `<security-model-doc-path>` | The `Security model — calibration` section of the skill's `review-flow.md`. Replace with the doc your project uses (Example: `airflow-core/docs/security/security_model.rst`). |
 
 ## Backports / version-specific PRs
 
-Pattern the skill uses to detect that a PR is a backport vs. a
-main-branch change. Backports get a lighter-touch review focused
-on diff parity and cherry-pick conflicts.
+Pattern the skill uses to detect that a PR is a backport vs.
+a main-branch change. Backports get a lighter-touch review
+focused on diff parity and cherry-pick conflicts.
 
 | Concept | Pattern | Notes |
 |---|---|---|
-| Backport branch pattern | `v\d+-\d+-test` | Regex matched against the PR's base branch name (e.g. `v3-0-test`). |
+| Backport branch pattern | `<your-backport-branch-regex>` | Regex matched against the PR's base branch name. Example: `v\d+-\d+-test` matches branches like `v3-0-test`. Use the convention your project's release-train branches follow. |
 
 ## Section anchors
 
@@ -84,19 +90,25 @@ For projects whose review docs are structured around named
 sections, list the section anchor URLs the framework expects.
 These are used when the skill links out per-finding.
 
+Replace the `<docs-base-url>/<doc-path>` placeholders below
+with your project's actual review-instructions doc URL plus
+the anchor for each section. Drop rows for sections your
+project's review doc doesn't have; add rows for sections it
+adds.
+
 | Section | Anchor URL |
 |---|---|
-| Architecture boundaries | `https://github.com/apache/airflow/blob/main/.github/instructions/code-review.instructions.md#architecture-boundaries` |
-| Database / query correctness | `https://github.com/apache/airflow/blob/main/.github/instructions/code-review.instructions.md#database-and-query-correctness` |
-| Code quality | `https://github.com/apache/airflow/blob/main/.github/instructions/code-review.instructions.md#code-quality-rules` |
+| Architecture boundaries | `<docs-base-url>/<doc-path>#architecture-boundaries` |
+| Database / query correctness | `<docs-base-url>/<doc-path>#database-and-query-correctness` |
+| Code quality | `<docs-base-url>/<doc-path>#code-quality-rules` |
 | License headers | `https://www.apache.org/legal/src-headers.html` |
-| Testing | `https://github.com/apache/airflow/blob/main/.github/instructions/code-review.instructions.md#testing-requirements` |
-| API correctness | `https://github.com/apache/airflow/blob/main/.github/instructions/code-review.instructions.md#api-correctness` |
-| UI (React/TypeScript) | `https://github.com/apache/airflow/blob/main/.github/instructions/code-review.instructions.md#ui-code-reacttypescript` |
-| Generated files | `https://github.com/apache/airflow/blob/main/.github/instructions/code-review.instructions.md#generated-files` |
-| AI-generated code signals | `https://github.com/apache/airflow/blob/main/.github/instructions/code-review.instructions.md#ai-generated-code-signals` |
-| Quality signals to check | `https://github.com/apache/airflow/blob/main/.github/instructions/code-review.instructions.md#quality-signals-to-check` |
-| Commits and PRs (newsfragments, commit messages, tracking issues) | `https://github.com/apache/airflow/blob/main/AGENTS.md#commits-and-prs` |
-| Security model | `https://github.com/apache/airflow/blob/main/AGENTS.md#security-model` |
+| Testing | `<docs-base-url>/<doc-path>#testing-requirements` |
+| API correctness | `<docs-base-url>/<doc-path>#api-correctness` |
+| UI (React/TypeScript) | `<docs-base-url>/<doc-path>#ui-code-reacttypescript` |
+| Generated files | `<docs-base-url>/<doc-path>#generated-files` |
+| AI-generated code signals | `<docs-base-url>/<doc-path>#ai-generated-code-signals` |
+| Quality signals to check | `<docs-base-url>/<doc-path>#quality-signals-to-check` |
+| Commits and PRs (newsfragments, commit messages, tracking issues) | `<docs-base-url>/AGENTS.md#commits-and-prs` |
+| Security model | `<docs-base-url>/AGENTS.md#security-model` |
 | Third-party license compliance | `https://www.apache.org/legal/resolved.html` |
 | Applying the Apache licence | `https://www.apache.org/legal/apply-license.html` |


### PR DESCRIPTION
## Summary

Same cleanup pattern as #280 / #283 — flagged by Step 6d audit
on a fresh upgrade.

The template was seeded from one adopter's review-criteria
map: title hardcoded, per-area rows pointing at that project's
subtree structure (`registry/`, `dev/`, `providers/<name>/`,
`providers/elasticsearch/`, `providers/opensearch/`), backport-
branch pattern tied to that project's release-train naming
(`v\d+-\d+-test`), and 14 section-anchor URLs all pointing at
one project's review-instructions doc.

## What changed

- Title → `# TODO: \`<Project Name>\` — ...`.
- Repo-wide source files (`.github/instructions/code-review.instructions.md`,
  `AGENTS.md`) stay since those are standard locations; cell
  notes now say "reuse if your project already uses it".
- Per-area table becomes three illustrative `<subtree>` /
  `<plugins-dir>` / `<specific-plugin>` rows that adopters
  replace with their real tree structure.
- Security-model calibration doc path → `<security-model-doc-path>`
  placeholder with "Example: airflow-core/..." annotation.
- Backport-branch pattern → `<your-backport-branch-regex>`
  placeholder with the airflow regex as an example.
- Section anchors → `<docs-base-url>/<doc-path>#<anchor>`
  placeholders. The three universal Apache-license-policy
  URLs (legal/src-headers.html, legal/resolved.html,
  legal/apply-license.html) stay as-is — they're
  framework-host-org links, not adopter-specific.

## Test plan

- [x] prek passes
- [x] Step 6d audit on this file would now find nothing

Generated-by: Claude (Opus 4.7)