### PR TITLE
chore(asf): drop lychee from required status checks (ahead of prek conversion)

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -156,11 +156,13 @@ github:
           - "zizmor"
           # Pre-commit (prek) — static checks across the repo.
           - "prek"
-          # Lychee — link checker. Runs on every PR (no path
-          # filter), so it gates merge on link rot introduced in
-          # the PR. The daily schedule run still catches drift on
-          # files the PR did not touch.
-          - "lychee"
+          # NOTE: `lychee` (the link checker) is intentionally NOT a
+          # required context. It is being converted from the
+          # standalone `link-check.yml` workflow into a `prek` hook;
+          # de-requiring it here first lets that conversion PR merge
+          # without being blocked on a `lychee` status that will stop
+          # posting once `link-check.yml` is removed. lychee still
+          # runs (and gates via `prek`) once the conversion lands.
           # Per-project pytest matrix from tests.yml. Required via
           # the single `tests-ok` umbrella job rather than the
           # individual `pytest (<project>)` matrix entries — branch


### PR DESCRIPTION
## Summary

Removes **`lychee`** from the required status-check `contexts` in `.asf.yaml`.

## Why now (separate from the conversion PR)

The `lychee` link check is being converted from the standalone `link-check.yml`
workflow into a **`prek` hook** in a follow-up PR. That conversion deletes
`link-check.yml`, so the `lychee` status will stop posting — but the **live
branch protection still lists `lychee` as required**, which would leave the
conversion PR **blocked forever** on a status that never reports (the classic
"the PR removing the requirement can't satisfy the requirement it removes").

This tiny PR de-requires `lychee` **first**. ASF infra reconciles branch
protection from `.asf.yaml` on the default branch at merge, so once this lands
the live protection no longer requires `lychee`, and the conversion PR can merge
cleanly.

- `lychee` still **runs** via `link-check.yml` until the conversion lands — it
  is simply no longer a *required* merge gate in the interim.
- After the conversion, link health is gated by the required **`prek`** context
  (the lychee check becomes a prek hook inside it).

## Type of change

- [x] CI / dev loop (branch protection)

## Test plan

- [x] `.asf.yaml` still parses; `contexts` is now `zizmor`, `prek`, `tests-ok`.
- [x] prek green (only `.asf.yaml` changed).
