### PR TITLE
feat(tools/skill-evals): add --fail-fast flag to stop on first failure

### DIFF
--- a/tools/skill-evals/src/skill_evals/runner.py
+++ b/tools/skill-evals/src/skill_evals/runner.py
@@ -760,6 +760,14 @@ def main(argv: list[str] | None = None) -> int:
         help="In --cli mode, also print the prompts and the model's raw stdout per case.",
     )
     parser.add_argument(
+        "--fail-fast",
+        action="store_true",
+        help=(
+            "Stops on the first failure instead of running all cases."
+            " Only applies in --cli mode; "
+        ),
+    )
+    parser.add_argument(
         "--tag",
         action="append",
         default=[],
@@ -796,6 +804,9 @@ def main(argv: list[str] | None = None) -> int:
     passed = failed = manual = errored = 0
 
     for case_dir, fixtures_dir in cases:
+        if (args.cli is not None) and args.fail_fast and (failed or errored):
+            print("Fail-fast enabled; stopping on first failure or error.")
+            break
         if fixtures_dir not in _step_config_cache:
             _step_config_cache[fixtures_dir] = load_step_config(fixtures_dir)
         system_prompt, user_prompt_template = _step_config_cache[fixtures_dir]

--- a/tools/skill-evals/tests/test_runner.py
+++ b/tools/skill-evals/tests/test_runner.py
@@ -751,6 +751,51 @@ def test_cli_mode_fail_with_wrong_json(tmp_path: Path, capsys: pytest.CaptureFix
     assert "FAIL" in stdout
     assert "1 failed" in stdout
 
+def test_cli_mode_fail_with_wrong_jsons(tmp_path: Path, capsys: pytest.CaptureFixture[str]):
+    """A CLI that returns the wrong JSONS should FAIL with multiple failures and exit non-zero."""
+    fixtures_dir, _ = _make_cli_case(tmp_path, expected={"verdict": "ok"})
+    _make_case(fixtures_dir, "case-2", report="another report", expected={"verdict": "ok"})
+    rc, stdout, _ = _run_main(
+        capsys,
+        ["--cli", 'echo \'{"verdict": "wrong"}\'', str(fixtures_dir)],
+    )
+    assert rc == 1
+    assert "FAIL" in stdout
+    assert "2 failed" in stdout # asserts that behaviour doesn't changes and outputs exactly 2 failures instead of stopping at the first one, which is tested in the next test case
+
+def test_cli_model_with_fail_fast_and_wrong_json(tmp_path: Path, capsys: pytest.CaptureFixture[str]):
+    """With --fail-fast, the runner should stop at the first failure and not run further cases."""
+    fixtures_dir, _ = _make_cli_case(tmp_path, expected={"verdict": "ok"})
+    # Add a second case that would FAIL if it ran, but should be skipped due to fail-fast.
+    _make_case(fixtures_dir, "case-2", report="another report", expected={"verdict": "ok"})
+    rc, stdout, _ = _run_main(
+        capsys,
+        ["--cli", 'echo \'{"verdict": "wrong"}\'', "--fail-fast", str(fixtures_dir)],
+    )
+    assert rc == 1
+    assert "FAIL" in stdout
+    assert "1 failed" in stdout
+    assert "CASE: case-2" not in stdout  # second case should not run at all
+
+def test_cli_model_with_fail_fast_and_error_json(tmp_path: Path, capsys: pytest.CaptureFixture[str]):
+    """In timeout being negative raise internal error when run_cli is called and --fail-fast is used."""
+    fixtures_dir, _ = _make_cli_case(tmp_path, expected={"verdict": "wrong"})
+    _make_case(fixtures_dir, "case-2", report="another report", expected={"verdict": "ok"})
+    rc, stdout, _ = _run_main(
+        capsys,
+        [
+            "--cli",
+            'echo \'{"verdict": "wrong"}\'',
+            '--timeout',"-1",  # force an error (timeout) instead of a fail, to check that fail-fast also applies to errors
+            "--exact",
+            "--fail-fast",
+            str(fixtures_dir),
+        ],
+    )
+    assert rc == 1
+    assert "ERROR" in stdout
+    assert "1 errored" in stdout
+    assert "CASE: case-2" not in stdout  # second case should not run at all
 
 def test_cli_mode_manual_skips_structural(tmp_path: Path, capsys: pytest.CaptureFixture[str]):
     """Structural expected.json (has_* / mention_*) is reported MANUAL, not auto-compared."""


### PR DESCRIPTION
Why: Large skill-evals suites can take minutes to surface a single failure because the harness runs the full suite. The --fail-fast flag (already supported by pytest and prek) stops execution after the first FAIL or ERROR in --cli mode, matching user expectations and reducing feedback latency.


<!-- SPDX-License-Identifier: Apache-2.0
     https://www.apache.org/licenses/LICENSE-2.0 -->

## Summary

<!--
1-3 bullets: what changed and why. The "why" is what reviewers care
about most — a one-line summary of the motivation beats a paragraph
restating the diff.
-->
*What changed*: Added --fail-fast flag support to stop test execution after the first failure or error.

This is a quality-of-life improvement for developers running tests locally or in CI/CD pipelines, allowing faster iteration when debugging test failures.
-

## Type of change

<!-- Tick all that apply. -->

- [ ] Skill change (`.claude/skills/<name>/`) — eval fixtures updated below
- [ ] Tool / bridge contract (`tools/<system>/*.md`)
- [x] Python package (`tools/*/` with `pyproject.toml`)
- [ ] Groovy reference impl
- [ ] Cross-cutting (RFC, AGENTS.md, sandbox, privacy-LLM)
- [ ] Documentation (`docs/`, `README.md`, `CONTRIBUTING.md`)
- [ ] Project template (`projects/_template/`)
- [x] CI / dev loop (`prek`, workflows, validators)
- [ ] Other:

## Test plan

<!--
How you verified the change. Be specific. The reviewer reads this to
decide what to spot-check vs trust. Empty "ran the tests" doesn't help.
-->

- [ ] `prek run --all-files` passes
- [x] For Python packages touched: `uv run pytest` / `ruff check` / `mypy` passes
- [ ] For Groovy bridges touched: command-line invocation tested end-to-end
- [ ] For skill changes: eval suite passes for the affected skill
      (`PYTHONPATH=tools/skill-evals/src python3 -m skill_evals.runner tools/skill-evals/evals/<skill>/`)
- [ ] For skill *behaviour* changes: a new or updated eval fixture is included in this PR
      (a regression test for the bug fixed / the behaviour added — see CONTRIBUTING.md)
- [x] Other:- Manual testing: `--fail-fast` flag stops on first failure or error and also made sure next case wasn't called

## RFC-AI-0004 compliance

<!--
Tick the principles the change touches. Skip rows that don't apply.
RFC-AI-0004 is the framework's constitution — see
docs/rfcs/RFC-AI-0004.md.
-->

- [ ] **HITL** — any new mutation is gated on explicit user confirmation
- [ ] **Sandbox** — no new unrestricted host access; network reach declared in the adapter
- [ ] **Vendor neutrality** — placeholders (`<PROJECT>`, `<tracker>`, `<upstream>`, `<security-list>`) used in all skill / tool prose (the `check-placeholders` prek hook is the mechanical gate)
- [ ] **Conversational + correctable** — agentic-override path documented if behaviour is adopter-tunable
- [ ] **Write-access discipline** — no autonomous outbound messages; drafts only, sent on confirmation
- [ ] **Privacy LLM** — private content does not reach a non-approved LLM; redactor invoked where needed

## Linked issues

<!-- e.g. Closes #NNN, Refs #NNN. List every related issue. -->
Closes #376
## Notes for reviewers (optional)

<!--
Anything specific you want the reviewer to look at. Areas of uncertainty.
Trade-offs you considered and rejected. Decisions that the agent and you
disagreed on during the authoring loop.
-->
  Validation reports several pre-existing SOFT warnings in unrelated skills (`security-issue-import-via-forwarder` and `setup-isolated-setup-doctor`). These are outside the scope of this PR and were not addressed as part of the `--fail-fast` change.

I also encountered a validation issue related to `tools/vulnogram/README.md`, which appears unrelated to the changes in this PR.

