### PR TITLE
fix(cve-tool): lower-case ASF qualitative severity words (moderate/important)

### DIFF
--- a/tools/cve-tool-vulnogram/generate-cve-json/src/generate_cve_json/cve_json.py
+++ b/tools/cve-tool-vulnogram/generate-cve-json/src/generate_cve_json/cve_json.py
@@ -774,10 +774,11 @@ def parse_affected_versions(value: str, version_start_override: str | None) -> l
 
 def normalise_severity(value: str) -> str:
     """Return the severity as a lower-case word
-    (``none`` / ``low`` / ``medium`` / ``high`` / ``critical``) or the
+    (``none`` / ``low`` / ``moderate`` / ``medium`` / ``high`` / ``important`` /
+    ``critical``) or the
     original text if it doesn't match the standard set."""
     lowered = value.strip().lower()
-    if lowered in {"none", "low", "medium", "high", "critical"}:
+    if lowered in {"none", "low", "moderate", "medium", "high", "important", "critical"}:
         return lowered
     return value.strip()
 

--- a/tools/cve-tool-vulnogram/generate-cve-json/tests/test_generate_cve_json.py
+++ b/tools/cve-tool-vulnogram/generate-cve-json/tests/test_generate_cve_json.py
@@ -1416,7 +1416,7 @@ class TestCombineRemediationDevelopers:
 
 class TestNormaliseSeverity:
     def test_known_values_are_lowercased(self):
-        for raw in ("None", "Low", "Medium", "High", "Critical"):
+        for raw in ("None", "Low", "Moderate", "Medium", "High", "Important", "Critical"):
             assert normalise_severity(raw) == raw.lower()
 
     def test_already_lowercase_known_value_passes_through(self):
@@ -1428,6 +1428,8 @@ class TestNormaliseSeverity:
     def test_mixed_case_known_value_normalised(self):
         assert normalise_severity("HIGH") == "high"
         assert normalise_severity("CRITICAL") == "critical"
+        assert normalise_severity("MODERATE") == "moderate"
+        assert normalise_severity("Important") == "important"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## What

`normalise_severity()` now lower-cases the ASF qualitative severity words **`moderate`** and **`important`** (in addition to the CVSS set it already handled).

## Why

`normalise_severity` only lower-cased `{none, low, medium, high, critical}`. The ASF qualitative rating words `Moderate` and `Important` fell through unchanged, so a tracker scored `Moderate` landed **capitalized** in the CVE record's `metrics[].other` *"Textual description of severity"* — inconsistent with the lower-case [ASF severity-rating convention](https://security.apache.org/blog/severityrating/) and with the CVSS words that *were* lower-cased.

Adding `moderate`/`important` to the set makes the full ASF rating set (`low` / `moderate` / `important` / `critical`) emit lower-case. Unknown values are still passed through stripped-but-unchanged.

Tests extended to cover `Moderate`/`Important` → lower-case.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
