### PR TITLE
chore(agent-isolation): bump claude-code pin to 2.1.150

### DIFF
--- a/tools/agent-isolation/pinned-versions.toml
+++ b/tools/agent-isolation/pinned-versions.toml
@@ -52,7 +52,7 @@
 
 # When this file was last touched. The check script uses this as the
 # minimum age the entries below claim to satisfy.
-pinned_at = "2026-05-16"
+pinned_at = "2026-05-25"
 
 [tools.bubblewrap]
 version = "0.11.2"
@@ -91,8 +91,8 @@ install.dnf = "dnf install socat-1.8.1.1"
 install.from_source = "http://www.dest-unreach.org/socat/download/socat-1.8.1.1.tar.gz"
 
 [tools.claude-code]
-version = "2.1.141"
-released = "2026-05-13"
+version = "2.1.150"
+released = "2026-05-23"
 # Override the framework-wide 7-day default. Claude Code releases
 # cadence is high (multiple releases per week) and any regression
 # that affects the framework's permission-rule semantics, sandbox
@@ -118,5 +118,5 @@ upstream_releases = "https://api.github.com/repos/anthropics/claude-code/release
 # Claude Code is distributed via npm; use `--no-save` so the global
 # install doesn't drift the local lockfile of any project the user
 # installs from.
-install.npm = "npm install -g --no-save @anthropic-ai/claude-code@2.1.141"
-install.brew = "# brew tap anthropics/claude-code; brew install claude-code@2.1.141 (when available)"
+install.npm = "npm install -g --no-save @anthropic-ai/claude-code@2.1.150"
+install.brew = "# brew tap anthropics/claude-code; brew install claude-code@2.1.150 (when available)"


### PR DESCRIPTION
## Summary
- Bump `tools/agent-isolation/pinned-versions.toml` `[tools.claude-code]` from
  `2.1.141` (2026-05-13) → `2.1.150` (2026-05-23).
- Bump top-level `pinned_at` to `2026-05-25`.
- Update `install.npm` / `install.brew` strings to match.

## Rationale
Several user-visible features and one regression fix across the 12-day diff:

- **2.1.142** — Fast mode defaults to Opus 4.7 (was 4.6); `claude agents` flags for dispatched background sessions
- **2.1.144** — `/resume` for background sessions; elapsed time on subagent completion notifications
- **2.1.145** — `claude agents --json` for scripting (tmux-resurrect, status bars); OTEL `agent_id`/`parent_agent_id` spans; statusLine GitHub repo/PR info
- **2.1.146/147** — `/simplify` renamed → `/code-review` with effort level + `--comment` for inline GitHub posting; MCP `resources/list` fix
- **2.1.147** — pinned background sessions stay alive when idle
- **2.1.148** — fix for Bash tool returning exit 127 on every command (regression introduced in 2.1.147)
- **2.1.149** — `/usage` per-category breakdown (skills / subagents / plugins / MCP); `/diff` scrolling; GFM task-list checkbox rendering
- **2.1.150** — internal infrastructure only (no user-visible changes)

Released 2026-05-23, 2 days past the tool's 1-day cooldown.

## Test plan
- [ ] `tools/agent-isolation/check-tool-updates.sh` reports `claude-code  2.1.150 → 2.1.150  ✓ up to date`
- [ ] Adopter on 2.1.141 running `npm install -g --no-save @anthropic-ai/claude-code@2.1.150` succeeds
- [ ] Existing sandbox/permission semantics unchanged (no regression in denyRead, permissions.deny, hooks)

🤖 Generated with [Claude Code](https://claude.com/claude-code)