### PR TITLE
chore(settings): allowlist read-only Gmail / Ponymail MCP + zizmor

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -45,7 +45,15 @@
   },
   "permissions": {
     "allow": [
-      "Bash(gh api graphql *)"
+      "Bash(gh api graphql *)",
+      "mcp__claude_ai_Gmail__get_thread",
+      "mcp__claude_ai_Gmail__search_threads",
+      "mcp__ponymail__search_list",
+      "mcp__ponymail__auth_status",
+      "mcp__ponymail__get_thread",
+      "mcp__ponymail__get_email",
+      "mcp__ponymail__list_restrictions",
+      "Bash(zizmor *)"
     ],
     "deny": [
       "Read(~/.aws/**)",

--- a/tools/sandbox-lint/expected.json
+++ b/tools/sandbox-lint/expected.json
@@ -45,7 +45,15 @@
   },
   "permissions": {
     "allow": [
-      "Bash(gh api graphql *)"
+      "Bash(gh api graphql *)",
+      "mcp__claude_ai_Gmail__get_thread",
+      "mcp__claude_ai_Gmail__search_threads",
+      "mcp__ponymail__search_list",
+      "mcp__ponymail__auth_status",
+      "mcp__ponymail__get_thread",
+      "mcp__ponymail__get_email",
+      "mcp__ponymail__list_restrictions",
+      "Bash(zizmor *)"
     ],
     "deny": [
       "Read(~/.aws/**)",


### PR DESCRIPTION
## Summary

Add eight read-only patterns to `.claude/settings.json` → `permissions.allow` (mirrored in `tools/sandbox-lint/expected.json` to keep the baseline in lockstep). Picked from a 50-transcript scan of actual Claude Code usage; each pattern fires ≥3× across recent sessions and is verifiably read-only.

| Pattern | Count | Notes |
|---|---|---|
| `mcp__claude_ai_Gmail__get_thread` | 107 | read Gmail thread by ID |
| `mcp__claude_ai_Gmail__search_threads` | 48 | search Gmail by query |
| `mcp__ponymail__search_list` | 47 | search ASF public mailing-list archive |
| `mcp__ponymail__auth_status` | 15 | ponymail auth probe |
| `mcp__ponymail__get_thread` | 8 | read ponymail thread |
| `mcp__ponymail__get_email` | 4 | read individual ponymail message |
| `mcp__ponymail__list_restrictions` | 3 | read access restriction list |
| `Bash(zizmor *)` | 4 | GitHub Actions security linter (read-only scan) |

## Why

Eliminates the most common permission prompts during security-mailbox sweeps (Gmail + Ponymail are the inbound surfaces for `security-issue-import` and friends) and CI lint passes (`zizmor` against `.github/workflows/`). All eight are read-only.

## Out of scope

The frequent `Bash(prek run *)` (56 calls in the scan) is intentionally NOT added — `prek` runs hooks that include formatters (`ruff format`, `doctoc`) which mutate files. Same reasoning for the `breeze run *` / shell-loop / filesystem-mutation patterns the scan surfaced.

## Test plan

- [ ] `pytest (sandbox-lint)` passes (verified locally; baseline and live settings agree).
- [ ] In a fresh session, a `mcp__claude_ai_Gmail__get_thread` call no longer prompts.