### PR TITLE
fix(audit-finding-fix): add missing capability frontmatter key

### DIFF
--- a/.claude/skills/audit-finding-fix/SKILL.md
+++ b/.claude/skills/audit-finding-fix/SKILL.md
@@ -19,6 +19,7 @@ when_to_use: |
   when findings are too ambiguous to fix without design
   discussion.
 argument-hint: "[--tool <name>] [--report <path>] [--finding <id>]"
+capability: capability:fix
 license: Apache-2.0
 ---
 

--- a/docs/labels-and-capabilities.md
+++ b/docs/labels-and-capabilities.md
@@ -139,6 +139,7 @@ Capabilities for every skill currently in
 | `pr-management-mentor` | `capability:review` |
 | `good-first-issue-author` | `capability:review` *(authors a newcomer-ready good first issue — contributor mentoring on the supply side)* |
 | `issue-fix-workflow` | `capability:fix` |
+| `audit-finding-fix` | `capability:fix` |
 | `security-issue-fix` | `capability:fix` + `capability:resolve` *(opens the PR that closes the tracker — both phases)* |
 | `security-issue-import` | `capability:intake` |
 | `security-issue-import-from-md` | `capability:intake` |


### PR DESCRIPTION
## What & why

`audit-finding-fix` merged to `main` without the required `capability`
frontmatter key, turning the **skill-and-tool validator** (and the `prek`
gate) red on `main` and on every open PR — the validator checks the whole
repo, so the breakage is repo-wide, not local to one branch.

It is a `mode: Drafting` skill that drafts the smallest code fix per
audit-tool finding → `capability:fix`. This adds the key and the matching
`capability`→skill map row in `docs/labels-and-capabilities.md`.

Two-line fix; unblocks the whole PR queue.

## Testing

`pytest (skill-and-tool-validator)` and the full `prek` gate green locally.

Generated-by: Claude Code (Opus 4.8)
