### PR TITLE
fix(template): replace hardcoded Airflow identity with placeholders in project.md (#506)

### DIFF
--- a/projects/_template/project.md
+++ b/projects/_template/project.md
@@ -711,15 +711,15 @@ scope_detection:
   # Consumed by: security-issue-triage, generate-cve-json.
   labels:
     airflow:
-      product: "Apache Airflow"
+      product: "<Product Name>"
       packageName: "apache-airflow"
       path_prefix: "^(airflow-core/|airflow/(?!providers/)|airflow-ctl/)"
     providers:
-      product: "Apache Airflow"
+      product: "<Product Name>"
       packageName: "apache-airflow-providers-<provider>"
       path_prefix: "^providers/"
     chart:
-      product: "Apache Airflow Helm Chart"
+      product: "<Secondary Product Name>"
       packageName: "apache-airflow-helm-chart"
       path_prefix: "^chart/"
 ```
@@ -834,7 +834,7 @@ product:
   # Override when: any other project — replace with the canonical
   # short name.
   # Consumed by: generate-cve-json, canned-responses templating.
-  name: Airflow
+  name: <ProjectShortName>
 
   # Package name shape for the primary artifact — used by the
   # advisory templating and the CVE JSON `affected[].packageName`.
@@ -877,7 +877,7 @@ product:
   # Override when: any other product — the literal product token
   # reporters use in version expressions.
   # Consumed by: security-issue-sync, generate-cve-json.
-  affected_version_extract_prefix: "Airflow"
+  affected_version_extract_prefix: "<ProjectShortName>"
 ```
 
 ## Pointers to sibling files


### PR DESCRIPTION
## What

The project-agnostic scaffold `projects/_template/project.md` carried live
**Apache Airflow** identity in several CVE / version-extraction config *values*
(not just in `# ASF/Airflow default:` example comments). A fresh adopter copying
the template inherited Airflow's identity in fields that drive CVE-JSON
generation and version extraction, rather than a placeholder they are prompted
to fill.

Surfaced by a `/magpie-setup upgrade` template-genericity audit (Step 6d) on
snapshot `110820e`.

## Changes

Replaced the five flagged values with `<placeholder>` tokens consistent with the
existing H1 title convention, preserving the `# ASF/Airflow default:`
documentation comments:

| Field | Before | After |
|---|---|---|
| cve scope `product` (airflow / providers) | `"Apache Airflow"` | `"<Product Name>"` |
| cve scope `product` (chart) | `"Apache Airflow Helm Chart"` | `"<Secondary Product Name>"` |
| `release_process.name` | `Airflow` | `<ProjectShortName>` |
| `affected_version_extract_prefix` | `"Airflow"` | `"<ProjectShortName>"` |

The lesser illustrative prose noted in the issue (README / quick-merge / stats
examples) is left as-is — those read as deliberate worked examples.

Closes #506.