### PR TITLE
chore(dependabot): collapse 9 uv entries into 1 group

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -58,11 +58,23 @@ updates:
         patterns:
           - "*"
 
-  # Root framework project — currently just `prek` as a dev dep,
-  # tracked here so the version bound in pyproject.toml stays in
-  # step with upstream releases.
+  # All Python projects in this repo, consolidated into one update
+  # entry with `directories:` (plural). Dependabot writes per-directory
+  # inside a SINGLE weekly PR per group, so this collapses what was
+  # previously nine independent uv PRs into one. Each tool's lockfile
+  # still updates correctly — the resolver runs per-directory; only the
+  # PR boundary is unified.
   - package-ecosystem: "uv"
-    directory: "/"
+    directories:
+      - "/"
+      - "/tools/privacy-llm/checker"
+      - "/tools/privacy-llm/redactor"
+      - "/tools/sandbox-lint"
+      - "/tools/skill-evals"
+      - "/tools/skill-and-tool-validator"
+      - "/tools/gmail/oauth-draft"
+      - "/tools/cve-tool-vulnogram/generate-cve-json"
+      - "/tools/cve-tool-vulnogram/oauth-api"
     schedule:
       interval: "weekly"
     cooldown:
@@ -71,118 +83,6 @@ updates:
       semver-minor-days: 7
       semver-patch-days: 7
     groups:
-      framework-deps:
-        patterns:
-          - "*"
-
-  - package-ecosystem: "uv"
-    directory: "/tools/privacy-llm/checker"
-    schedule:
-      interval: "weekly"
-    cooldown:
-      default-days: 7
-      semver-major-days: 7
-      semver-minor-days: 7
-      semver-patch-days: 7
-    groups:
-      privacy-llm-checker-deps:
-        patterns:
-          - "*"
-
-  - package-ecosystem: "uv"
-    directory: "/tools/privacy-llm/redactor"
-    schedule:
-      interval: "weekly"
-    cooldown:
-      default-days: 7
-      semver-major-days: 7
-      semver-minor-days: 7
-      semver-patch-days: 7
-    groups:
-      privacy-llm-redactor-deps:
-        patterns:
-          - "*"
-
-  - package-ecosystem: "uv"
-    directory: "/tools/sandbox-lint"
-    schedule:
-      interval: "weekly"
-    cooldown:
-      default-days: 7
-      semver-major-days: 7
-      semver-minor-days: 7
-      semver-patch-days: 7
-    groups:
-      sandbox-lint-deps:
-        patterns:
-          - "*"
-
-  - package-ecosystem: "uv"
-    directory: "/tools/skill-evals"
-    schedule:
-      interval: "weekly"
-    cooldown:
-      default-days: 7
-      semver-major-days: 7
-      semver-minor-days: 7
-      semver-patch-days: 7
-    groups:
-      skill-evals-deps:
-        patterns:
-          - "*"
-
-  - package-ecosystem: "uv"
-    directory: "/tools/skill-and-tool-validator"
-    schedule:
-      interval: "weekly"
-    cooldown:
-      default-days: 7
-      semver-major-days: 7
-      semver-minor-days: 7
-      semver-patch-days: 7
-    groups:
-      skill-and-tool-validator-deps:
-        patterns:
-          - "*"
-
-  - package-ecosystem: "uv"
-    directory: "/tools/gmail/oauth-draft"
-    schedule:
-      interval: "weekly"
-    cooldown:
-      default-days: 7
-      semver-major-days: 7
-      semver-minor-days: 7
-      semver-patch-days: 7
-    groups:
-      oauth-draft-deps:
-        patterns:
-          - "*"
-
-  - package-ecosystem: "uv"
-    directory: "/tools/cve-tool-vulnogram/generate-cve-json"
-    schedule:
-      interval: "weekly"
-    cooldown:
-      default-days: 7
-      semver-major-days: 7
-      semver-minor-days: 7
-      semver-patch-days: 7
-    groups:
-      generate-cve-json-deps:
-        patterns:
-          - "*"
-
-  - package-ecosystem: "uv"
-    directory: "/tools/cve-tool-vulnogram/oauth-api"
-    schedule:
-      interval: "weekly"
-    cooldown:
-      default-days: 7
-      semver-major-days: 7
-      semver-minor-days: 7
-      semver-patch-days: 7
-    groups:
-      vulnogram-oauth-api-deps:
+      python-deps:
         patterns:
           - "*"


### PR DESCRIPTION
## Summary

Consolidate the nine separate `uv` `package-ecosystem` entries in
`.github/dependabot.yml` into a single entry using `directories:`
(plural) + one `python-deps` group.

Dependabot writes per-directory lockfile updates inside a single
weekly PR for the whole group, so the framework's weekly Dependabot
output collapses from **up to 11 PRs** (1 github-actions + 1
pre-commit + 9 uv) **down to up to 3**.

## Why

Reduces review-queue noise. The 9 uv tools (`/`, `privacy-llm/checker`,
`privacy-llm/redactor`, `sandbox-lint`, `skill-evals`,
`skill-and-tool-validator`, `gmail/oauth-draft`,
`cve-tool-vulnogram/generate-cve-json`, `cve-tool-vulnogram/oauth-api`)
mostly share their dep set, so per-tool PRs created mostly-redundant
review work.

## What doesn't change

- Each tool's lockfile still **resolves independently** — the
  dependency resolver runs per-directory inside the consolidated
  update job; only the PR boundary is unified.
- Per-tool CI blocks (`ruff` / `mypy` / `pytest` under each
  `tools/<name>/`) still fire on their own directory's changes, so
  per-tool regressions still surface independently.
- 7-day cooldown windows on every ecosystem.
- `github-actions` ecosystem (already a single entry).
- `pre-commit` ecosystem (already a single entry).
- `[tool.uv] exclude-newer = "7 days"` in root `pyproject.toml`.
- `exclude-newer-span = "P7D"` baked into every `uv.lock`.

## Trade-off

A single weekly Dependabot PR now touches multiple lockfiles instead
of one per tool. Reviewers see all uv bumps for the week in one place;
if a single tool's bumps need rejection, the cleanest path is to
amend or close-and-reopen rather than picking only some bumps from
the grouped PR.

## Diff stat

`.github/dependabot.yml`: **+17 / -117** (~7× reduction in file
size; mostly removing the 9 repeated cooldown/groups blocks).

## Test plan

- [x] YAML validates (`yaml.safe_load` succeeds; 3 update entries
  remain — 1 github-actions, 1 pre-commit, 1 uv).
- [x] The uv entry's `directories` list covers all 9 paths previously
  declared as separate entries.
- [ ] After merge, observe the next Dependabot run and confirm a
  single PR lands covering all uv directories (rather than 9 separate
  PRs).
- [ ] If a uv bump is rejected at PR-review time, confirm Dependabot
  re-includes the rejected version in the next week's grouped PR
  (Dependabot's default per-ecosystem ignore list behaviour) rather
  than silently dropping it.
