### PR TITLE
update specs and implementation plan

### DIFF
--- a/tools/spec-loop/IMPLEMENTATION_PLAN.md
+++ b/tools/spec-loop/IMPLEMENTATION_PLAN.md
@@ -25,6 +25,45 @@ one PR** (the branch-per-feature constraint).
   per work item; never pushes), `PROMPT_plan.md`, `PROMPT_build.md`,
   `PROMPT_consolidate.md`, `AGENTS.md` (loop-scoped operational context),
   and this plan.
+- **Pairing — pre-flight self-review skill** — `.claude/skills/pairing-self-review/`
+  shipped; `docs/modes.md` Pairing row updated to 1 skill / `experimental`.
+  Spec: [`specs/pairing-mode.md`](specs/pairing-mode.md).
+- **Mentoring — first prototype skill** — `pr-management-mentor` shipped,
+  `mode: Mentoring` + `experimental`, teaching-register replies with
+  explicit hand-off. Spec: [`specs/mentoring-mode.md`](specs/mentoring-mode.md).
+- **Docs — mode economics page** — `docs/mode-economics.md` exists
+  (per-mode token-cost shape, vendor-neutral).
+- **Meta — spec-status index** — `tools/spec-status-index/` exists as a
+  `uv` tool that prints specs grouped by status.
+  Spec: [`specs/meta-and-quality-tooling.md`](specs/meta-and-quality-tooling.md).
+- **Eval backfill** — 24 skill eval suites committed to `main`, covering
+  every non-setup skill. Setup-family suites are in-flight (see below).
+
+---
+
+## In-flight work
+
+These branches and/or open PRs already carry the change. Do **not** add
+a plan item for any of them; the build beat must not re-pick them.
+
+| Branch | PR | Description |
+|---|---|---|
+| `pairing-multi-agent-review` | #269 (draft) | Pairing multi-agent review pipeline |
+| `generic-drafting` | #296 (draft) | Generic (non-security) drafting from audit findings |
+| `eval-setup-isolated-setup-doctor` | — | Eval suite for setup-isolated-setup-doctor |
+| `eval-setup-isolated-setup-install` | — | Eval suite for setup-isolated-setup-install |
+| `eval-setup-isolated-setup-update` | — | Eval suite for setup-isolated-setup-update |
+| `eval-setup-override-upstream` | — | Eval suite for setup-override-upstream |
+| `eval-setup-shared-config-sync` | — | Eval suite for setup-shared-config-sync |
+| `eval-setup-steward` | — | Eval suite for setup-steward |
+| `spec-validator` | — | `tools/spec-validator/` — spec frontmatter + body-section validator |
+| `spec-loop-preflight-checks` | — | Freshness check + branch-name collision guard for the loop |
+| `injection-guard` | — | Prompt-injection defence hardening |
+| `check-headers` | — | License headers as a first-class review category |
+| `issue-fix-workflow` | — | issue-fix-workflow skill updates |
+| `contributor-readiness` | #227 (draft) | contributor-nomination skill + eval |
+| `contributor-activity` | #228 (draft) | contributor-activity-sweep skill + eval |
+| `contributor-onboarding` | #229 (draft) | committer-onboarding skill |
 
 ---
 
@@ -33,54 +72,30 @@ one PR** (the branch-per-feature constraint).
 Priority order. Each maps to one branch and one PR. Branch names are
 slugs, not numbers (numbering implies an order the specs don't carry).
 
-1. **Pairing — pre-flight self-review skill.** Highest priority: closes
-   the empty-Pairing-family gap MISSION makes a v1 goal. New
-   `.claude/skills/pairing-self-review/SKILL.md` (read-only, hands a
-   report back, never opens a PR); update `docs/modes.md` Pairing row
-   0 → 1, `proposed` → `experimental`. Validate with `skill-validate`.
-   Spec: [`specs/pairing-mode.md`](specs/pairing-mode.md). Branch
-   `pairing-self-review`.
+1. **Security reporting — add tool test suite.** `tools/security-tracker-stats-dashboard/`
+   has Python scripts (`render.py`, `fetch_*.py`) but no `tests/`
+   directory. The spec acceptance criterion #3 and its Known Gaps section
+   both require tests here. Add a `tests/` directory with pytest coverage
+   for the fetch/render pipeline. Validation:
+   ```bash
+   uv run --project tools/security-tracker-stats-dashboard --group dev pytest
+   bash -n tools/security-tracker-stats-dashboard/run.sh
+   shellcheck tools/security-tracker-stats-dashboard/run.sh
+   ```
+   Spec: [`specs/security-reporting.md`](specs/security-reporting.md).
+   Branch `security-reporting-tests`.
 
-2. **Mentoring — first prototype skill.** `pr-management-mentor` (working
-   name), `mode: Mentoring` + `experimental`, drafting replies in a
-   teaching register with an explicit hand-off to a human. The Mentoring
-   spec/tone-guide already exists under `docs/mentoring/`. Spec:
-   [`specs/mentoring-mode.md`](specs/mentoring-mode.md). Branch
-   `mentoring-prototype`.
-
-3. **Docs — mode economics page.** New `docs/mode-economics.md` (per-mode
-   token-cost shape, vendor-neutral, indicative-not-a-quote), linked from
-   `docs/modes.md`. From MISSION § Affordability. Branch
-   `mode-economics-doc`.
-
-4. **Meta — spec-status index.** A deterministic `uv` tool (mirrors
-   `list-steward-skills`) that prints specs by status and a `--ready`
-   filter, so later build iterations choose the next work item
-   mechanically. Spec: [`specs/meta-and-quality-tooling.md`](specs/meta-and-quality-tooling.md).
-   Branch `spec-status-index`.
-
-5. **Pairing — multi-agent review pipeline.** Fans a local diff through
-   independent review passes (correctness / security / conventions) and
-   merges the findings. Reuses the self-review report format, so it
-   follows work item 1. Branch `pairing-multi-agent-review`.
-
-6. **Drafting — generic (non-security) drafting.** Extend Drafting beyond
-   the security + general-issue cases to lint fixes, audit-tool findings,
-   and documentation holes (MISSION names these in scope). Larger; split
-   into per-source work items as it is picked up. Spec:
-   [`specs/drafting-mode.md`](specs/drafting-mode.md). Branch
-   `generic-drafting`.
-
-7. **Meta — back-fill missing skill eval suites.** Per `/AGENTS.md`
-   § Reusable skills, every skill ships an eval suite under
-   `tools/skill-evals/evals/<skill-name>/`. Several skills predate that
-   convention and have none. Add one suite per uncovered skill — one
-   branch per skill (or per family). Spec:
-   [`specs/meta-and-quality-tooling.md`](specs/meta-and-quality-tooling.md).
-   Branch `eval-<skill-name>`.
-
-   Also: when a build iteration creates a new skill, its eval suite is
-   part of that same work item — not a separate one.
+2. **Agent isolation — Python packaging and test harness.** `tools/agent-isolation/`
+   is shell-only (no `pyproject.toml`, no `tests/`), but the spec's
+   validation command requires `uv run --project tools/agent-isolation
+   --group dev pytest`. Convert the tool to a `uv` Python project, add a
+   `pyproject.toml`, and write tests that verify the sandbox profiles and
+   clean-env wrapper behave correctly. Validation:
+   ```bash
+   uv run --project tools/agent-isolation --group dev pytest
+   ```
+   Spec: [`specs/agent-isolation-sandbox.md`](specs/agent-isolation-sandbox.md).
+   Branch `agent-isolation-tests`.
 
 ---
 
@@ -93,3 +108,5 @@ slugs, not numbers (numbering implies an order the specs don't carry).
   section; the build prompt runs it as backpressure before committing.
 - Auto-merge is deliberately off and has no work items — building toward
   it would skip the proof MISSION requires.
+- When a build iteration creates a new skill, its eval suite is part of
+  that same work item — not a separate one.

--- a/tools/spec-loop/specs/README.md
+++ b/tools/spec-loop/specs/README.md
@@ -36,7 +36,8 @@ Start with [`overview.md`](overview.md), then:
   [`cve-tooling.md`](cve-tooling.md),
   [`adoption-and-setup.md`](adoption-and-setup.md),
   [`adapters.md`](adapters.md),
-  [`meta-and-quality-tooling.md`](meta-and-quality-tooling.md).
+  [`meta-and-quality-tooling.md`](meta-and-quality-tooling.md),
+  [`security-reporting.md`](security-reporting.md).
 
 (Auto-merge, the fifth MISSION mode, is deliberately off and has no
 spec — see the note in [`overview.md`](overview.md).)

--- a/tools/spec-loop/specs/adapters.md
+++ b/tools/spec-loop/specs/adapters.md
@@ -2,7 +2,7 @@
      https://www.apache.org/licenses/LICENSE-2.0 -->
 
 ---
-title: Adapters (Gmail / PonyMail / Jira / GitHub)
+title: Adapters (Gmail / PonyMail / Jira / GitHub / mail-source)
 status: experimental
 kind: feature
 mode: infra
@@ -10,7 +10,7 @@ source: >
   MISSION.md § Rationale ("ASF integrations live behind clean
   configuration boundaries; non-ASF adopters swap them") and § Technical
   scope (extensible adapter layer). Implemented in tools/gmail/,
-  tools/ponymail/, tools/jira/, tools/github/.
+  tools/ponymail/, tools/jira/, tools/github/, tools/mail-source/.
 acceptance:
   - Project-specific integrations live behind adapter modules, not
     hardcoded into skills.
@@ -36,6 +36,13 @@ by swapping the adapter, not the skill.
 - `tools/ponymail/` — public mailing-list archive search.
 - `tools/jira/` — issue-tracker adapter for projects on Jira.
 - `tools/github/` — issues/PRs/labels read + write-back helpers.
+- `tools/mail-source/` — abstract mail backend contract (operations,
+  capability matrix, adopter-declaration syntax) with concrete IMAP and
+  mbox implementations. Skills (`security-issue-import`,
+  `security-issue-sync`, `security-cve-allocate`) address every mail
+  source through this contract rather than calling Gmail or PonyMail
+  directly; the adopter's `<project-config>/project.md → Mail sources`
+  section declares which backends are active and what role each plays.
 
 ## Behaviour & contract
 

--- a/tools/spec-loop/specs/agent-isolation-sandbox.md
+++ b/tools/spec-loop/specs/agent-isolation-sandbox.md
@@ -35,7 +35,10 @@ saying "no".
 - `.claude/settings.json` — the `sandbox` block (filesystem
   allow/deny, network `allowedDomains`) and `permissions` (`deny` /
   `ask`).
-- Skills: `setup-isolated-setup-install`, `-update`, `-verify`.
+- Skills: `setup-isolated-setup-install`, `-update`, `-verify`,
+  `-doctor` (probes live sandbox restrictions — SSH-agent reachability,
+  localhost port binding, docker/podman socket — and maps each to a
+  numbered troubleshooting entry; read-only, never modifies settings).
 - `docs/setup/secure-agent-internals.md` — the three-layer model.
 
 ## Behaviour & contract

--- a/tools/spec-loop/specs/mentoring-mode.md
+++ b/tools/spec-loop/specs/mentoring-mode.md
@@ -3,13 +3,13 @@
 
 ---
 title: Mentoring mode
-status: proposed
+status: experimental
 kind: feature
 mode: Mentoring
 source: >
   MISSION.md § Technical scope (Mentoring) — "the highest-value
   project-side mode and the one off-the-shelf agent tooling skips".
-  docs/modes.md § Mentoring (proposed, 0 skills). Spec exists at
+  docs/modes.md § Mentoring (experimental, 1 skill). Spec exists at
   docs/mentoring/spec.md ahead of any skill code.
 acceptance:
   - The Mentoring spec (tone guide, hand-off protocol, adopter knobs) is
@@ -32,11 +32,11 @@ contributor-empowerment lever the wider ecosystem most needs.
 
 ## Where it lives
 
-- Spec ahead of code: `docs/mentoring/README.md`,
-  `docs/mentoring/spec.md`.
+- Spec: `docs/mentoring/README.md`, `docs/mentoring/spec.md`.
 - Adopter config scaffold: `projects/_template/mentoring-config.md`.
-- First skill (planned): `pr-management-mentor` (working name), ships
-  `mode: Mentoring` + `experimental`.
+- Skill: `pr-management-mentor` — drafts a teaching-register comment on
+  a single GitHub issue or PR thread; waits for explicit maintainer
+  confirmation before posting. Ships `mode: Mentoring` + `experimental`.
 
 ## Behaviour & contract
 
@@ -70,6 +70,6 @@ uv run --project tools/skill-validator --group dev skill-validate
 
 ## Known gaps
 
-- **No skill yet** — this is a pure `proposed` gap. The spec and tone
-  guide exist; the prototype skill is the first work item the loop would
-  pick up under this area.
+- **`experimental` — no adopter pilot has run.** The first skill
+  (`pr-management-mentor`) shipped; shape may change as adopter pilots
+  and contributor-sentiment evaluations land.

--- a/tools/spec-loop/specs/meta-and-quality-tooling.md
+++ b/tools/spec-loop/specs/meta-and-quality-tooling.md
@@ -39,6 +39,12 @@ trustworthy as it grows.
 - `tools/dashboard-generator/` — read-only HTML dashboards over campaign
   artefacts.
 - `tools/probe-templates/` — reusable probes.
+- `tools/spec-status-index/` — deterministic `uv` tool that reads
+  `tools/spec-loop/specs/` and prints specs grouped by status; used by
+  build iterations to mechanically select the next work item.
+- `tools/spec-validator/` — validates spec-loop spec frontmatter
+  (required keys, valid `status`/`kind`/`mode` values, body-section
+  presence); the spec-side counterpart to `skill-validator`.
 - Skills: `write-skill` (author/update a skill), `list-steward-skills`
   (live, generated index of every skill, grouped by family).
 

--- a/tools/spec-loop/specs/overview.md
+++ b/tools/spec-loop/specs/overview.md
@@ -30,10 +30,10 @@ Each mode is an independently toggleable set of skills. Maturity mirrors
 
 | Mode | Spec | Maturity |
 |---|---|---|
-| Triage | [triage-mode.md](triage-mode.md) | stable (security) / experimental (PR, issue) |
-| Mentoring | [mentoring-mode.md](mentoring-mode.md) | proposed (0 skills) |
+| Triage | [triage-mode.md](triage-mode.md) | stable (security) / experimental (PR, issue, contributor-nomination) |
+| Mentoring | [mentoring-mode.md](mentoring-mode.md) | experimental (1 skill) |
 | Drafting | [drafting-mode.md](drafting-mode.md) | stable (security) / experimental (issue) |
-| Pairing | [pairing-mode.md](pairing-mode.md) | proposed (0 skills) |
+| Pairing | [pairing-mode.md](pairing-mode.md) | experimental (1 skill) |
 
 > **Auto-merge** is the fifth MISSION mode but is deliberately **off** by
 > sequencing policy (`.asf.yaml` `allow_auto_merge: false`) — it has no
@@ -48,8 +48,9 @@ Each mode is an independently toggleable set of skills. Maturity mirrors
 | Privacy-LLM gate + PII redaction | [privacy-llm-gate.md](privacy-llm-gate.md) |
 | Agent isolation / layered sandbox | [agent-isolation-sandbox.md](agent-isolation-sandbox.md) |
 | CVE tooling | [cve-tooling.md](cve-tooling.md) |
+| Security reporting & dashboards | [security-reporting.md](security-reporting.md) |
 | Adoption & setup | [adoption-and-setup.md](adoption-and-setup.md) |
-| Adapters (Gmail / PonyMail / Jira / GitHub) | [adapters.md](adapters.md) |
+| Adapters (Gmail / PonyMail / Jira / GitHub / mail-source) | [adapters.md](adapters.md) |
 | Meta & quality tooling | [meta-and-quality-tooling.md](meta-and-quality-tooling.md) |
 
 ## The non-negotiables every area inherits

--- a/tools/spec-loop/specs/pairing-mode.md
+++ b/tools/spec-loop/specs/pairing-mode.md
@@ -3,13 +3,13 @@
 
 ---
 title: Pairing mode
-status: proposed
+status: experimental
 kind: feature
 mode: Pairing
 source: >
   MISSION.md § Technical scope (Pairing) and § Initial Goals ("Ship at
   least one Pairing skill family in v1"). docs/modes.md § Pairing
-  (proposed, 0 skills).
+  (experimental, 1 skill).
 acceptance:
   - At least one Pairing skill exists and validates (v1 goal).
   - Pairing skills run in the developer's OWN dev loop and make no state
@@ -32,9 +32,12 @@ protecting the ASF contribution path (contributor → committer → PMC).
 
 ## Where it lives
 
-- Currently nowhere — the family is empty (`docs/modes.md`: 0 skills).
-- Planned skills: a pre-flight **self-review** skill (highest priority)
-  and a **multi-agent review** pipeline — both tracked as work items in
+- Skill: `pairing-self-review` — structured pre-flight self-review of
+  local changes before opening a PR. Read-only; returns a structured
+  report with no external writes. Ships `mode: Pairing` + `experimental`.
+- Planned follow-on: a **multi-agent review** pipeline (fans the diff
+  through independent review passes, shares the self-review report
+  format) — tracked as a work item in
   [`../IMPLEMENTATION_PLAN.md`](../IMPLEMENTATION_PLAN.md).
 
 ## Behaviour & contract
@@ -66,7 +69,6 @@ uv run --project tools/skill-validator --group dev skill-validate
 
 ## Known gaps
 
-- **Empty family** — the largest functional gap against MISSION's v1
-  goals. Work items (in [`../IMPLEMENTATION_PLAN.md`](../IMPLEMENTATION_PLAN.md)):
-  a pre-flight self-review skill (first, highest priority), then a
-  multi-agent review pipeline.
+- **`experimental` — no adopter pilot has run.** `pairing-self-review`
+  shipped; the multi-agent review pipeline is the next planned skill.
+  No contributor-sentiment evaluation has run yet; shape may change.

--- a/tools/spec-loop/specs/security-reporting.md
+++ b/tools/spec-loop/specs/security-reporting.md
@@ -1,0 +1,77 @@
+<!-- SPDX-License-Identifier: Apache-2.0
+     https://www.apache.org/licenses/LICENSE-2.0 -->
+
+---
+title: Security reporting & dashboards
+status: experimental
+kind: feature
+mode: infra
+source: >
+  README.md § Skill families (security) and AGENTS.md § Reusable skills.
+  Implemented by tools/security-tracker-stats-dashboard/ and the
+  security-tracker-stats-dashboard skill.
+acceptance:
+  - A single command produces a self-contained HTML dashboard of tracker
+    statistics without modifying any tracker state.
+  - The dashboard is read-only; no tracker labels, milestones, or issue
+    bodies are written.
+  - The tool ships its own tests.
+---
+
+# Security reporting & dashboards
+
+## What it does
+
+Generates read-only aggregate views of the security tracker's issue
+backlog — lifecycle-band breakdowns, time-to-triage trends, per-scope
+pressure, and velocity charts — so the security team can review campaign
+health without navigating the tracker issue-by-issue.
+
+## Where it lives
+
+- `tools/security-tracker-stats-dashboard/` — Python tool that fetches
+  issue and event data from `<tracker>` (via `gh`) and renders a
+  self-contained HTML file. Supports incremental resume (re-runs extend
+  the existing data rather than re-fetching everything), configurable
+  lifecycle categories, milestone annotations, and a null-`upstream_repo`
+  path for trackers whose fixes land across multiple repos.
+- Skill: `security-tracker-stats-dashboard` — invokes the tool, surfaces
+  the output path, and handles staleness detection (~24 h default). Reads
+  only; never posts to the tracker.
+
+## Behaviour & contract
+
+- **Read-only.** Neither the tool nor the skill writes to any tracker
+  issue, label, milestone, or project board field.
+- **Self-contained output.** The rendered HTML embeds all data; no
+  external service is needed to view it.
+- **Incremental by default.** Resume behaviour extends an existing dataset
+  without re-fetching all history; a full rebuild is an opt-in flag.
+- **Config-driven.** Lifecycle category bands, time-to-triage signal,
+  milestone vertical annotations, and the null-`upstream_repo` path are
+  declared in the tool's `default-config.yaml` and overridden per-adopter.
+
+## Out of scope
+
+- Writing back any artefact to the tracker (that is the lifecycle skills).
+- Publishing the dashboard publicly — output is a local file; distribution
+  is the security team's choice.
+
+## Acceptance criteria
+
+1. `render.py` / `run.sh` produces a valid HTML file from `<tracker>` data.
+2. No tracker state is mutated (read-only `gh` calls only).
+3. The tool ships its own tests under `tools/security-tracker-stats-dashboard/`.
+
+## Validation
+
+```bash
+bash -n tools/security-tracker-stats-dashboard/run.sh
+shellcheck tools/security-tracker-stats-dashboard/run.sh
+```
+
+## Known gaps
+
+- `experimental` — no adopter pilot has run the dashboard end-to-end.
+  The tool's test coverage and CI integration are tracked as follow-on
+  work items.

--- a/tools/spec-loop/specs/triage-mode.md
+++ b/tools/spec-loop/specs/triage-mode.md
@@ -31,13 +31,19 @@ suggestion the human signs off on.
 
 - PR queue: `pr-management-triage`, `pr-management-stats`,
   `pr-management-code-review` (deep review is a triage variant).
+  Reference implementation: `tools/pr-management-stats/`.
 - General issues: `issue-triage`, `issue-reassess`, `issue-reproducer`.
+  Companion reporting skill: `issue-reassess-stats` (read-only dashboard
+  over `verdict.json` files produced by `issue-reassess` campaigns).
+- Contributor readiness: `contributor-nomination` (read-only brief for a
+  named contributor — activity breadth, consistency, and nomination-
+  evidence prose for a committer or PMC thread).
 - Security inbound: `security-issue-import`, `-import-from-pr`,
   `-import-from-md`, `security-issue-deduplicate`,
   `security-issue-invalidate`, `security-issue-sync`,
   `security-cve-allocate`.
 - Adapters it reads through: `tools/github`, `tools/jira`,
-  `tools/ponymail`, `tools/gmail`.
+  `tools/ponymail`, `tools/gmail`, `tools/mail-source`.
 
 ## Behaviour & contract
 


### PR DESCRIPTION
## Summary

update specs and implementation plan based on what's been done so far.
-

## Type of change

<!-- Tick all that apply. -->

- [ ] Skill change (`.claude/skills/<name>/`) — eval fixtures updated below
- [ ] Tool / bridge contract (`tools/<system>/*.md`)
- [ ] Python package (`tools/*/` with `pyproject.toml`)
- [ ] Groovy reference impl
- [ ] Cross-cutting (RFC, AGENTS.md, sandbox, privacy-LLM)
- [X] Documentation (`docs/`, `README.md`, `CONTRIBUTING.md`)
- [ ] Project template (`projects/_template/`)
- [ ] CI / dev loop (`prek`, workflows, validators)
- [ ] Other:

## Test plan

- [X] `prek run --all-files` passes
- [ ] For Python packages touched: `uv run pytest` / `ruff check` / `mypy` passes
- [ ] For Groovy bridges touched: command-line invocation tested end-to-end
- [ ] For skill changes: eval suite passes for the affected skill
      (`PYTHONPATH=tools/skill-evals/src python3 -m skill_evals.runner tools/skill-evals/evals/<skill>/`)
- [ ] For skill *behaviour* changes: a new or updated eval fixture is included in this PR
      (a regression test for the bug fixed / the behaviour added — see CONTRIBUTING.md)
- [ ] Other:
