### PR TITLE
Remove dead placeholder allowlist marker

### DIFF
--- a/tools/dev/check-placeholders.sh
+++ b/tools/dev/check-placeholders.sh
@@ -82,10 +82,10 @@ ALLOWLIST_PATHS=(
 # Inline markers that signal an intentional explanatory mention
 # of Airflow on the same line. Lines matching any of these are
 # treated as allowlisted.
+# Entries are matched as literal bash substrings, not regex patterns.
 INLINE_ALLOW_MARKERS=(
   "example:"
   "e.g."
-  "e\.g\."
   "for Airflow"
   "the Airflow"
   "legacy"


### PR DESCRIPTION
## Summary
- remove the dead `"e\.g\."` placeholder allowlist marker
- document that inline allow markers are matched as literal bash substrings, not regex patterns

Fixes #407

## Test plan
- Ran `tools/dev/check-placeholders.sh` before the change with Git Bash: OK
- Ran `tools/dev/check-placeholders.sh` after the change with Git Bash: OK
- Ran `git diff --check -- tools/dev/check-placeholders.sh`
- Confirmed the regex-escaped marker is gone and the substring-match comment is present