### PR TITLE
added --list-tags to print case tags with counts

### DIFF
--- a/tools/skill-evals/src/skill_evals/runner.py
+++ b/tools/skill-evals/src/skill_evals/runner.py
@@ -689,6 +689,15 @@ def find_cases(path: Path) -> list[tuple[Path, Path]]:
     return results
 
 
+def collect_tag_counts(cases: list[tuple[Path, Path]]) -> dict[str, int]:
+    """Return how many discovered cases carry each tag."""
+    counts: dict[str, int] = {}
+    for case_dir, _fixtures_dir in cases:
+        for tag in load_case_tags(case_dir):
+            counts[tag] = counts.get(tag, 0) + 1
+    return counts
+
+
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(
         description=(
@@ -776,6 +785,15 @@ def main(argv: list[str] | None = None) -> int:
             "times; a case is included if it has all requested tags."
         ),
     )
+    parser.add_argument(
+        "--list-tags",
+        action="store_true",
+        help=(
+            "Print every distinct tag declared in case-meta.json under path, "
+            "with the number of cases carrying each tag, and exit without "
+            "running prompts."
+        ),
+    )
     args = parser.parse_args(argv)
 
     grader_explicit = args.grader_cli != DEFAULT_GRADER_CLI
@@ -783,6 +801,15 @@ def main(argv: list[str] | None = None) -> int:
         parser.error("--grader-cli and --exact require --cli")
 
     cases = find_cases(args.path)
+    if args.list_tags:
+        tag_counts = collect_tag_counts(cases)
+        if not tag_counts:
+            print("no tags found")
+            return 0
+        for tag in sorted(tag_counts):
+            print(f"{tag} {tag_counts[tag]}")
+        return 0
+
     if args.tag:
         requested_tags = set(args.tag)
         cases = [

--- a/tools/skill-evals/tests/test_runner.py
+++ b/tools/skill-evals/tests/test_runner.py
@@ -31,6 +31,7 @@ from skill_evals.runner import (
     build_corpus_text,
     build_roster_text,
     collect_diffs,
+    collect_tag_counts,
     compare_outputs,
     compare_with_grader,
     extract_json_from_output,
@@ -943,6 +944,43 @@ def test_tag_filter_runs_only_matching_cases(tmp_path: Path, capsys: pytest.Capt
     assert rc == 0
     assert "1 passed" in stdout
     assert "case-2-untagged" not in stdout
+
+
+def test_list_tags_prints_counts(tmp_path: Path, capsys: pytest.CaptureFixture[str]):
+    """--list-tags prints distinct tags with per-tag case counts."""
+    fixtures_dir = tmp_path / "fixtures"
+    fixtures_dir.mkdir()
+    case1 = _make_case(fixtures_dir, "case-1")
+    case2 = _make_case(fixtures_dir, "case-2")
+    (case1 / "case-meta.json").write_text(json.dumps({"tags": ["llama"]}))
+    (case2 / "case-meta.json").write_text(json.dumps({"tags": ["qwen", "llama"]}))
+
+    rc, stdout, stderr = _run_main(capsys, [str(fixtures_dir), "--list-tags"])
+    assert rc == 0
+    assert stderr == ""
+    assert stdout.strip().splitlines() == ["llama 2", "qwen 1"]
+
+
+def test_list_tags_no_tags_found(tmp_path: Path, capsys: pytest.CaptureFixture[str]):
+    """--list-tags exits 0 with an informational line when no tags exist."""
+    fixtures_dir = tmp_path / "fixtures"
+    _make_case(fixtures_dir, "case-1")
+
+    rc, stdout, stderr = _run_main(capsys, [str(fixtures_dir), "--list-tags"])
+    assert rc == 0
+    assert stderr == ""
+    assert stdout.strip() == "no tags found"
+
+
+def test_collect_tag_counts(tmp_path: Path):
+    fixtures_dir = tmp_path / "fixtures"
+    case1 = _make_case(fixtures_dir, "case-1")
+    case2 = _make_case(fixtures_dir, "case-2")
+    (case1 / "case-meta.json").write_text(json.dumps({"tags": ["alpha"]}))
+    (case2 / "case-meta.json").write_text(json.dumps({"tags": ["alpha", "beta"]}))
+
+    counts = collect_tag_counts(find_cases(fixtures_dir))
+    assert counts == {"alpha": 2, "beta": 1}
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
<!-- SPDX-License-Identifier: Apache-2.0
     https://www.apache.org/licenses/LICENSE-2.0 -->

## Summary

- Add `--list-tags` to `skill_evals.runner` so users can discover valid `--tag` values without grepping every `case-meta.json`.
- The flag walks the same case tree as the existing runner, prints each distinct tag alphabetically with its case count (e.g. `llama 12`), and exits without running prompts or requiring `--cli`.
- Includes regression tests for tag listing, empty-tag handling, and the `collect_tag_counts` helper.

## Type of change

- [ ] Skill change (`.claude/skills/<name>/`) — eval fixtures updated below
- [ ] Tool / bridge contract (`tools/<system>/*.md`)
- [x] Python package (`tools/*/` with `pyproject.toml`)
- [ ] Groovy reference impl
- [ ] Cross-cutting (RFC, AGENTS.md, sandbox, privacy-LLM)
- [ ] Documentation (`docs/`, `README.md`, `CONTRIBUTING.md`)
- [ ] Project template (`projects/_template/`)
- [ ] CI / dev loop (`prek`, workflows, validators)
- [ ] Other:

## Test plan

- [ ] `prek run --all-files` passes
- [x] For Python packages touched: `uv run pytest` / `ruff check` / `mypy` passes
- [ ] For Groovy bridges touched: command-line invocation tested end-to-end
- [ ] For skill changes: eval suite passes for the affected skill
      (`PYTHONPATH=tools/skill-evals/src python3 -m skill_evals.runner tools/skill-evals/evals/<skill>/`)
- [x] For skill *behaviour* changes: a new or updated eval fixture is included in this PR
      (a regression test for the bug fixed / the behaviour added — see CONTRIBUTING.md)
- [x] Other:
  - `uv run --directory tools/skill-evals --group dev pytest tests/test_runner.py -k "list_tags or collect_tag_counts or tag_filter"` — 4 passed
  - Manual smoke test: `python3 -m skill_evals.runner --list-tags <fixtures-dir>` prints sorted tags with counts

## RFC-AI-0004 compliance

- [ ] **HITL** — any new mutation is gated on explicit user confirmation
- [ ] **Sandbox** — no new unrestricted host access; network reach declared in the adapter
- [ ] **Vendor neutrality** — placeholders (`<PROJECT>`, `<tracker>`, `<upstream>`, `<security-list>`) used in all skill / tool prose (the `check-placeholders` prek hook is the mechanical gate)
- [ ] **Conversational + correctable** — agentic-override path documented if behaviour is adopter-tunable
- [ ] **Write-access discipline** — no autonomous outbound messages; drafts only, sent on confirmation
- [ ] **Privacy LLM** — private content does not reach a non-approved LLM; redactor invoked where needed

## Linked issues

Closes #378

## Notes for reviewers (optional)

- `--list-tags` reuses `find_cases` and `load_case_tags`; existing `--tag` filtering is unchanged.
- When no tags exist under the path, the runner prints `no tags found` and exits 0.
- 
<img width="1582" height="216" alt="image" src="https://github.com/user-attachments/assets/9b1b764d-87eb-43af-a621-73d65d5671d4" />

