### PR TITLE
default plan, update and consolidate to 1 pass

### DIFF
--- a/tools/spec-loop/README.md
+++ b/tools/spec-loop/README.md
@@ -27,9 +27,9 @@ this is the operator quickstart.
 ```bash
 ./tools/spec-loop/loop.sh              # build, unlimited iterations
 ./tools/spec-loop/loop.sh 10           # build, max 10 iterations
-./tools/spec-loop/loop.sh plan         # gap-analysis → rewrite the plan (no code changes)
-./tools/spec-loop/loop.sh update       # back-fill specs from functionality others contributed
-./tools/spec-loop/loop.sh consolidate  # shrink the plan when it grows too long
+./tools/spec-loop/loop.sh plan         # gap-analysis → rewrite the plan (no code changes; 1 pass, add N for more)
+./tools/spec-loop/loop.sh update       # back-fill specs from functionality others contributed (1 pass, add N for more)
+./tools/spec-loop/loop.sh consolidate  # shrink the plan when it grows too long (1 pass, add N for more)
 ```
 
 - **plan** — compares `specs/` against the code and rewrites

--- a/tools/spec-loop/loop.sh
+++ b/tools/spec-loop/loop.sh
@@ -10,9 +10,9 @@
 #   * THREE modes, ONE mechanism:
 #       ./loop.sh                 build, unlimited iterations
 #       ./loop.sh 20              build, max 20 iterations
-#       ./loop.sh plan [N]        gap-analysis only (updates the plan)
-#       ./loop.sh update [N]      back-fill specs from code others contributed
-#       ./loop.sh consolidate [N] shrink the plan
+#       ./loop.sh plan [N]        gap-analysis only, updates the plan (default 1 pass; N=0 unlimited)
+#       ./loop.sh update [N]      back-fill specs from code others contributed (default 1 pass; N=0 unlimited)
+#       ./loop.sh consolidate [N] shrink the plan (default 1 pass; N=0 unlimited)
 #   * BRANCH PER WORK ITEM: before each build iteration the loop returns
 #     to the integration base; the build prompt then carves out
 #     <slug> for the one work item it implements. One work item =
@@ -93,11 +93,11 @@ PLAN_CONSOLIDATE_THRESHOLD="${SPEC_LOOP_PLAN_MAX:-500}"
 
 # ---- parse arguments -------------------------------------------------
 if [ "${1:-}" = "plan" ]; then
-    MODE="plan";        PROMPT_FILE="$LOOP_DIR/PROMPT_plan.md";        MAX_ITERATIONS="${2:-0}"
+    MODE="plan";        PROMPT_FILE="$LOOP_DIR/PROMPT_plan.md";        MAX_ITERATIONS="${2:-1}"
 elif [ "${1:-}" = "update" ]; then
-    MODE="update";      PROMPT_FILE="$LOOP_DIR/PROMPT_update.md";      MAX_ITERATIONS="${2:-0}"
+    MODE="update";      PROMPT_FILE="$LOOP_DIR/PROMPT_update.md";      MAX_ITERATIONS="${2:-1}"
 elif [ "${1:-}" = "consolidate" ]; then
-    MODE="consolidate"; PROMPT_FILE="$LOOP_DIR/PROMPT_consolidate.md"; MAX_ITERATIONS="${2:-0}"
+    MODE="consolidate"; PROMPT_FILE="$LOOP_DIR/PROMPT_consolidate.md"; MAX_ITERATIONS="${2:-1}"
 elif [[ "${1:-}" =~ ^[0-9]+$ ]]; then
     MODE="build";       PROMPT_FILE="$LOOP_DIR/PROMPT_build.md";       MAX_ITERATIONS="$1"
 else


### PR DESCRIPTION
## Summary

default plan, update and consolidate to 1 pass so they don't loop forever

## Type of change

- [ ] Skill change (`.claude/skills/<name>/`) — eval fixtures updated below
- [ ] Tool / bridge contract (`tools/<system>/*.md`)
- [ ] Python package (`tools/*/` with `pyproject.toml`)
- [ ] Groovy reference impl
- [ ] Cross-cutting (RFC, AGENTS.md, sandbox, privacy-LLM)
- [ ] Documentation (`docs/`, `README.md`, `CONTRIBUTING.md`)
- [ ] Project template (`projects/_template/`)
- [ ] CI / dev loop (`prek`, workflows, validators)
- [X] Other: minor improvemnet to loop

## Test plan

- [X] `prek run --all-files` passes
- [ ] For Python packages touched: `uv run pytest` / `ruff check` / `mypy` passes
- [ ] For Groovy bridges touched: command-line invocation tested end-to-end
- [ ] For skill changes: eval suite passes for the affected skill
      (`PYTHONPATH=tools/skill-evals/src python3 -m skill_evals.runner tools/skill-evals/evals/<skill>/`)
- [ ] For skill *behaviour* changes: a new or updated eval fixture is included in this PR
      (a regression test for the bug fixed / the behaviour added — see CONTRIBUTING.md)
- [ ] Other:
