### PR TITLE
chore(agent-isolation): bump pinned claude-code 2.1.165 → 2.1.172

### DIFF
--- a/docs/setup/secure-agent-setup.md
+++ b/docs/setup/secure-agent-setup.md
@@ -158,7 +158,7 @@ The same flow, condensed to commands you run yourself:
 #    section: "Required tools (pinned versions)" below.
 sudo apt-get install --no-install-recommends \
     bubblewrap=0.11.2-* socat=1.8.1.1-*
-npm install -g --no-save @anthropic-ai/claude-code@2.1.165
+npm install -g --no-save @anthropic-ai/claude-code@2.1.172
 
 # 2. Project-scope `.claude/settings.json`. Copy the framework's
 #    sandbox / permissions.deny / permissions.ask / allowedDomains
@@ -256,7 +256,7 @@ version, no pin enforced — Homebrew rolls forward, so the
 
 ```bash
 # npm distribution (the only stable channel today)
-npm install -g --no-save @anthropic-ai/claude-code@2.1.165
+npm install -g --no-save @anthropic-ai/claude-code@2.1.172
 ```
 
 ### Distro-specific shortcut — Linux Mint 22.x / Ubuntu 24.04 Noble

--- a/tools/agent-isolation/pinned-versions.toml
+++ b/tools/agent-isolation/pinned-versions.toml
@@ -52,7 +52,7 @@
 
 # When this file was last touched. The check script uses this as the
 # minimum age the entries below claim to satisfy.
-pinned_at = "2026-06-06"
+pinned_at = "2026-06-12"
 
 [tools.bubblewrap]
 version = "0.11.2"
@@ -91,8 +91,8 @@ install.dnf = "dnf install socat-1.8.1.1"
 install.from_source = "http://www.dest-unreach.org/socat/download/socat-1.8.1.1.tar.gz"
 
 [tools.claude-code]
-version = "2.1.165"
-released = "2026-06-05"
+version = "2.1.172"
+released = "2026-06-10"
 # Override the framework-wide 7-day default. Claude Code releases
 # cadence is high (multiple releases per week) and any regression
 # that affects the framework's permission-rule semantics, sandbox
@@ -118,5 +118,5 @@ upstream_releases = "https://api.github.com/repos/anthropics/claude-code/release
 # Claude Code is distributed via npm; use `--no-save` so the global
 # install doesn't drift the local lockfile of any project the user
 # installs from.
-install.npm = "npm install -g --no-save @anthropic-ai/claude-code@2.1.165"
-install.brew = "# brew tap anthropics/claude-code; brew install claude-code@2.1.165 (when available)"
+install.npm = "npm install -g --no-save @anthropic-ai/claude-code@2.1.172"
+install.brew = "# brew tap anthropics/claude-code; brew install claude-code@2.1.172 (when available)"


### PR DESCRIPTION
Bumps the pinned `claude-code` from **2.1.165** to **2.1.172** (released 2026-06-10, past the 1-day cooldown).

Changelog reviewed against the secure setup — no weakening of permission-rule semantics, sandbox flags, or prompt-injection mitigations. Several entries *strengthen* the posture:

- **2.1.166** — relayed `SendMessage` tool requests no longer carry user authority (closes a cross-session permission-escalation path); glob deny rules in tool-name position; managed-settings enforcement hardened.
- **2.1.169** — untrusted project settings can no longer set OTEL client-cert paths without trust confirmation.
- **2.1.172** — `WebFetch` allow/deny/ask domain-wildcard rules now match subdomains correctly (was a silent permission gap).

2.1.170 ships Claude Fable 5. Updates `pinned_at` and both install commands in `docs/setup/secure-agent-setup.md`. `check-tool-updates.sh` is green after the bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)