### PR TITLE
docs(mission): sync founding-member roster with board resolution draft

### DIFF
--- a/MISSION.md
+++ b/MISSION.md
@@ -188,6 +188,9 @@ ASF members for the roster:
 - Rich Bowen (rbowen) — Incubator PMC, ComDev PMC, …
 - Mike Drob (mdrob) — Accumulo PMC, Curator PMC, HBase PMC, Lucene PMC, Solr PMC
 - Craig L Russell (clr) — Security Team, Incubator PMC, ComDev PMC, …
+- Coty Sutherland (csutherl) — Tomcat PMC
+- Rémy Maucherat (remm) — Tomcat PMC
+- Richard Zowalla (rzo1) — Logging Services PMC, Hop PMC
 
 The named PMC roster will accompany the resolution at the time of vote.
 


### PR DESCRIPTION
Synchronizes `MISSION.md`'s "ASF members for the roster" list with the
authoritative `docs/board-resolution-draft.md`, which lists 22 initial
PMC members.

Three members were present in the resolution draft but missing from
MISSION.md. This PR adds them:

- Coty Sutherland (csutherl) — Tomcat PMC
- Rémy Maucherat (remm) — Tomcat PMC
- Richard Zowalla (rzo1) — Logging Services PMC, Hop PMC

MISSION.md now lists all 22 members. No members removed; no ID conflicts.
.

Generated-by: Claude Code (Opus 4.8)