### PR TITLE
feat(spec-validator): enforce Known gaps section in every functional spec

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -29,7 +29,11 @@ default_language_version:
   # `@eslint/js@10.0.1` declares engines `^20.19.0 || ^22.13.0 || >=24`,
   # so the old 22.11.0 pin failed `npm install` with EBADENGINE. 22.13.0
   # is the lowest 22.x that satisfies it.
-  node: 22.13.0
+  #
+  # Bumped 22.13.0 -> 22.20.0: ava@7.0.0 declares engines
+  # `^20.19 || ^22.20 || ^24.12 || >=25`; 22.13.0 fails EBADENGINE.
+  # 22.20.0 is the lowest 22.x that satisfies both constraints.
+  node: 22.20.0
 minimum_prek_version: '0.3.5'
 repos:
   - repo: meta

--- a/tools/spec-validator/src/spec_validator/__init__.py
+++ b/tools/spec-validator/src/spec_validator/__init__.py
@@ -25,7 +25,8 @@ Checks every .md file that carries a YAML frontmatter block:
 4. Valid ``mode`` value  — Triage | Mentoring | Drafting | Pairing | infra.
 5. Non-empty ``acceptance`` list — at least one ``- item`` entry.
 6. Required body sections — What it does, Where it lives,
-   Behaviour & contract, Out of scope, Acceptance criteria, Validation.
+   Behaviour & contract, Out of scope, Acceptance criteria, Validation,
+   Known gaps.
 7. Validation section contains at least one fenced code block.
 
 Files without frontmatter (README.md, overview.md) are skipped silently.
@@ -61,6 +62,7 @@ REQUIRED_SECTIONS: tuple[str, ...] = (
     "Out of scope",
     "Acceptance criteria",
     "Validation",
+    "Known gaps",
 )
 
 DEFAULT_SPEC_DIR = Path("tools/spec-loop/specs")

--- a/tools/spec-validator/tests/test_spec_validator.py
+++ b/tools/spec-validator/tests/test_spec_validator.py
@@ -85,6 +85,10 @@ _VALID_SPEC = textwrap.dedent("""\
     ```bash
     uv run --project tools/example --group dev pytest
     ```
+
+    ## Known gaps
+
+    - `stable`; no gaps at this time.
     """)
 
 


### PR DESCRIPTION
## Summary

All twelve functional spec files already carry a ## Known gaps section. Add it to REQUIRED_SECTIONS so the validator catches any future spec that omits it, and update the _VALID_SPEC test fixture to include the section (one extra parametrised test case.

## Type of change

<!-- Tick all that apply. -->

- [ ] Skill change (`.claude/skills/<name>/`) — eval fixtures updated below
- [ ] Tool / bridge contract (`tools/<system>/*.md`)
- [ ] Python package (`tools/*/` with `pyproject.toml`)
- [ ] Groovy reference impl
- [ ] Cross-cutting (RFC, AGENTS.md, sandbox, privacy-LLM)
- [X] Documentation (`docs/`, `README.md`, `CONTRIBUTING.md`)
- [ ] Project template (`projects/_template/`)
- [ ] CI / dev loop (`prek`, workflows, validators)
- [ ] Other:

## Test plan

<!--
How you verified the change. Be specific. The reviewer reads this to
decide what to spot-check vs trust. Empty "ran the tests" doesn't help.
-->

- [X] `prek run --all-files` passes
- [X] For Python packages touched: `uv run pytest` / `ruff check` / `mypy` passes
- [ ] For Groovy bridges touched: command-line invocation tested end-to-end
- [ ] For skill changes: eval suite passes for the affected skill
      (`PYTHONPATH=tools/skill-evals/src python3 -m skill_evals.runner tools/skill-evals/evals/<skill>/`)
- [ ] For skill *behaviour* changes: a new or updated eval fixture is included in this PR
      (a regression test for the bug fixed / the behaviour added — see CONTRIBUTING.md)
- [ ] Other:
