### PR TITLE
chore(ci): require pytest via tests-ok umbrella job

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -161,16 +161,16 @@ github:
           # the PR. The daily schedule run still catches drift on
           # files the PR did not touch.
           - "lychee"
-          # Per-project pytest matrix from tests.yml. Mirrors the
-          # `matrix.project[].name` list there; keep these two
-          # lists in sync when projects are added or renamed.
-          - "pytest (oauth-draft)"
-          - "pytest (generate-cve-json)"
-          - "pytest (skill-validator)"
-          - "pytest (privacy-llm-checker)"
-          - "pytest (privacy-llm-redactor)"
-          - "pytest (vulnogram-oauth-api)"
-          - "pytest (sandbox-lint)"
+          # Per-project pytest matrix from tests.yml. Required via
+          # the single `tests-ok` umbrella job rather than the
+          # individual `pytest (<project>)` matrix entries — branch
+          # protection and rulesets both require exact-match status
+          # check names, so listing matrix entries here would force
+          # an `.asf.yaml` change on every matrix add / rename /
+          # removal. `tests-ok` `needs:` every matrix entry and
+          # fails unless all succeed, so the gate semantics are the
+          # same.
+          - "tests-ok"
       # `required_pull_request_reviews:` deliberately omitted — see
       # the TEMPORARY POSTURE note above. Re-add at PMC formation.
       #

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -83,3 +83,31 @@ jobs:
         # needs because each project's `pyproject.toml` declares
         # `testpaths = ["tests"]` relative to its own root.
         run: uv run --directory ${{ matrix.project.path }} --group dev pytest --color=yes
+
+  # Umbrella status check. `.asf.yaml`'s `required_status_checks`
+  # cannot use patterns or wildcards (GitHub's branch-protection and
+  # rulesets APIs both require exact context names), so a matrix job
+  # with N entries would otherwise force N `.asf.yaml` lines that
+  # must be kept in lock-step with the matrix. This single
+  # `tests-ok` job is the only pytest-related context required by
+  # branch protection — it passes iff every entry in the `pytest`
+  # matrix above passed. Adding, renaming, or removing matrix
+  # entries no longer touches `.asf.yaml`.
+  tests-ok:
+    name: tests-ok
+    runs-on: ubuntu-latest
+    needs: pytest
+    # `always()` — without it, this job would be skipped (not
+    # failed) when an upstream matrix entry fails, and a skipped
+    # required-check is treated as missing by branch protection,
+    # which leaves the PR mergeable. Run unconditionally and assert
+    # on the result instead.
+    if: always()
+    steps:
+      - name: Assert all pytest matrix entries succeeded
+        run: |
+          if [ "${{ needs.pytest.result }}" != "success" ]; then
+            echo "pytest matrix result: ${{ needs.pytest.result }}"
+            exit 1
+          fi
+          echo "all pytest matrix entries passed"


### PR DESCRIPTION
## Summary

- Branch protection on `main` cannot use patterns for required status check names — GitHub's classic branch-protection and rulesets APIs both require exact-match `context` strings, so each entry in the `pytest` matrix in `tests.yml` previously needed its own line in `.asf.yaml`.
- That coupling caused two known issues:
  - #340 renames `pytest (skill-validator)` → `pytest (skill-and-tool-validator)` and cannot merge, because branch protection on `main` still requires the old context name (which no longer runs in CI after the rename).
  - The `pytest (agent-isolation)` matrix entry added in #339 was never added to `.asf.yaml` and is silently not gated.
- Add a `tests-ok` umbrella job in `tests.yml` that `needs:` the `pytest` matrix and fails unless every matrix entry succeeded.
- Replace all `pytest (...)` entries in `.asf.yaml` with the single `tests-ok` context. Adding, renaming, or removing matrix entries no longer touches `.asf.yaml`.

## Follow-up

- #340 needs to drop its `.asf.yaml` hunk (the `skill-validator` → `skill-and-tool-validator` rename) and rebase — the line is gone on `main` after this PR merges.

## Test plan

- [ ] CI on this PR passes all pre-existing required checks (the seven `pytest (<project>)` matrix entries still required by branch protection on `main` until this PR merges).
- [ ] The new `tests-ok` job appears in the checks list and passes.
- [ ] After merge: #340 (once rebased) shows `tests-ok` as the single pytest-related required check, and is mergeable when all matrix entries pass.
- [ ] After merge: subsequent matrix renames (e.g. another tool added) do not require an `.asf.yaml` change.