### PR TITLE
docs(agents): require lychee local-run on every PR — added to Before submitting

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1681,6 +1681,32 @@ that does not change what the model is asked to produce —
 
 - Re-read the diff and check that every change is intentional.
 - Check that any renamed headings have matching TOC updates.
+- **Run lychee against every changed `.md` / `.rst` / `.md.j2` file.**
+  CI runs the same check on every PR and a single broken link blocks
+  the merge; catching it locally avoids a round-trip. The canonical
+  recipe — same as
+  [`.github/workflows/doc-validation.yml`](.github/workflows/doc-validation.yml)
+  invokes:
+
+  ```bash
+  lychee --config .lychee.toml .
+  ```
+
+  Run on the whole repo (cheap — most checks are offline file +
+  fragment lookups; only the external-URL subset hits the network).
+  Pay attention to **`Fragment not found in document`** errors —
+  those are anchor-style links (`other.md#section`) whose target
+  heading no longer exists. They are the most common breakage after
+  any refactor that moved a section between files or renamed a
+  heading. Re-write the link to point at the new location; do not
+  silence it with an ignore-pattern.
+
+  If your local lychee is v0.24+ (the example config in
+  `.lychee.toml` pins the v0.23 schema), replace
+  `include_fragments = true` with `include_fragments = "anchor-only"`
+  before running, or invoke directly:
+  `lychee --include-fragments=anchor-only --no-progress <paths>`.
+
 - Verify that links to the project's Security Model use an anchor that
   exists on the current stable version (adopting project's anchors:
   [`<project-config>/security-model.md`](<project-config>/security-model.md)).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1685,7 +1685,7 @@ that does not change what the model is asked to produce —
   CI runs the same check on every PR and a single broken link blocks
   the merge; catching it locally avoids a round-trip. The canonical
   recipe — same as
-  [`.github/workflows/doc-validation.yml`](.github/workflows/doc-validation.yml)
+  [`.github/workflows/link-check.yml`](.github/workflows/link-check.yml)
   invokes:
 
   ```bash


### PR DESCRIPTION
## Summary

Add a Before-submitting checklist entry that requires running \`lychee --config .lychee.toml .\` locally on every PR. Caught a Fragment-not-found regression in [PR #410](https://github.com/apache/airflow-steward/pull/410) only after CI flagged it; the check is cheap to run locally and catching it before the push avoids a round-trip.

## Change

Append to the existing **Before submitting** checklist in \`AGENTS.md\`:

1. The canonical invocation (matches the CI workflow).
2. A note on the most common failure class — \`Fragment not found in document\` — which is exactly what bites on doc refactors that move sections between files or rename headings (the class that just bit PR #410).
3. A one-liner workaround for v0.24+ local lychee installs, since \`.lychee.toml\` pins the v0.23 schema for CI compatibility.

The rule is enforced by CI either way (the lychee workflow blocks merge on any failure); this just makes the local check a documented pre-push habit so agents avoid the CI round-trip.

## Test plan

- [x] AGENTS.md renders cleanly (table of contents intact, no broken links introduced by this edit)
- [ ] Next PR opened against the framework after this lands has the lychee local-run done before push (verified by absence of doc-refactor-induced fragment errors on CI)

🤖 Generated with [Claude Code](https://claude.com/claude-code)