### PR TITLE
fix(gmail): guarantee plain-text drafts on both backends

### DIFF
--- a/tools/gmail/draft-backends.md
+++ b/tools/gmail/draft-backends.md
@@ -188,6 +188,15 @@ are involved (either backend); always do the per-thread check too.
 
 ## Limitations that apply to both backends
 
+- **Plain text only — never HTML.** Both backends produce plain-text
+  (`text/plain`) drafts, and must keep doing so. `oauth_curl` builds a
+  single `text/plain` part via `EmailMessage.set_content` (its test
+  suite asserts the message stays single-part `text/plain` with no
+  `text/html` alternative). For `claude_ai_mcp`, this is guaranteed by
+  populating only the `body` parameter and **never** `htmlBody` —
+  passing `htmlBody` would add a `text/html` part. The project's
+  correspondence (security replies, relays, advisory text) is plain
+  text by policy; no skill should ever emit an HTML draft.
 - **No update, no delete** on the claude.ai MCP side — see
   [`operations.md` — Hard limitation](operations.md#hard-limitation--no-update-no-delete).
   The `oauth_curl` script could in principle update or delete drafts

--- a/tools/gmail/oauth-draft/src/oauth_draft/create_draft.py
+++ b/tools/gmail/oauth-draft/src/oauth_draft/create_draft.py
@@ -136,6 +136,12 @@ def build_mime(
         msg["In-Reply-To"] = in_reply_to
     if references:
         msg["References"] = references
+    # Plain text only — by design. ``set_content(str)`` produces a
+    # single ``text/plain; charset="utf-8"`` part with no ``text/html``
+    # alternative. The project's outbound mail is always plain text:
+    # never call ``add_alternative`` / ``set_content(..., subtype="html")``
+    # here, and never attach an HTML body. (The test suite asserts the
+    # built message stays single-part text/plain.)
     msg.set_content(body)
     return bytes(msg)
 

--- a/tools/gmail/oauth-draft/tests/test_create_draft.py
+++ b/tools/gmail/oauth-draft/tests/test_create_draft.py
@@ -68,6 +68,34 @@ def test_build_mime_sets_basic_headers():
     assert msg.get_content().rstrip() == "Body content."
 
 
+def test_build_mime_is_plain_text_not_html():
+    """The built message must be single-part ``text/plain`` — never HTML.
+
+    The project sends plain-text mail only. ``build_mime`` uses
+    ``EmailMessage.set_content(str)``, which yields a single
+    ``text/plain`` part with no ``text/html`` alternative. This guards
+    against a regression that would introduce an HTML body (e.g. a
+    stray ``add_alternative`` / ``set_content(subtype="html")``).
+    """
+    raw = build_mime(
+        from_addr="me@example.com",
+        to=["a@example.com"],
+        cc=[],
+        bcc=[],
+        subject="Plain",
+        body="Just text, no markup.",
+        in_reply_to=None,
+        references=None,
+    )
+    msg = parse_built_message(raw)
+    assert msg.get_content_type() == "text/plain"
+    assert not msg.is_multipart()
+    # No HTML part anywhere in the tree.
+    assert all(part.get_content_type() != "text/html" for part in msg.walk())
+    # The raw RFC822 bytes carry no HTML content-type header either.
+    assert b"text/html" not in raw
+
+
 def test_build_mime_joins_multiple_recipients():
     raw = build_mime(
         from_addr="me@example.com",

--- a/tools/gmail/operations.md
+++ b/tools/gmail/operations.md
@@ -194,16 +194,25 @@ mcp__claude_ai_Gmail__get_thread(
 )
 # → take messages[-1].id as <reply-to-message-id>
 
-# 2. Create the draft with replyToMessageId set:
+# 2. Create the draft with replyToMessageId set.
+#    Pass `body` (plain text) ONLY — never `htmlBody`. The tool sends
+#    a plain-text message iff `htmlBody` is omitted; supplying it adds
+#    a text/html alternative, which the project never wants.
 mcp__claude_ai_Gmail__create_draft(
   subject='Re: <root subject of the inbound message>',
   to=['<primary>'],
   cc=['<security-list>', ...],
-  body='<body>',
+  body='<body>',                # plain text only
   replyToMessageId='<reply-to-message-id>',
+  # htmlBody=...                # DO NOT SET — would make the draft HTML
 )
 ```
 
+- **Plain text only — never set `htmlBody`.** The `create_draft` tool
+  produces a plain-text message when only `body` is supplied; passing
+  `htmlBody` (or `body` + `htmlBody`) creates a `text/html` part. The
+  project's outbound mail is always plain text, so only ever populate
+  `body`.
 - **`replyToMessageId` is the message ID of the latest message on the
   inbound thread.** Resolve it from `get_thread` rather than guessing
   — Gmail does not accept a `threadId` here.
@@ -249,6 +258,11 @@ backend too — drafts only, never send; subject is always
 ### Hard rules that apply to both backends
 
 - **Never send.**
+- **Plain text only — never HTML.** Every draft is a plain-text
+  (`text/plain`) message. For `claude_ai_mcp`, populate `body` and
+  never `htmlBody`. For `oauth_curl`, the script builds a single
+  `text/plain` part via `EmailMessage.set_content` (asserted by its
+  test suite). Do not introduce an HTML body in either backend.
 - **Subject is always `Re: <root subject>`**, never fabricated.
 - **Run `pii-reveal` before passing the body to the create-draft
   call.** If the draft body carries any third-party identifiers


### PR DESCRIPTION
## What

Make plain-text-only an enforced, documented invariant for Gmail drafts created by either backend (`oauth_curl` and the claude.ai Gmail MCP).

## Why

The project's outbound correspondence (security replies, ASF-security relays, advisory text) is plain text by policy. Nothing previously *guaranteed* that — the oauth backend happened to emit plain text but had no guard against a regression, and the MCP path will emit an HTML part if `htmlBody` is ever passed.

## Changes

- **`oauth_curl`** (`tools/gmail/oauth-draft/src/oauth_draft/create_draft.py`): comment on `build_mime` locking the intent — `set_content(str)` yields a single `text/plain` part; never add an HTML alternative.
- **Test** (`tests/test_create_draft.py`): new `test_build_mime_is_plain_text_not_html` asserting the built MIME is single-part `text/plain`, not multipart, with no `text/html` anywhere and no `text/html` in the raw bytes.
- **`claude_ai_mcp`**: documented the hard rule — pass only `body`, never `htmlBody` (which adds a `text/html` part) — in `operations.md` (call-shape example + bullet + "Hard rules that apply to both backends") and `draft-backends.md` ("Limitations that apply to both backends").

Docs + one Python package. `prek`-equivalent hooks ran on commit and pass: ruff, mypy, pytest (60 tests), markdownlint, typos, check-placeholders.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
