### PR TITLE
fix(skills): add --limit to gh list calls flagged by validator

### DIFF
--- a/.claude/skills/security-issue-fix/SKILL.md
+++ b/.claude/skills/security-issue-fix/SKILL.md
@@ -263,7 +263,7 @@ Run (in order, stop at the first that produces results):
    touch the same area:
 
    ```bash
-   gh pr list --repo <upstream> --state open --search "<keywords from issue title or affected file paths>" --json number,title,url,author,headRefName
+   gh pr list --repo <upstream> --state open --search "<keywords from issue title or affected file paths>" --limit 100 --json number,title,url,author,headRefName
    ```
 
    Use 2–3 distinctive keywords from the issue's description (e.g.

--- a/.claude/skills/security-issue-sync/SKILL.md
+++ b/.claude/skills/security-issue-sync/SKILL.md
@@ -185,8 +185,8 @@ concurrently, which is exactly what the sync needs.
    | `sync all open` | explicit open-only variant — `gh issue list --repo <tracker> --state open --limit 100 --json number,title,labels`. No closed trackers. Use when you want the classic open-only sweep and nothing else. |
    | `sync #212`, `sync 212`, `sync #212, #214, #218`, `sync #212-#218` | the issue number(s) verbatim — no resolution needed. Works on open and closed trackers alike (the closed-issue sub-steps run when the tracker is closed with `announced`). |
    | `sync CVE-2026-40913` or `sync CVE-2026-40913, CVE-2026-40690` | regex-validate each token against `^CVE-\d{4}-\d{4,7}$` first (anything that does not match is a hard error — *never* interpolate an unvalidated free-form string into the search arg, which is in double quotes and would expand `$(...)`); then look up each validated CVE ID with `gh search issues "CVE-YYYY-NNNNN" --repo <tracker> --json number,title,body --jq '.[] | select(.body \| contains("CVE-YYYY-NNNNN")) \| .number'` (match against the body's *CVE tool link* field) and expand. |
-   | `sync <free-text>` (e.g. `sync JWT`, `sync KubernetesExecutor`) | title-substring match — run `gh issue list --repo <tracker> --state open --search "<free-text> in:title" --json number,title` and surface the matches back to the user for confirmation before dispatching (title matches are the fuzziest selector — always confirm, never auto-dispatch). |
-   | `sync <label>` (e.g. `sync announced`, `sync pr merged`) | all open issues carrying that label — `gh issue list --repo <tracker> --state open --label "<label>" --json number,title`. |
+   | `sync <free-text>` (e.g. `sync JWT`, `sync KubernetesExecutor`) | title-substring match — run `gh issue list --repo <tracker> --state open --search "<free-text> in:title" --limit 100 --json number,title` and surface the matches back to the user for confirmation before dispatching (title matches are the fuzziest selector — always confirm, never auto-dispatch). |
+   | `sync <label>` (e.g. `sync announced`, `sync pr merged`) | all open issues carrying that label — `gh issue list --repo <tracker> --state open --label "<label>" --limit 100 --json number,title`. |
    | `sync announced` (as a label selector) | as above, open-only. To include the recently-closed `announced` bucket, use `sync all` (default) or `sync closed announced`. |
    | `sync closed announced` | the recently-closed `announced` bucket by itself — useful when you want to run the cve.org publication-check sweep without touching open issues (for example, as a post-release cron). |
    | `sync open` | alias for `sync all open`. |
@@ -2228,7 +2228,7 @@ before moving on to the next item. Use:
     # The just-closed tracker is no longer in the open list, so
     # `open` here counts SIBLINGS still open on the same milestone.
     open=$(gh issue list --repo <tracker> --milestone "$ms" \
-      --state open --json number --jq 'length')
+      --state open --limit 1000 --json number --jq 'length')
     if [ "$open" -eq 0 ]; then
       ms_url=$(gh api repos/<tracker>/milestones/$ms --jq '.html_url')
       ms_title=$(gh api repos/<tracker>/milestones/$ms --jq '.title')

--- a/.claude/skills/security-issue-triage/SKILL.md
+++ b/.claude/skills/security-issue-triage/SKILL.md
@@ -802,7 +802,7 @@ mechanically:
 
    ```bash
    gh pr list --repo <upstream> --search 'reviewed-by:<handle>' \
-     --json files,reviews,mergedAt -- <pointer>
+     --limit 100 --json files,reviews,mergedAt -- <pointer>
    ```
 
    Iterate the roster (cached in Step 0); the roster member with


### PR DESCRIPTION
  <!-- SPDX-License-Identifier: Apache-2.0
       https://www.apache.org/licenses/LICENSE-2.0 -->

## Summary

- Add explicit `--limit` to every `gh issue/pr list` call flagged by `skill-and-tool-validator`'s `gh-list-no-limit` rule across 3 skills (`security-issue-fix`, `security-issue-triage`, `security-issue-sync`). Silent 30-row cap on busy trackers can drop open issues/PRs from a sweep or skew a count — this removes that risk without changing any other behaviour.
- Cover the two `security-issue-sync` selector-table rows (`sync <free-text>`, `sync <label>`) called out in the issue's "where to look" list as well — same silent-30-cap exposure, even though today's validator only scans fenced `bash` blocks and doesn't flag table-form calls.
- `--limit 100` for list returns; `--limit 1000` for the milestone sibling **count** (`--jq 'length'`) so the count itself isn't capped —per the issue's explicit guidance ("comfortably above the real number of open trackers").

## Type of change
- [x] Skill change (`.claude/skills/<name>/`) — no eval fixture needed (rationale below)
- [ ] Tool / bridge contract (`tools/<system>/*.md`)
- [ ] Python package (`tools/*/` with `pyproject.toml`)
- [ ] Groovy reference impl
- [ ] Cross-cutting (RFC, AGENTS.md, sandbox, privacy-LLM)
- [ ] Documentation (`docs/`, `README.md`, `CONTRIBUTING.md`)
- [ ] Project template (`projects/_template/`)
- [ ] CI / dev loop (`prek`, workflows, validators)
- [ ] Other:

## Test plan

- [x] `prek run --all-files` passes locally — all hooks green (`skill-and-tool-validate`, `check-placeholders`, `markdownlint`, `typos`,  `end-of-file-fixer`, `trailing-whitespace`, `detect-private-key`, etc.).
- [x] `skill-and-tool-validator` reports **0** `gh-list-no-limit` warnings after the change (was 3). Exit 0.
```bash
uv run --project tools/skill-and-tool-validator --group dev skill-and-tool-validate
```

<img width="826" height="122" alt="Screenshot 2026-05-28 at 1 26 13 PM" src="https://github.com/user-attachments/assets/5fb33dc3-4766-4a16-842a-b7edab456097" />

Note: the issue body references the script as `skill-validate`, but the actual entry point declared in `tools/skill-and-tool-validator/pyproject.toml` (and documented in that tool's README) is `skill-and-tool-validate`. Same script, just the correct name. A typo-only follow-up could fix the issue body — out of scope here per the "one concern per PR" rule.

- [x] No Python / Groovy code touched, so language-level test suites don't apply.
- [x] No eval fixture added — change is a pure string-literal edit inside `gh` invocations. Skill behaviour, output shape, and decision logic are unchanged; the only observable difference is that `gh` returns up to N rows instead of being silently capped at 30, which is the bug being fixed (no regression-test surface exists for "gh didn't silently truncate", since the truncation happens inside `gh` itself).
- [x] Diff scope verified: `3 files changed, 5 insertions(+), 5 deletions(-)` — every change is a single-token `--limit <N>` insertion.

No flags removed, no JSON fields changed, no `--search` arguments touched, no surrounding prose altered.

## RFC-AI-0004 compliance

- [ ] **HITL** — no new mutation; this only widens the bound of read-only `gh` queries
- [ ] **Sandbox** — no new outbound hosts; `gh` is already in the allowlist
- [x] **Vendor neutrality** — `<tracker>`, `<upstream>` placeholders preserved verbatim; `check-placeholders` prek hook passes
- [ ] **Conversational + correctable** — no new behaviour to override
- [ ] **Write-access discipline** — no outbound messages added
- [ ] **Privacy LLM** — no LLM-bound data path touched

## Linked issues

Closes #349.

## Notes for reviewers (optional)

- **Why `--limit 1000` on the sibling count and not `--limit 100`** — `security-issue-sync` line ~2230 is `gh issue list --milestone "$ms" --state open --json number --jq 'length'`, a count. `--limit 100` would silently cap the count at 100, which is the same bug at a different cap. The issue body asks for a value "comfortably above the real number of open trackers" specifically for this call, so 1000 follows that guidance.
- **Why the two table-form rows are included** — today's `skill-and-tool-validator` only walks fenced ```` ```bash ```` blocks, so it doesn't flag the markdown-table form `| ... \`gh issue list ...\` ... |` in `security-issue-sync` lines 188/189. The issue's "where to look" list explicitly enumerates them and the same silent-30-cap applies, so fixing them now matches the maintainer's stated scope. Expanding the validator to walk inline code in tables felt like a separate concern and would belong in its own PR.
- **No eval-fixture update** — listed in CONTRIBUTING.md as required for *behaviour* changes. This change has no observable behaviour change at the skill-output level: the skill still constructs the same `gh` invocation shape and consumes the same JSON keys; only `gh`'s upstream row-cap moves from an implicit 30 to an explicit 100 (or 1000 for the count). If a reviewer disagrees and wants a fixture, happy to add one — flag a path under `tools/skill-evals/evals/<skill>/` and I'll wire it in.