### PR TITLE
Adds a setup hint to CONTRIBUTING

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -511,8 +511,17 @@ First-time clone:
 ```bash
 git clone git@github.com:apache/airflow-steward.git
 cd airflow-steward
+uv tool install prek
 prek install                   # wire the hooks into .git/hooks
 prek run --all-files           # runs every hook on every file
+```
+
+Note that if you are already using `prek` for some other project, you
+may need to do the following:
+
+```bash
+git config --local core.hooksPath .git/hooks
+prek install
 ```
 
 The hooks are described in detail under [Running the dev loop](#running-the-dev-loop).


### PR DESCRIPTION

<!-- SPDX-License-Identifier: Apache-2.0
     https://www.apache.org/licenses/LICENSE-2.0 -->

## Summary

Adds a hint to the CONTRIBUTING doc for folks who are completely new to prek, uv, and this style of developing.

## Type of change

<!-- Tick all that apply. -->

- [x] Documentation (`docs/`, `README.md`, `CONTRIBUTING.md`)

## Test plan

It's just a doc

- [x] `prek run --all-files` passes

## RFC-AI-0004 compliance

N/A

## Linked issues

N/A

## Notes for reviewers (optional)

No change for most users. But this is what I needed to do to bootstrap the project.