### PR TITLE
Fix two Magpie migration-shim gaps: committed magpie-setup tracking + adopter lint exclusions

### DIFF
--- a/.claude/skills/setup-steward/upgrade.md
+++ b/.claude/skills/setup-steward/upgrade.md
@@ -169,13 +169,23 @@ because **every** framework symlink now carries the prefix:
 /.apache-magpie/
 /.apache-magpie.local.lock
 /.claude/skills/magpie-*
+!/.claude/skills/magpie-setup
 /.github/skills/magpie-*              # (Pattern B; or the canonical side for D)
+!/.github/skills/magpie-setup        # (Pattern B/D — same side as the glob above)
 ```
 
 Keep the orientation right for the adopter's pattern (Pattern A → only
-the `.claude/skills/magpie-*` line; D → only the canonical side). The
-committed `.apache-magpie.lock` and `.apache-magpie-overrides/` are
-**not** gitignored.
+the `.claude/skills/magpie-*` pair; D → only the canonical side). The
+`!/.../magpie-setup` negation is **required**: the `magpie-*` glob would
+otherwise swallow the committed `magpie-setup` bootstrap (the one tracked
+framework skill, per [`SKILL.md` Golden rule 6](SKILL.md#golden-rules)), so
+a plain `git add` would silently skip it and fresh clones would land with
+no bootstrap skill. Keep the negation on the **same side(s)** as the glob
+(Pattern A → the `.claude` pair only; Pattern B → both pairs; Pattern D →
+the canonical side only). Use **no trailing slash** — it must re-include
+the outer symlink in Pattern B as well as the real directory. The committed
+`.apache-magpie.lock` and `.apache-magpie-overrides/` are **not**
+gitignored.
 
 ## Step 7 — Migrate the per-user config dir + sandbox allowlist
 

--- a/.claude/skills/setup-steward/upgrade.md
+++ b/.claude/skills/setup-steward/upgrade.md
@@ -196,7 +196,7 @@ or user-scope `~/.claude/settings.json`) must become
 able to read the moved credentials. The framework cannot edit those
 settings files for the operator — surface the exact one-line change.
 
-## Step 8 — Migrate the post-checkout hook + doc sections
+## Step 8 — Migrate the post-checkout hook, lint config + doc sections
 
 - **Git hook.** If `.git/hooks/post-checkout` contains the legacy
   `setup-steward verify --auto-fix-symlinks` recipe, update it to
@@ -208,6 +208,18 @@ settings files for the operator — surface the exact one-line change.
   symlinks. Best-effort and surfaced as part of the migration diff; the
   framework-name prose ("Apache Magpie") is independent and not touched
   here.
+- **Lint / pre-commit config.** If the adopter's `.pre-commit-config.yaml`
+  (or any other prek / linter config) *excludes* the committed framework
+  skill or the overrides dir by their old paths — e.g.
+  `^\.github/skills/setup-steward/`, `^\.claude/skills/setup-steward/`,
+  `^\.apache-steward-overrides/` — re-point those exclusion patterns to the
+  magpie paths (`magpie-setup`, `.apache-magpie-overrides/`). Adopters add
+  these so the committed bootstrap skill is skipped by license / spellcheck
+  / markdown-lint / link-check hooks; leaving a pattern stale lets those
+  hooks run on the renamed files and the migration commit **fails**. The
+  exact lines are adopter-specific — grep the config for `setup-steward`
+  and `apache-steward` and re-point every match. Surfaced as part of the
+  migration diff.
 
 ## Step 9 — Hand off to `magpie-setup` and finish the upgrade
 

--- a/skills/setup/adopt.md
+++ b/skills/setup/adopt.md
@@ -400,10 +400,11 @@ idempotent — re-add them if they're missing.
   so a single `magpie-*` glob covers them all — no per-family
   lines.
 
-- **Pattern A (flat)** — only the `.claude/skills/...` line:
+- **Pattern A (flat)** — only the `.claude/skills/...` lines:
 
   ```text
   /.claude/skills/magpie-*
+  !/.claude/skills/magpie-setup
   ```
 
 - **Pattern B (double-symlinked)** — both `.claude/skills/...`
@@ -413,7 +414,9 @@ idempotent — re-add them if they're missing.
 
   ```text
   /.claude/skills/magpie-*
+  !/.claude/skills/magpie-setup
   /.github/skills/magpie-*
+  !/.github/skills/magpie-setup
   ```
 
 - **Pattern D (single directory symlink)** — only the
@@ -422,10 +425,12 @@ idempotent — re-add them if they're missing.
 
   ```text
   /.github/skills/magpie-*
+  !/.github/skills/magpie-setup
   ```
 
   With D.2 (canonical = `.claude/skills/`), use
-  `/.claude/skills/magpie-*` instead. Pattern D does not
+  `/.claude/skills/magpie-*` (plus `!/.claude/skills/magpie-setup`)
+  instead. Pattern D does not
   need ignore lines on the *symlinked* side because that side
   is itself a single tracked symlink — git does not descend
   into it, so the symlinked-side paths match no tracked file.
@@ -439,8 +444,12 @@ discovery family) per
 [`SKILL.md` Golden rule 8](SKILL.md#golden-rules); every
 symlinked framework skill is gitignored on every adopter
 regardless of the opt-in family pick. The committed
-`magpie-setup` skill is **not** gitignored — it is the one
-copied framework skill.
+`magpie-setup` skill is kept tracked by the
+`!/.../magpie-setup` negation line in each block above —
+without it the `magpie-*` glob would ignore the bootstrap and
+a plain `git add` would silently skip it, leaving fresh clones
+with no committed framework skill. It is the one copied
+framework skill.
 
 `.claude/settings.local.json` is the project-local
 per-machine settings file that


### PR DESCRIPTION
Two fixes to the pre-Magpie → Magpie migration path, both hit live while migrating `apache/airflow` through the upgrade.

## 1. Keep the committed `magpie-setup` tracked under the `magpie-*` gitignore glob

The collapsed `/.claude/skills/magpie-*` (and `/.github/skills/magpie-*`) glob in `adopt.md` Step 7 and the migration shim's Step 6 also matches the **committed** `magpie-setup` bootstrap — the one tracked framework skill (Golden rule 6). Since git only ignores *untracked* files, a plain `git add` silently skips it and a fresh clone lands with no bootstrap. `conventions.md` already documented the `!/.../magpie-setup` negation for the "`.claude/` already gitignored" caveat, but the general blocks omitted it. Adds the negation (no trailing slash, so it re-includes the Pattern-B outer symlink as well as the real directory) to both blocks, per pattern, with an explanation of why it's required.

## 2. Step 8 — re-point adopter lint / pre-commit exclusions

The shim renames `setup-steward` → `magpie-setup` and `.apache-steward-overrides/` → `.apache-magpie-overrides/`. Adopters who exclude the committed skill / overrides dir from lint hooks (e.g. `.pre-commit-config.yaml`) are left with **stale** exclusion patterns; those hooks (license / spellcheck / markdown-lint / link-check) then run on the renamed files and the migration commit **fails**. Step 8 now tells the migration to grep for `setup-steward` / `apache-steward` exclusion patterns and re-point each to the magpie paths.

Generated-by: Claude Code (Opus 4.8)
