### PR TITLE
feat(github): add issue and PR templates aligned with CONTRIBUTING.md

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,66 @@
+# SPDX-License-Identifier: Apache-2.0
+# https://www.apache.org/licenses/LICENSE-2.0
+
+name: Bug report
+description: Something in the framework doesn't behave as its SKILL.md / tool.md / RFC says it should.
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to file a bug. Before submitting:
+
+        - Read the relevant `SKILL.md` or `tool.md` — that contract is authoritative. If the bug is a *contract* problem (the doc says one thing, the implementation does another), say which one is wrong.
+        - Check the open issues for a duplicate.
+        - If the bug is in a skill's behaviour, the eval fixture you'd add as a regression test is the highest-signal evidence you can include. See `tools/skill-evals/README.md` for the fixture format.
+
+  - type: textarea
+    id: what
+    attributes:
+      label: What's broken
+      description: One or two sentences. The bug, not the diagnosis.
+      placeholder: |
+        e.g. `security-issue-triage` step 4 emits a `_No response_` literal for the public-advisory-url field when the reporter included a draft GHSA URL inline.
+    validations:
+      required: true
+
+  - type: textarea
+    id: where
+    attributes:
+      label: Which layer
+      description: Where in the tree does the bug live? Include the file path if you have it.
+      placeholder: |
+        e.g. `.claude/skills/security-issue-triage/step-4-classify.md`
+        or  `tools/vulnogram/generate-cve-json/src/...`
+    validations:
+      required: true
+
+  - type: textarea
+    id: repro
+    attributes:
+      label: How to reproduce
+      description: |
+        Minimum steps. For a skill bug, the input that triggers the wrong output (an eval-fixture-shaped block is ideal). For a Python / Groovy bug, the command + the error.
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected vs actual
+      description: What you expected to happen; what actually happened. Quote the relevant SKILL.md / tool.md / RFC line if there's a contract violation.
+    validations:
+      required: true
+
+  - type: textarea
+    id: scope
+    attributes:
+      label: Surface area (optional)
+      description: Other skills / tools / files this might also affect. Helps whoever picks this up scope the change correctly.
+
+  - type: textarea
+    id: env
+    attributes:
+      label: Environment (optional)
+      description: |
+        Claude Code (or other harness) version, OS, sandbox state (`/setup-isolated-setup-verify` output), anything in `<project-config>/` that might matter. Skip if not relevant.

--- a/.github/ISSUE_TEMPLATE/change_proposal.yml
+++ b/.github/ISSUE_TEMPLATE/change_proposal.yml
@@ -1,0 +1,69 @@
+# SPDX-License-Identifier: Apache-2.0
+# https://www.apache.org/licenses/LICENSE-2.0
+
+name: Change proposal
+description: New skill, new tool bridge, behaviour change to an existing one, doc improvement, or RFC. Intent-first.
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        This template is **intent-first** by design. Tell us *what* you want and *why* — let the agent (or a maintainer) figure out *how*. See [CONTRIBUTING.md → Authoring with an agent](../blob/main/CONTRIBUTING.md#authoring-with-an-agent) for the loop.
+
+        Don't worry about writing a complete spec. The discussion in this issue plus the agentic loop on the eventual PR are where the design converges. A sharp two-sentence intent is more useful than a vague half-built design.
+
+  - type: textarea
+    id: what
+    attributes:
+      label: What should happen
+      description: One or two sentences. Behaviour-shaped, not implementation-shaped.
+      placeholder: |
+        e.g. `security-issue-triage` should flag reports that arrive with a draft GHSA URL in the body and route them to the pre-coordinated-by-CNA branch of the triage tree.
+    validations:
+      required: true
+
+  - type: textarea
+    id: why
+    attributes:
+      label: Why
+      description: The motivation, in concrete terms. A constraint, a workflow gap, a regression, a principle from RFC-AI-0004 — whatever the actual reason is.
+      placeholder: |
+        e.g. Pre-coordinated GHSA reports are treated as fresh inbound today, which wastes a triage cycle and confuses the reporter when our acknowledgement asks them to provide information their CNA has already published.
+    validations:
+      required: true
+
+  - type: dropdown
+    id: layer
+    attributes:
+      label: Which layer
+      description: Best guess — a maintainer or the agent can re-route during triage.
+      options:
+        - Skill (`.claude/skills/<name>/`)
+        - Tool / bridge (`tools/<system>/`)
+        - Python package (`tools/*/` with `pyproject.toml`)
+        - Groovy reference impl
+        - Cross-cutting (RFC, AGENTS.md, sandbox, privacy-LLM)
+        - Documentation (`docs/`, `README.md`, `CONTRIBUTING.md`)
+        - Project template (`projects/_template/`)
+        - Other / unsure
+    validations:
+      required: true
+
+  - type: textarea
+    id: edges
+    attributes:
+      label: Boundary conditions (optional)
+      description: |
+        Edge cases worth raising up front — what should happen if input X is empty, malformed, contradictory, or already pre-existing. The agent will probe these during implementation; flagging the obvious ones here saves a round-trip.
+
+  - type: textarea
+    id: out-of-scope
+    attributes:
+      label: Out of scope (optional)
+      description: Things you're *not* proposing, to keep the discussion focused. Especially useful for changes that touch a sensitive area (security, privacy-LLM, sandbox, write-access discipline).
+
+  - type: textarea
+    id: references
+    attributes:
+      label: References (optional)
+      description: Related issues, prior PRs, RFC sections, upstream API docs — anything that gives whoever picks this up a head start.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,11 @@
+# SPDX-License-Identifier: Apache-2.0
+# https://www.apache.org/licenses/LICENSE-2.0
+
+blank_issues_enabled: false
+contact_links:
+  - name: Discussion
+    url: https://github.com/apache/airflow-steward/discussions
+    about: Open-ended questions, ideas, "is this in scope?" — use Discussions, not an issue.
+  - name: Security vulnerability in a project that uses this framework
+    url: https://www.apache.org/security/
+    about: Report to that project's `security@` list per ASF policy. Do NOT file a public issue here.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,69 @@
+<!-- SPDX-License-Identifier: Apache-2.0
+     https://www.apache.org/licenses/LICENSE-2.0 -->
+
+## Summary
+
+<!--
+1-3 bullets: what changed and why. The "why" is what reviewers care
+about most — a one-line summary of the motivation beats a paragraph
+restating the diff.
+-->
+
+-
+
+## Type of change
+
+<!-- Tick all that apply. -->
+
+- [ ] Skill change (`.claude/skills/<name>/`) — eval fixtures updated below
+- [ ] Tool / bridge contract (`tools/<system>/*.md`)
+- [ ] Python package (`tools/*/` with `pyproject.toml`)
+- [ ] Groovy reference impl
+- [ ] Cross-cutting (RFC, AGENTS.md, sandbox, privacy-LLM)
+- [ ] Documentation (`docs/`, `README.md`, `CONTRIBUTING.md`)
+- [ ] Project template (`projects/_template/`)
+- [ ] CI / dev loop (`prek`, workflows, validators)
+- [ ] Other:
+
+## Test plan
+
+<!--
+How you verified the change. Be specific. The reviewer reads this to
+decide what to spot-check vs trust. Empty "ran the tests" doesn't help.
+-->
+
+- [ ] `prek run --all-files` passes
+- [ ] For Python packages touched: `uv run pytest` / `ruff check` / `mypy` passes
+- [ ] For Groovy bridges touched: command-line invocation tested end-to-end
+- [ ] For skill changes: eval suite passes for the affected skill
+      (`PYTHONPATH=tools/skill-evals/src python3 -m skill_evals.runner tools/skill-evals/evals/<skill>/`)
+- [ ] For skill *behaviour* changes: a new or updated eval fixture is included in this PR
+      (a regression test for the bug fixed / the behaviour added — see CONTRIBUTING.md)
+- [ ] Other:
+
+## RFC-AI-0004 compliance
+
+<!--
+Tick the principles the change touches. Skip rows that don't apply.
+RFC-AI-0004 is the framework's constitution — see
+docs/rfcs/RFC-AI-0004.md.
+-->
+
+- [ ] **HITL** — any new mutation is gated on explicit user confirmation
+- [ ] **Sandbox** — no new unrestricted host access; network reach declared in the adapter
+- [ ] **Vendor neutrality** — placeholders (`<PROJECT>`, `<tracker>`, `<upstream>`, `<security-list>`) used in all skill / tool prose (the `check-placeholders` prek hook is the mechanical gate)
+- [ ] **Conversational + correctable** — agentic-override path documented if behaviour is adopter-tunable
+- [ ] **Write-access discipline** — no autonomous outbound messages; drafts only, sent on confirmation
+- [ ] **Privacy LLM** — private content does not reach a non-approved LLM; redactor invoked where needed
+
+## Linked issues
+
+<!-- e.g. Closes #NNN, Refs #NNN. List every related issue. -->
+
+## Notes for reviewers (optional)
+
+<!--
+Anything specific you want the reviewer to look at. Areas of uncertainty.
+Trade-offs you considered and rejected. Decisions that the agent and you
+disagreed on during the authoring loop.
+-->

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -43,7 +43,10 @@ repos:
         # the first thing in the file, which is incompatible with doctoc
         # inserting a TOC block at the top. Also skip skill-evals fixture and
         # README files — short, single-purpose docs that don't warrant a TOC.
-        exclude: ^(\.claude/skills/.*|tools/vulnogram/generate-cve-json/SKILL\.md|tools/skill-evals/.*)$
+        # Skip the PR template — GitHub pre-populates a new PR description
+        # with the template verbatim, so a TOC block becomes per-PR noise the
+        # contributor has to delete by hand.
+        exclude: ^(\.claude/skills/.*|tools/vulnogram/generate-cve-json/SKILL\.md|tools/skill-evals/.*|\.github/PULL_REQUEST_TEMPLATE\.md)$
         args:
           - "--maxlevel"
           - "3"


### PR DESCRIPTION
## Summary

- Adds three issue templates (`bug_report.yml`, `change_proposal.yml`, `config.yml`) and one PR template (`PULL_REQUEST_TEMPLATE.md`) that operationalise the guidance landed in CONTRIBUTING.md (#323).
- The `change_proposal.yml` template is intent-first by design — required fields are *what* + *why* + which layer; *how* is explicitly out of scope at the issue stage and is left to the agentic loop on the eventual PR.
- The PR template carries the `## Summary` + `## Test plan` shape documented in CONTRIBUTING.md, plus a Type-of-change checklist scoped to the framework's layer map and an explicit RFC-AI-0004 compliance checklist (six principles → six checkboxes).
- `config.yml` disables blank issues, routes open-ended questions to Discussions, and routes adopter security vulnerabilities to the adopter project's `security@` list per ASF policy (not here).

## Type of change

- [x] Documentation (`docs/`, `README.md`, `CONTRIBUTING.md`) — issue / PR template scaffolding
- [x] CI / dev loop (`prek`, workflows, validators) — doctoc exclude tweak

## Test plan

- [x] `prek run --files .pre-commit-config.yaml .github/ISSUE_TEMPLATE/*.yml .github/PULL_REQUEST_TEMPLATE.md` passes
- [x] Verified the PR template is no longer touched by doctoc after adding it to the exclude list — `head` of the file starts at the SPDX header, no TOC injected
- [x] Issue templates are GitHub Issue Forms YAML — render shape can be verified once merged via the *New issue* flow

## Companion change in `.pre-commit-config.yaml`

GitHub pre-populates a new PR description with the template verbatim, so a doctoc-generated TOC becomes per-PR noise that the contributor has to delete by hand. Added `\.github/PULL_REQUEST_TEMPLATE\.md` to the doctoc exclude pattern.

## Linked issues

Follows from #323 (CONTRIBUTING.md rewrite — landed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)