### PR TITLE
Fix failed hook summary extraction

### DIFF
--- a/tools/dev/agent-pre-commit.sh
+++ b/tools/dev/agent-pre-commit.sh
@@ -77,7 +77,21 @@ echo "agent-pre-commit: ❌ one or more checks failed (exit $prek_rc)" >&2
 echo "Review the output above, fix the issues, and run this script again." >&2
 
 # Extract which hooks failed for a quick summary.
-failed_hooks=$(echo "$prek_output" | grep -E '\[41mFailed\[49m' | sed 's/.*\[41mFailed\[49m.*/  - FAILED/' | sed 's/^  - FAILED //')
+failed_hooks=$(
+  echo "$prek_output" | awk '
+    {
+      line = $0
+      gsub(/\033\[[0-9;]*m/, "", line)
+      if (line ~ /\.+Failed/) {
+        sub(/\.+Failed.*/, "", line)
+        sub(/[[:space:]]+$/, "", line)
+        if (line != "") {
+          print "  - " line
+        }
+      }
+    }
+  '
+)
 if [[ -n "$failed_hooks" ]]; then
   echo "" >&2
   echo "Failed hooks:" >&2


### PR DESCRIPTION
## Summary
- replace the failed-hook extraction pipeline with ANSI-stripping awk parsing
- list each failed hook name in the trailing summary instead of a generic failed line
- preserve the wrapper exit behavior for success and failure paths

Fixes #406

## Test plan
- Stubbed `prek` failure output with colorized `typos` and `ruff` failures; script exited 1 and printed both hook names under `Failed hooks:`
- Stubbed successful `prek` output; script exited 0
- Ran `git diff --check -- tools/dev/agent-pre-commit.sh`