### PR TITLE
chore(pre-commit): add spec-validate hook for spec-loop specs

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -179,3 +179,17 @@ repos:
         entry: uv run --project tools/skill-and-tool-validator skill-and-tool-validate
         files: ^(skills/.*\.md|tools/[^/]+/README\.md|docs/labels-and-capabilities\.md|tools/skill-and-tool-validator/(src|pyproject\.toml))
         pass_filenames: false
+
+  # Validate `tools/spec-loop/specs/` frontmatter and required body sections
+  # via the `spec-validate` CLI. Re-fires on spec-source changes so rule
+  # updates get re-applied. `--project` (not `--directory`) so CWD stays at
+  # repo root; the directory argument is passed directly to the CLI so it
+  # scans the full specs tree even when only one file changed.
+  - repo: local
+    hooks:
+      - id: spec-validate
+        name: spec-validate (spec-loop specs frontmatter + sections)
+        language: system
+        entry: uv run --project tools/spec-validator spec-validate tools/spec-loop/specs/
+        files: ^(tools/spec-loop/specs/.*\.md|tools/spec-validator/(src|pyproject\.toml))
+        pass_filenames: false


### PR DESCRIPTION
## Summary

The spec-validator tool already ships a `spec-validate` CLI and passes all tests, but was never wired into pre-commit. Any spec-frontmatter or section regression would therefore only surface in CI, not at commit time. Hook fires on changes to `tools/spec-loop/specs/**/*.md` and to the validator source so rule updates are reapplied automatically.

## Type of change

<!-- Tick all that apply. -->

- [ ] Skill change (`.claude/skills/<name>/`) — eval fixtures updated below
- [X] Tool / bridge contract (`tools/<system>/*.md`)
- [ ] Python package (`tools/*/` with `pyproject.toml`)
- [ ] Groovy reference impl
- [ ] Cross-cutting (RFC, AGENTS.md, sandbox, privacy-LLM)
- [ ] Documentation (`docs/`, `README.md`, `CONTRIBUTING.md`)
- [ ] Project template (`projects/_template/`)
- [ ] CI / dev loop (`prek`, workflows, validators)
- [ ] Other:

## Test plan

- [X] `prek run --all-files` passes
- [X] For Python packages touched: `uv run pytest` / `ruff check` / `mypy` passes
- [ ] For Groovy bridges touched: command-line invocation tested end-to-end
- [ ] For skill changes: eval suite passes for the affected skill
      (`PYTHONPATH=tools/skill-evals/src python3 -m skill_evals.runner tools/skill-evals/evals/<skill>/`)
- [ ] For skill *behaviour* changes: a new or updated eval fixture is included in this PR
      (a regression test for the bug fixed / the behaviour added — see CONTRIBUTING.md)
- [ ] Other:
