### PR TITLE
docs: strip stale 'lychee is informational' wording

### DIFF
--- a/.github/workflows/link-check.yml
+++ b/.github/workflows/link-check.yml
@@ -18,12 +18,14 @@
 ---
 name: link-check
 
-# Lychee runs in informational mode for now: it surfaces broken
-# internal links and broken external URLs, but does not block PR
-# merges. The existing tree has a known set of pre-existing broken
-# references (to files like `config/active-project.md` that this
-# repository plans to add later) which would otherwise fail every
-# PR. Once the baseline reaches zero, flip `continue-on-error` off.
+# Lychee is a hard gate: every broken internal link or unreachable
+# external URL fails this workflow, and `lychee` is one of the
+# required status checks in `.asf.yaml`. Promoted from
+# informational mode in PR #47 after the pre-existing baseline
+# was driven to zero. Anyone adding a broken link to a PR fails
+# this check and cannot merge until the link is fixed (or
+# excluded via `.lychee.toml` if the target is genuinely
+# placeholder-style — but the bar for adding excludes is high).
 
 on:  # yamllint disable-line rule:truthy
   pull_request:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -795,10 +795,12 @@ Separate GitHub workflows:
 - **`zizmor.yml`** — lints GitHub Actions workflows for known-bad
   patterns; runs on every PR.
 - **`link-check.yml`** — runs [lychee](https://lychee.cli.rs/) on
-  every PR and daily on a schedule. **Informational only** today
-  (`continue-on-error: true`) because the tree carries a known set
-  of placeholder / not-yet-created file references; once the
-  baseline reaches zero the workflow flips to a hard gate.
+  every PR and daily on a schedule. **Hard gate** (`fail: true`,
+  `continue-on-error: false`); a single broken internal link or
+  unreachable external URL fails the workflow and blocks merge.
+  Run lychee locally before pushing (see *Before submitting* in
+  [`AGENTS.md`](AGENTS.md#before-submitting)) — the local invocation
+  catches the same errors and avoids a CI round-trip.
 
 To run a single Python package's tests directly:
 
@@ -849,9 +851,9 @@ agent self-eval mode).
 - **PR description:** one `## Summary` section (1–3 bullets of
   *what changed and why*) and one `## Test plan` section (how you
   verified). The `gh pr create` template in this repo matches.
-- **CI gates:** `prek run --all-files` must pass; `zizmor` must
-  pass. `link-check` is informational. All gates run automatically
-  on every PR.
+- **CI gates:** `prek run --all-files`, `zizmor`, `lychee`, and
+  every entry in the `tests-ok` pytest-matrix umbrella must pass.
+  All gates run automatically on every PR.
 - **Reviews:** at least one approval from a repo collaborator. Any
   change that edits [`AGENTS.md`](AGENTS.md), an RFC, or a skill
   file should get an extra set of eyes because those ripple into


### PR DESCRIPTION
## Why

PR #47 (2026-05-04) promoted link-check to a hard gate: `fail: true`, `continue-on-error: false`, and `lychee` was added to `.asf.yaml`'s `required_status_checks`. Three places in the tree still describe the workflow as informational, contradicting actual behaviour.

## Updates

- **`.github/workflows/link-check.yml` header** — claimed lychee was in informational mode and said to "flip `continue-on-error` off once the baseline reaches zero". The flag has been off since #47. Rewritten to describe the current hard-gate state + the bar for adding `.lychee.toml` excludes (genuinely-placeholder targets only).
- **`CONTRIBUTING.md` § CI workflows entry** — claimed `continue-on-error: true` (it is false) and called lychee baseline-pending. Updated to describe the hard gate + point at `AGENTS.md § Before submitting` for the local pre-push invocation.
- **`CONTRIBUTING.md` § CI gates bullet** — listed only prek + zizmor and called link-check informational. Updated to the actual gate set (prek, zizmor, lychee, every `tests-ok` matrix entry).

Pure documentation; the workflow itself is unchanged.

## Test plan

- [x] Re-swept for any remaining stale references — none left
- [x] `prek run --files <edited>` — all green (markdownlint, typos, EOL, trailing-whitespace)
- [ ] CI: lychee + tests-ok

🤖 Generated with [Claude Code](https://claude.com/claude-code)