### PR TITLE
chore(setup): exclude .agents/skills + .github/skills from doctoc

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -44,16 +44,18 @@ repos:
       - id: doctoc
         name: Add TOC for Markdown and RST files
         files: ^.+\.(md|rst)$
-        # Skip agent-facing skill definitions: their YAML frontmatter must be
-        # the first thing in the file, which is incompatible with doctoc
-        # inserting a TOC block at the top. Also skip skill-evals fixture and
+        # Skip agent-facing skill definitions across every skill-dir layout
+        # (.agents/skills canonical home, plus the .claude/skills and
+        # .github/skills relays, and the skills/ source): their YAML
+        # frontmatter must be the first thing in the file, which is
+        # incompatible with doctoc inserting a TOC block at the top. Also skip skill-evals fixture and
         # README files, and the spec-loop specs/prompts (YAML-frontmatter
         # specs and short single-purpose prompts, same rationale as skills)
         # — short docs that don't warrant a TOC.
         # Skip the PR template — GitHub pre-populates a new PR description
         # with the template verbatim, so a TOC block becomes per-PR noise the
         # contributor has to delete by hand.
-        exclude: ^(\.claude/skills/.*|skills/.*|tools/cve-tool-vulnogram/generate-cve-json/SKILL\.md|tools/skill-evals/.*|tools/spec-loop/.*|\.github/PULL_REQUEST_TEMPLATE\.md)$
+        exclude: ^(\.claude/skills/.*|\.agents/skills/.*|\.github/skills/.*|skills/.*|tools/cve-tool-vulnogram/generate-cve-json/SKILL\.md|tools/skill-evals/.*|tools/spec-loop/.*|\.github/PULL_REQUEST_TEMPLATE\.md)$
         args:
           - "--maxlevel"
           - "3"


### PR DESCRIPTION
## What

Add `.agents/skills/.*` and `.github/skills/.*` to the doctoc pre-commit `exclude` regex.

## Why

The exclude already skipped `.claude/skills/` and the `skills/` source, but not `.agents/skills/` — which is now the **canonical** skill home — nor the `.github/skills/` relays. doctoc therefore re-inserts a Table-of-Contents block into skill `SKILL.md` files reached via those paths, which:

- fights the agent-skill requirement that YAML frontmatter be the first thing in the file, and
- causes TOC churn on every adopter commit that touches the committed `magpie-setup` bootstrap (the TOC gets re-added, the commit aborts, the contributor has to re-stage).

The `skills/` source files are already TOC-free; this is a config-only fix so they stay that way regardless of which skill-dir path pre-commit feeds doctoc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
