### PR TITLE
chore(setup): bump pinned claude-code 2.1.150 → 2.1.165

### DIFF
--- a/docs/setup/secure-agent-setup.md
+++ b/docs/setup/secure-agent-setup.md
@@ -154,7 +154,7 @@ The same flow, condensed to commands you run yourself:
 #    section: "Required tools (pinned versions)" below.
 sudo apt-get install --no-install-recommends \
     bubblewrap=0.11.2-* socat=1.8.1.1-*
-npm install -g --no-save @anthropic-ai/claude-code@2.1.141
+npm install -g --no-save @anthropic-ai/claude-code@2.1.165
 
 # 2. Project-scope `.claude/settings.json`. Copy the framework's
 #    sandbox / permissions.deny / permissions.ask / allowedDomains
@@ -252,7 +252,7 @@ version, no pin enforced — Homebrew rolls forward, so the
 
 ```bash
 # npm distribution (the only stable channel today)
-npm install -g --no-save @anthropic-ai/claude-code@2.1.141
+npm install -g --no-save @anthropic-ai/claude-code@2.1.165
 ```
 
 ### Distro-specific shortcut — Linux Mint 22.x / Ubuntu 24.04 Noble

--- a/tools/agent-isolation/pinned-versions.toml
+++ b/tools/agent-isolation/pinned-versions.toml
@@ -52,7 +52,7 @@
 
 # When this file was last touched. The check script uses this as the
 # minimum age the entries below claim to satisfy.
-pinned_at = "2026-05-25"
+pinned_at = "2026-06-06"
 
 [tools.bubblewrap]
 version = "0.11.2"
@@ -91,8 +91,8 @@ install.dnf = "dnf install socat-1.8.1.1"
 install.from_source = "http://www.dest-unreach.org/socat/download/socat-1.8.1.1.tar.gz"
 
 [tools.claude-code]
-version = "2.1.150"
-released = "2026-05-23"
+version = "2.1.165"
+released = "2026-06-05"
 # Override the framework-wide 7-day default. Claude Code releases
 # cadence is high (multiple releases per week) and any regression
 # that affects the framework's permission-rule semantics, sandbox
@@ -118,5 +118,5 @@ upstream_releases = "https://api.github.com/repos/anthropics/claude-code/release
 # Claude Code is distributed via npm; use `--no-save` so the global
 # install doesn't drift the local lockfile of any project the user
 # installs from.
-install.npm = "npm install -g --no-save @anthropic-ai/claude-code@2.1.150"
-install.brew = "# brew tap anthropics/claude-code; brew install claude-code@2.1.150 (when available)"
+install.npm = "npm install -g --no-save @anthropic-ai/claude-code@2.1.165"
+install.brew = "# brew tap anthropics/claude-code; brew install claude-code@2.1.165 (when available)"


### PR DESCRIPTION
## What

Bumps the pinned `claude-code` in `tools/agent-isolation/pinned-versions.toml`
from **2.1.150** to **2.1.165** (released 2026-06-05, aged past the tool's
1-day cooldown), and bumps `pinned_at` to 2026-06-06.

Also realigns the two install commands in `docs/setup/secure-agent-setup.md`,
which still pinned the stale **2.1.141** — the previous 2.1.150 bump updated
the manifest but not the doc. They now match the manifest at 2.1.165.

## Changelog review

Per the bump process, reviewed the upstream changelog across 2.1.151-2.1.165.
Nothing changes the framework's permission-rule, sandbox, or prompt-injection
semantics — the range is forward improvements and security hardening:

- **2.1.162** — hardened cross-session messaging (relayed messages no longer
  carry user authority)
- **2.1.160** — added a prompt before writing to shell startup files
  (`.zshenv`, `.bash_login`, …)
- **2.1.163** — fixed a `$TMPDIR` override regression from 2.1.154

## Verification

- `tools/agent-isolation/check-tool-updates.sh` now reports `claude-code … ✓ up to date`
- `prek run --files …` passes on both changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)
