### PR TITLE
fix(vulnogram/oauth-api): treat first-time affected[] population as non-change in merge-mode guard

### DIFF
--- a/tools/vulnogram/oauth-api/src/vulnogram_api/merge_mode.py
+++ b/tools/vulnogram/oauth-api/src/vulnogram_api/merge_mode.py
@@ -155,6 +155,12 @@ def _diff_affected_products(
     new_sigs = {_product_signature(entry) for entry in new if isinstance(entry, dict)}
     if current_sigs == new_sigs:
         return []
+    # First-time population (e.g. a freshly-allocated RESERVED record with an
+    # empty ``affected[]``) is not a product *change* — there is no prior
+    # signature to be renamed away from. Treat it as a non-diff so the guard
+    # does not force --allow-product-change for the normal first push.
+    if not current_sigs:
+        return []
     diffs: list[str] = []
     for sig in sorted(current_sigs - new_sigs):
         package, product = sig

--- a/tools/vulnogram/oauth-api/tests/test_merge_mode.py
+++ b/tools/vulnogram/oauth-api/tests/test_merge_mode.py
@@ -270,6 +270,25 @@ class TestProductChangeGuard:
         )
         assert diffs == []
 
+    def test_diff_empty_when_current_is_first_time_populated(self):
+        # A freshly-allocated RESERVED record carries an empty ``affected[]``;
+        # the first push that populates it must not be treated as a product
+        # *change* (there is no prior signature to be renamed away from).
+        diffs = _diff_affected_products(
+            current=[],
+            new=[{"packageName": "apache-foo", "product": "Apache Foo"}],
+        )
+        assert diffs == []
+
+    def test_first_time_population_does_not_require_allow_product_change(self):
+        # End-to-end: pushing a populated ``affected[]`` onto a record that
+        # had none before must succeed without ``--allow-product-change``.
+        merged = apply_merge_mode_guards(
+            _current(affected=[]),
+            _new(affected=[{"packageName": "apache-foo", "product": "Apache Foo"}]),
+        )
+        assert merged["containers"]["cna"]["affected"][0]["packageName"] == "apache-foo"
+
 
 # ---------------------------------------------------------------------------
 # Composition + edge cases


### PR DESCRIPTION
## Summary

A freshly-allocated Vulnogram CVE record (RESERVED state, title-only) carries an empty `affected[]` array. The first `vulnogram-api-record-update` push that populates the array was previously misclassified as a product *change* by `_diff_affected_products` and refused unless the caller passed `--allow-product-change` — a flag intended for genuine `packageName` / `product` renames, not for the normal first push.

This caused real friction during the 2026-05 bulk regeneration: 7 of 17 trackers' first push refused with a `MergeModeRefused: product changed` error and had to be retried with `--allow-product-change`, even though no product was actually being changed.

The fix: surface the empty-`current` case as a non-diff so the guard does not trip on first-time population.

```python
if current_sigs == new_sigs:
    return []
if not current_sigs:  # first-time population is not a change
    return []
```

The genuine rename case is unaffected: a non-empty `current` with a different signature than `new` still raises `MergeModeRefused`, still requires `--allow-product-change`.

## Test plan

- [x] New unit test: `_diff_affected_products(current=[], new=[...])` returns `[]`.
- [x] New unit test: `apply_merge_mode_guards` end-to-end succeeds for empty→populated without `--allow-product-change`.
- [x] Existing 23 tests pass (rename refusal, `--allow-product-change` override, order-insensitive set comparison, etc.).
- [x] `uv run pytest tools/vulnogram/oauth-api/tests/test_merge_mode.py` — 25 passed.

##### Was generative AI tooling used to co-author this PR?

- [x] Yes — Claude Opus 4.7 (1M context)