### PR TITLE
Add --list-categories flag to validator

### DIFF
--- a/tools/skill-and-tool-validator/src/skill_and_tool_validator/__init__.py
+++ b/tools/skill-and-tool-validator/src/skill_and_tool_validator/__init__.py
@@ -245,6 +245,21 @@ SOFT_CATEGORIES: frozenset[str] = frozenset(
         LOWERCASE_F_FIELD_CATEGORY,
     }
 )
+ALL_CATEGORIES: frozenset[str] = frozenset(
+    {
+        TOOL_README_CATEGORY,
+        TOOL_CAPABILITY_CATEGORY,
+        CAPABILITY_SYNC_CATEGORY,
+        PRINCIPLE_CATEGORY,
+        TRIGGER_PRESERVATION_CATEGORY,
+        INJECTION_GUARD_CATEGORY,
+        INJECTION_GUARD_TODO_CATEGORY,
+        GH_LIST_CATEGORY,
+        SECURITY_PATTERN_CATEGORY,
+        PRIVACY_CATEGORY,
+        LOWERCASE_F_FIELD_CATEGORY,
+    }
+)
 
 # ---------------------------------------------------------------------------
 # Injection-guard constants (Pattern 4)
@@ -1648,7 +1663,18 @@ def main(argv: list[str] | None = None) -> int:
         action="store_true",
         help="Promote SOFT categories (advisory) to hard failures.",
     )
+    parser.add_argument(
+        "--list-categories",
+        action="store_true",
+        help="Print every violation category name (SOFT ones marked) and exit.",
+    )
     args = parser.parse_args(argv)
+
+    if args.list_categories:
+        for category in sorted(ALL_CATEGORIES):
+            suffix = " (advisory)" if category in SOFT_CATEGORIES else ""
+            print(f"{category}{suffix}")
+        return 0
 
     skip = {c.strip() for c in args.skip_categories.split(",") if c.strip()}
     violations = run_validation()

--- a/tools/skill-and-tool-validator/src/skill_and_tool_validator/__init__.py
+++ b/tools/skill-and-tool-validator/src/skill_and_tool_validator/__init__.py
@@ -245,21 +245,15 @@ SOFT_CATEGORIES: frozenset[str] = frozenset(
         LOWERCASE_F_FIELD_CATEGORY,
     }
 )
-ALL_CATEGORIES: frozenset[str] = frozenset(
+HARD_CATEGORIES: frozenset[str] = frozenset(
     {
         TOOL_README_CATEGORY,
         TOOL_CAPABILITY_CATEGORY,
         CAPABILITY_SYNC_CATEGORY,
-        PRINCIPLE_CATEGORY,
-        TRIGGER_PRESERVATION_CATEGORY,
         INJECTION_GUARD_CATEGORY,
-        INJECTION_GUARD_TODO_CATEGORY,
-        GH_LIST_CATEGORY,
-        SECURITY_PATTERN_CATEGORY,
-        PRIVACY_CATEGORY,
-        LOWERCASE_F_FIELD_CATEGORY,
     }
 )
+ALL_CATEGORIES = HARD_CATEGORIES | SOFT_CATEGORIES
 
 # ---------------------------------------------------------------------------
 # Injection-guard constants (Pattern 4)

--- a/tools/skill-and-tool-validator/tests/test_validator.py
+++ b/tools/skill-and-tool-validator/tests/test_validator.py
@@ -28,6 +28,7 @@ from skill_and_tool_validator import (
     _MODE_TAXONOMY,
     _OFF_MODES,
     _PRIVACY_EXTERNAL_CONTENT_MODES,
+    ALL_CATEGORIES,
     ALLOWED_MODES,
     FORBIDDEN_PATTERNS,
     GH_LIST_CATEGORY,
@@ -1879,6 +1880,16 @@ def _make_valid_skill(root: Path, name: str) -> Path:
 
 
 class TestMain:
+    def test_list_categories(self, capsys: pytest.CaptureFixture[str]) -> None:
+        rc = main(["--list-categories"])
+        assert rc == 0
+        out = capsys.readouterr().out
+        expected = [
+            f"{c} (advisory)" if c in SOFT_CATEGORIES else c
+            for c in sorted(ALL_CATEGORIES)
+        ]
+        assert out.strip().splitlines() == expected
+
     def test_returns_0_when_no_violations(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
         root = _skill_root(tmp_path)
         _make_valid_skill(root, "my-skill")

--- a/tools/skill-and-tool-validator/tests/test_validator.py
+++ b/tools/skill-and-tool-validator/tests/test_validator.py
@@ -32,6 +32,7 @@ from skill_and_tool_validator import (
     ALLOWED_MODES,
     FORBIDDEN_PATTERNS,
     GH_LIST_CATEGORY,
+    HARD_CATEGORIES,
     INJECTION_GUARD_CALLOUT_SENTINEL,
     INJECTION_GUARD_CATEGORY,
     INJECTION_GUARD_TODO_CATEGORY,
@@ -1392,6 +1393,10 @@ class TestLowercaseFField:
 
 
 class TestSoftCategories:
+    def test_all_categories_is_union_of_hard_and_soft(self) -> None:
+        assert ALL_CATEGORIES == HARD_CATEGORIES | SOFT_CATEGORIES
+        assert HARD_CATEGORIES.isdisjoint(SOFT_CATEGORIES)
+
     def test_soft_categories_set(self) -> None:
         assert PRINCIPLE_CATEGORY in SOFT_CATEGORIES
         assert TRIGGER_PRESERVATION_CATEGORY in SOFT_CATEGORIES
@@ -1884,10 +1889,7 @@ class TestMain:
         rc = main(["--list-categories"])
         assert rc == 0
         out = capsys.readouterr().out
-        expected = [
-            f"{c} (advisory)" if c in SOFT_CATEGORIES else c
-            for c in sorted(ALL_CATEGORIES)
-        ]
+        expected = [f"{c} (advisory)" if c in SOFT_CATEGORIES else c for c in sorted(ALL_CATEGORIES)]
         assert out.strip().splitlines() == expected
 
     def test_returns_0_when_no_violations(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:


### PR DESCRIPTION
<!-- SPDX-License-Identifier: Apache-2.0
     https://www.apache.org/licenses/LICENSE-2.0 -->

## Summary

- Add `--list-categories` to `skill-and-tool-validator` so callers can discover valid `--skip-categories` names without grepping the source
- Print all 11 category constants sorted alphabetically; SOFT categories marked with `(advisory)`
- Add regression test asserting exact sorted output

## Type of change

- [ ] Skill change (`.claude/skills/<name>/`) — eval fixtures updated below
- [ ] Tool / bridge contract (`tools/<system>/*.md`)
- [x] Python package (`tools/*/` with `pyproject.toml`)
- [ ] Groovy reference impl
- [ ] Cross-cutting (RFC, AGENTS.md, sandbox, privacy-LLM)
- [ ] Documentation (`docs/`, `README.md`, `CONTRIBUTING.md`)
- [ ] Project template (`projects/_template/`)
- [ ] CI / dev loop (`prek`, workflows, validators)
- [ ] Other:

## Test plan

- [ ] `prek run --all-files` passes
- [x] For Python packages touched: `uv run pytest` / `ruff check` / `mypy` passes
- [ ] For Groovy bridges touched: command-line invocation tested end-to-end
- [ ] For skill changes: eval suite passes for the affected skill
- [ ] For skill *behaviour* changes: a new or updated eval fixture is included in this PR
- [x] Other: `uv run --directory tools/skill-and-tool-validator skill-and-tool-validate --list-categories` prints sorted categories with advisory markers

## RFC-AI-0004 compliance

- [ ] **HITL**
- [ ] **Sandbox**
- [ ] **Vendor neutrality**
- [ ] **Conversational + correctable**
- [ ] **Write-access discipline**
- [ ] **Privacy LLM**

## Linked issues

Closes #377

## Notes for reviewers (optional)
<img width="833" height="186" alt="Screenshot 2026-05-30 at 8 09 43 PM" src="https://github.com/user-attachments/assets/dcb2d956-3746-4476-92b4-871ede0455fe" />

Discovery flag exits 0 before `run_validation()`. Includes all 11 named category constants (tool/capability-sync categories plus the skill-validation set).