### PR TITLE
Fix stale snapshots in security-tracker-stats-dashboard (now, is_open, event cache)

### DIFF
--- a/tools/security-tracker-stats-dashboard/fetch_events.py
+++ b/tools/security-tracker-stats-dashboard/fetch_events.py
@@ -4,6 +4,7 @@
 import json
 import subprocess
 import concurrent.futures
+import datetime as dt
 import os
 
 ROOT = os.environ.get('TRACKER_STATS_CACHE', '/tmp/tracker-stats-cache')
@@ -14,6 +15,16 @@ with open(f'{ROOT}/issues.json') as f:
     issues = json.load(f)
 
 numbers = [i['number'] for i in issues]
+# Map issue number -> last-updated epoch so the cache can be refreshed when an
+# issue was relabeled / closed after its events were last fetched.
+def _iso_to_epoch(s):
+    if not s:
+        return None
+    try:
+        return dt.datetime.fromisoformat(s.replace('Z', '+00:00')).timestamp()
+    except ValueError:
+        return None
+UPDATED_AT = {i['number']: _iso_to_epoch(i.get('updatedAt')) for i in issues}
 print(f"Fetching events for {len(numbers)} issues...")
 
 os.makedirs(EVENTS_DIR, exist_ok=True)
@@ -21,7 +32,11 @@ os.makedirs(EVENTS_DIR, exist_ok=True)
 def fetch_one(n):
     out_path = f'{EVENTS_DIR}/{n}.json'
     if os.path.exists(out_path) and os.path.getsize(out_path) > 0:
-        return (n, True, 'cached')
+        # Trust the cache only if it was written after the issue was last
+        # updated; otherwise the issue changed since and the events are stale.
+        upd = UPDATED_AT.get(n)
+        if upd is None or os.path.getmtime(out_path) >= upd:
+            return (n, True, 'cached')
     try:
         r = subprocess.run(
             ['gh', 'api', f'repos/{REPO}/issues/{n}/events',

--- a/tools/security-tracker-stats-dashboard/render.py
+++ b/tools/security-tracker-stats-dashboard/render.py
@@ -382,7 +382,7 @@ if UPSTREAM_REPO:
         with open(prs_path) as f:
             prs_cache = json.load(f)
 
-NOW = dt.datetime(2026, 5, 21, 0, 0, 0, tzinfo=dt.timezone.utc)
+NOW = dt.datetime.now(dt.timezone.utc)
 
 if UPSTREAM_REPO:
     # Match the original literal in the body-parse regex so an upstream
@@ -586,6 +586,13 @@ def labels_open_at(issue, ts):
             is_open = False
         elif e['event'] == 'reopened':
             is_open = True
+    # The issue-events API can omit the 'closed' event for some (often
+    # older) issues, which would leave is_open stuck True and miscount a
+    # closed issue as open. Trust the authoritative closedAt from the
+    # issue payload as a backstop (the cum_closed series already does).
+    closed_at = parse_dt(issue.get('closedAt'))
+    if issue.get('state') == 'CLOSED' and closed_at and closed_at <= ts:
+        is_open = False
     return labels, is_open
 
 


### PR DESCRIPTION
The `security-tracker-stats-dashboard` produced snapshots that no longer
matched the tracker's current state. Three independent causes:

1. **`render.py` hard-coded `NOW`** to `2026-05-21`, freezing every snapshot
   at that date so the latest bucket and all "as of now" classifications
   lagged reality. Now uses `datetime.now(timezone.utc)`.

2. **`render.py` `labels_open_at` derived `is_open` only from replayed
   `closed`/`reopened` events.** GitHub's issue-events API omits the `closed`
   event for some (often older) issues, leaving them stuck "open" and
   miscounted (e.g. as open-untriaged). It now backstops `is_open` with the
   authoritative `closedAt` from the issue payload — the same field the
   `cum_closed` series already trusts.

3. **`fetch_events.py` never refreshed cached event files** (it returned
   `cached` whenever the file existed), so an issue relabeled/closed after
   its events were first fetched kept stale history across runs. It now
   re-fetches when the cached file is older than the issue's `updatedAt`.

Together these made the dashboard, for example, report trackers as untriaged
that had since been triaged, and closed trackers as still open.

### Test plan
- [x] `render.py` against a warm cache reports `now: <today>` and classifies
      open issues by their current labels (untriaged count matches the live
      `needs triage` / scope-label state).
- [x] `fetch_events.py` re-fetches an event cache whose mtime predates the
      issue's `updatedAt` (verified by back-dating a cache file).

Generated-by: Claude Opus 4.8 (1M context)
