### PR TITLE
chore(skills): wire magpie-* symlinks for security-issue-import-from-scan

### DIFF
--- a/.agents/skills/magpie-security-issue-import-from-scan
+++ b/.agents/skills/magpie-security-issue-import-from-scan
@@ -1,0 +1,1 @@
+../../skills/security-issue-import-from-scan

--- a/.claude/skills/magpie-security-issue-import-from-scan
+++ b/.claude/skills/magpie-security-issue-import-from-scan
@@ -1,0 +1,1 @@
+../../.agents/skills/magpie-security-issue-import-from-scan

--- a/.github/skills/magpie-security-issue-import-from-scan
+++ b/.github/skills/magpie-security-issue-import-from-scan
@@ -1,0 +1,1 @@
+../../.agents/skills/magpie-security-issue-import-from-scan


### PR DESCRIPTION
## Summary

- The `security-issue-import-from-scan` skill source landed in #496 but its
  `magpie-*` symlinks were never wired into the agent target dirs, so the skill
  was not discoverable by any harness.
- Add the canonical link (`.agents/skills/`) plus the `.claude/` and `.github/`
  relays — bringing all three active targets to 41/41 matching `skills/`.
- Found and fixed by a `/magpie-setup upgrade` run on the framework checkout.

## Type of change

- [x] Skill change (`.claude/skills/<name>/`) — symlink wiring only, no skill content change
- [x] Other: framework self-adoption symlink reconcile

## Test plan

- [x] `prek run --all-files` passes (pre-commit ran clean on the commit)
- [x] All three target dirs resolve to the skill's `SKILL.md`; counts 41/41/41 vs `skills/`
- [x] Other: no eval/behaviour change — these are committed symlinks for local self-adoption

## RFC-AI-0004 compliance

- [x] **Vendor neutrality** — no prose change; symlinks only

## Linked issues

Refs #496