### PR TITLE
chore(setup): shorten skill description

### DIFF
--- a/skills/setup/SKILL.md
+++ b/skills/setup/SKILL.md
@@ -3,25 +3,15 @@ name: magpie-setup
 description: |
   Adopt and maintain the apache-steward framework in a project
   repo via the snapshot-based adoption mechanism. The only
-  framework skill committed in an adopter's repo — every other
+  framework skill committed in an adopter's repo; every other
   skill is a symlink the adopt sub-action wires up.
   Sub-actions:
-    `/magpie-setup`         — first-time adoption (default;
-                                main-checkout only)
-    `/magpie-setup upgrade` — refresh the gitignored snapshot
-                                per the committed lock
-                                (main-checkout only)
-    `/magpie-setup worktree-init` — symlink a worktree's
-                                snapshot to the main's
-    `/magpie-setup verify`  — health check + drift detection
-    `/magpie-setup override <skill>` — open or scaffold an
-                                agentic override in
-                                `.apache-magpie-overrides/`
-    `/magpie-setup unadopt` — reverse the adoption (snapshot,
-                               locks, symlinks, hook, doc
-                               sections); preserves
-                               `.apache-magpie-overrides/` by
-                               default (main-checkout only)
+    `/magpie-setup` - first-time adoption (default; main-checkout only)
+    `/magpie-setup upgrade` - refresh the gitignored snapshot per the committed lock (main-checkout only)
+    `/magpie-setup worktree-init` - symlink a worktree's snapshot to the main's
+    `/magpie-setup verify` - health check + drift detection
+    `/magpie-setup override <skill>` - open or scaffold an agentic override in `.apache-magpie-overrides/`
+    `/magpie-setup unadopt` - reverse the adoption (snapshot, locks, symlinks, hook, doc sections); preserves `.apache-magpie-overrides/` by default (main-checkout only)
 when_to_use: |
   Invoke when the user says "adopt apache-steward", "adopt
   apache/airflow-steward", "set up steward in this repo",


### PR DESCRIPTION
## Summary

Micro-optimization inspired by the warning I got from [Pi](https://github.com/earendil-works/pi):

<img width="535" height="42" alt="Screenshot 2026-06-07 at 05 06 56" src="https://github.com/user-attachments/assets/97f0d999-0010-4ce9-a67e-d595d7b1befb" />

This keeps the `magpie-setup` skill description under the 1024-character metadata budget without changing the sub-action wording.

The change removes alignment whitespace and wraps each sub-action onto one line. It also replaces the em dash in the first sentence with a semicolon.

I also checked the other skill descriptions for whitespace-only savings. All descriptions are already under 1024 characters, and the remaining whitespace-only savings are tiny (at most 22 bytes outside this file), so this PR only changes `magpie-setup`.

## Type of change

- [x] Skill change (`.claude/skills/<name>/`) — eval fixtures updated below
- [ ] Tool / bridge contract (`tools/<system>/*.md`)
- [ ] Python package (`tools/*/` with `pyproject.toml`)
- [ ] Groovy reference impl
- [ ] Cross-cutting (RFC, AGENTS.md, sandbox, privacy-LLM)
- [ ] Documentation (`docs/`, `README.md`, `CONTRIBUTING.md`)
- [ ] Project template (`projects/_template/`)
- [ ] CI / dev loop (`prek`, workflows, validators)
- [ ] Other:

## Test plan

- [x] `prek run --all-files` passes
- [ ] For Python packages touched: `uv run pytest` / `ruff check` / `mypy` passes
- [ ] For Groovy bridges touched: command-line invocation tested end-to-end
- [x] For skill changes: eval suite passes for the affected skill
     (`PYTHONPATH=tools/skill-evals/src python3 -m skill_evals.runner tools/skill-evals/evals/setup`)
- [ ] For skill *behaviour* changes: a new or updated eval fixture is included in this PR
     (a regression test for the bug fixed / the behaviour added — see CONTRIBUTING.md)
- [x] Other: `uv run --project tools/skill-and-tool-validator skill-and-tool-validate` passes with existing soft warnings only:
 - `skills/security-issue-import-via-forwarder/SKILL.md`: action inventory + criteria-source warnings
 - `skills/setup-isolated-setup-verify/SKILL.md`: action inventory warning
- [x] Other: verified the setup skill description is 846 characters

No eval fixture was updated because this is a frontmatter metadata-size cleanup only. It does not change skill behavior.

## RFC-AI-0004 compliance

- [ ] **HITL** — any new mutation is gated on explicit user confirmation
- [ ] **Sandbox** — no new unrestricted host access; network reach declared in the adapter
- [x] **Vendor neutrality** — placeholders (`<PROJECT>`, `<tracker>`, `<upstream>`, `<security-list>`) used in all skill / tool prose (the `check-placeholders` prek hook is the
mechanical gate)
- [ ] **Conversational + correctable** — agentic-override path documented if behaviour is adopter-tunable
- [ ] **Write-access discipline** — no autonomous outbound messages; drafts only, sent on confirmation
- [ ] **Privacy LLM** — private content does not reach a non-approved LLM; redactor invoked where needed

## Linked issues

None.

## Notes for reviewers (optional)

Please check that the compacted sub-action list still reads clearly. The intent is only to reduce metadata size, not to change routing or setup behavior.