### PR TITLE
fix(template): replace Airflow identity with placeholders in _template scaffold

### DIFF
--- a/projects/_template/project.md
+++ b/projects/_template/project.md
@@ -802,29 +802,25 @@ roster:
   # reference contributors by first name only; this map binds
   # those bare names to GitHub handles so the skills can produce
   # @-mentions on the tracker.
-  # ASF/Airflow default: the existing airflow-s bare-name map.
-  # Override when: adapt to the adopter's roster — add/remove
-  # entries as needed.
+  # Replace the example entries below with the adopter's roster —
+  # add/remove entries as needed.
   # Consumed by: security-issue-sync, pr-management-mentor.
   bare_name_handles:
-    Jarek: "@potiuk"
-    Ash: "@ashb"
-    Kaxil: "@kaxil"
-    Ephraim: "@ephraimbuddy"
-    Jed: "@jedcunningham"
+    # Example (replace with your project's contributors):
+    "<FirstName>": "@<handle>"
+    # "<FirstName>": "@<handle>"
 
   # Release-manager handles, ordered by recency of train ownership.
   # First handle is the current default RM; the rest are the
   # historical RMs the skill falls back to when assigning legacy
   # trains.
-  # ASF/Airflow default: the current RM order from release-trains.md.
-  # Override when: keep in sync with `release-trains.md`.
+  # Replace the example entries below; keep in sync with
+  # `release-trains.md`.
   # Consumed by: security-issue-sync, security-issue-fix.
   release_managers:
-    - "@ephraimbuddy"
-    - "@jedcunningham"
-    - "@potiuk"
-    - "@kaxil"
+    # Example (replace with your project's release managers):
+    - "@<handle>"
+    # - "@<handle>"
 ```
 
 ### Product

--- a/projects/_template/release-management-config.md
+++ b/projects/_template/release-management-config.md
@@ -120,13 +120,13 @@ variants* below).
 
 | Key | Value |
 |---|---|
-| `vote_dev_list` | `dev@airflow.apache.org` |
+| `vote_dev_list` | `<dev-list>` *(e.g. `dev@airflow.apache.org`)* |
 | `mail_archive` | `ponymail` |
-| `mail_archive_url_template` | `https://lists.apache.org/list.html?dev@airflow.apache.org` |
+| `mail_archive_url_template` | `<mail-archive-url>` *(ASF e.g. `https://lists.apache.org/list.html?<dev-list>`)* |
 | `vote_window_hours` | `72` |
 | `vote_pass_rule_overrides` | *(none, uses ASF baseline: 3 binding +1 minimum, more binding +1 than -1)* |
-| `vote_subject_template` | `[VOTE] Release Apache Airflow <version> from <version>-rcN` |
-| `result_subject_template` | `[RESULT] [VOTE] Release Apache Airflow <version> from <version>-rcN` |
+| `vote_subject_template` | `[VOTE] Release <Product Name> <version> from <version>-rcN` |
+| `result_subject_template` | `[RESULT] [VOTE] Release <Product Name> <version> from <version>-rcN` |
 | `release_approver_roster_path` | `<project-config>/pmc-roster.md` *(ASF default); non-ASF: e.g. `<project-config>/release-approvers.md`)* |
 
 The configured `vote_window_hours` is a floor per
@@ -155,9 +155,9 @@ variants* below).
 | Key | Value |
 |---|---|
 | `announce_list` | `announce@apache.org` |
-| `announce_cc_lists` | `dev@airflow.apache.org`, `users@airflow.apache.org` |
-| `announce_subject_template` | `[ANNOUNCE] Apache Airflow <version> released` |
-| `site_repo` | `apache/airflow-site` |
+| `announce_cc_lists` | `<dev-list>`, `<users-list>` *(e.g. `dev@airflow.apache.org`, `users@airflow.apache.org`)* |
+| `announce_subject_template` | `[ANNOUNCE] <Product Name> <version> released` |
+| `site_repo` | `<site-repo>` *(e.g. `apache/airflow-site`)* |
 | `site_pr_files` | `landing-pages/site/content/en/_index.md`, `landing-pages/site/content/en/announcements/<version>.md` |
 
 `announce@apache.org` is mandatory for ASF TLP releases per


### PR DESCRIPTION
Fixes #461.

The vendor-neutral `projects/_template/` scaffold carried Apache Airflow's
concrete identity in a few places where an arbitrary adopter would inherit it
as a default.

**`project.md`**
- `bare_name_handles`: replaced the live Airflow roster with example
  `<FirstName>`/`@<handle>` placeholders.
- `release_managers`: replaced the real RM handles with `@<handle>` examples.

**`release-management-config.md`** (a "filled example" file): turned the
project-identity values in the Value column into `<placeholder>` tokens, keeping
the Airflow value as an inline example (matching the existing
`release_approver_roster_path` style):
- `vote_dev_list`, `mail_archive_url_template`
- `announce_cc_lists`, `site_repo`
- vote/result/announce subject templates → `<Product Name>`

Scoped to the project-identity values flagged in the issue. Remaining `airflow`
references (dist URLs, `project_dist_name`, `version_manifest_files`) are part of
the file's deliberate "filled example" framing. `announce@apache.org` left as-is
(shared ASF list, correctly generic).