### PR TITLE
add note to claim issue first

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -874,6 +874,9 @@ Good entry points, in rough order of ramp-up cost:
    The current backlog has 24+ such issues, including 22 net-new
    tool / adapter bridges and per-CLI runtime ports tracked at
    [#301–#322](https://github.com/apache/airflow-steward/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22+sort%3Acreated-desc).
+   Before you start work, please leave a comment on the issue so a
+   maintainer can assign it to you. That keeps two people from working
+   on the same issue at the same time.
    Two clusters:
    - **Tool bridges** ([#301–#312](https://github.com/apache/airflow-steward/issues/301)) — JIRA write path, Bugzilla, IMAP / mbox concrete wiring, GitLab, Mailman 3 / Hyperkitty, Discourse, Zulip, Matrix, Forgejo, OSV.dev, Pagure.
    - **Agent-CLI runtime adapters** ([#313–#322](https://github.com/apache/airflow-steward/issues/313)) — Codex, Gemini, local-LLM, Cursor, Aider, gh-copilot, Goose, Amazon Q, Junie, OpenHands.


### PR DESCRIPTION

## Summary

Add a note to claim issue first, so that we don't get multiple people working on teh same issue.

## Type of change

<!-- Tick all that apply. -->

- [ ] Skill change (`.claude/skills/<name>/`) — eval fixtures updated below
- [ ] Tool / bridge contract (`tools/<system>/*.md`)
- [ ] Python package (`tools/*/` with `pyproject.toml`)
- [ ] Groovy reference impl
- [ ] Cross-cutting (RFC, AGENTS.md, sandbox, privacy-LLM)
- [ ] Documentation (`docs/`, `README.md`, `CONTRIBUTING.md`)
- [ ] Project template (`projects/_template/`)
- [ ] CI / dev loop (`prek`, workflows, validators)
- [X] Other: doc only change

## Test plan

- [X] `prek run --all-files` passes
- [ ] For Python packages touched: `uv run pytest` / `ruff check` / `mypy` passes
- [ ] For Groovy bridges touched: command-line invocation tested end-to-end
- [ ] For skill changes: eval suite passes for the affected skill
      (`PYTHONPATH=tools/skill-evals/src python3 -m skill_evals.runner tools/skill-evals/evals/<skill>/`)
- [ ] For skill *behaviour* changes: a new or updated eval fixture is included in this PR
      (a regression test for the bug fixed / the behaviour added — see CONTRIBUTING.md)
- [ ] Other:
