### PR TITLE
feat(setup): add __pycache__/ and *.pyc to adopted .gitignore entries

### DIFF
--- a/docs/setup/install-recipes.md
+++ b/docs/setup/install-recipes.md
@@ -114,6 +114,11 @@ cat >> .gitignore <<'GITIGNORE'
 # detect drift.
 /.apache-magpie.local.lock
 
+# Byte-compiled artefacts emitted when framework skill scripts run
+# from this checkout. Non-anchored so they match at any depth.
+__pycache__/
+*.pyc
+
 # Framework-skill symlinks created by /magpie-setup. One uniform
 # block per skills dir you use: the `magpie-*` glob ignores them
 # all (their targets are the gitignored snapshot, so they would

--- a/skills/setup/adopt.md
+++ b/skills/setup/adopt.md
@@ -503,7 +503,16 @@ idempotent — re-add them if they're missing.
 /.apache-magpie/
 /.apache-magpie.local.lock
 /.claude/settings.local.json
+__pycache__/
+*.pyc
 ```
+
+The `__pycache__/` and `*.pyc` lines (non-anchored — they match at
+any depth) keep the byte-compiled artefacts that framework skill
+scripts emit when run from the adopter checkout (e.g.
+[`setup-status/scripts/collect_status.py`](../setup-status/scripts/collect_status.py))
+out of the tree. Most adopters already carry these from a stock
+Python `.gitignore`; the adopt flow adds them if missing.
 
 **Symlink entries — one uniform block per active target
 ([`agents.md`](agents.md)), no per-layout variation.** Every
@@ -1252,6 +1261,7 @@ Committed (you'll see in `git status`):
 Gitignored (do NOT commit):
   .apache-magpie/
   .apache-magpie.local.lock
+  __pycache__/ + *.pyc       # byte-compiled artefacts from skill scripts; added to .gitignore if missing
   .agents/skills/magpie-*   (except magpie-setup, committed above)  # canonical links into the snapshot: opt-in + always-on families
   .claude/skills/magpie-*   (except magpie-setup, committed above)  # relays → ../../.agents/skills/magpie-*
   .github/skills/magpie-*   (except magpie-setup, committed above)  # relays → ../../.agents/skills/magpie-*

--- a/skills/setup/unadopt.md
+++ b/skills/setup/unadopt.md
@@ -249,7 +249,13 @@ pointing at a deleted snapshot.
    [`adopt.md` Step 7](adopt.md) that are present, and leave
    any adopter-added entries (e.g. unrelated rules near the
    adoption block) untouched. Do not collapse blank lines —
-   the diff stays minimal.
+   the diff stays minimal. **Exception:** leave `__pycache__/`
+   and `*.pyc` in place — they are stock Python entries that
+   most repos carry independently of the framework, so removing
+   them would break the adopter's own Python ignores. Only drop
+   them if they sit unambiguously inside the steward-managed
+   block (under the same comment header the adopt flow wrote)
+   and the repo has no other Python sources.
 6. **Doc sections.** For each of `README.md`, `AGENTS.md`,
    `CONTRIBUTING.md` that contains an adoption section,
    remove the section. The boundaries are the section
@@ -372,6 +378,10 @@ need a human re-read.
   adopter also has `/.apache-magpie/foo` for unrelated
   reasons) → only the exact adopt-template lines are
   removed; adopter rules stay.
+- **Stock Python entries (`__pycache__/`, `*.pyc`)** → left
+  in place by default per Step 5; they predate adoption in
+  most repos, so removing them would break the adopter's own
+  Python ignores.
 - **Adopter ran `unadopt` then realised they wanted to keep
   override content** → the override directory was preserved
   by default; if they passed `--purge-overrides` and

--- a/skills/setup/verify.md
+++ b/skills/setup/verify.md
@@ -159,6 +159,9 @@ Check that the entries from
   [issue #197](https://github.com/apache/airflow-steward/issues/197);
   must never be committed since the content is machine-specific
   absolute paths)
+- `__pycache__/` and `*.pyc` (byte-compiled artefacts emitted when
+  framework skill scripts run from the adopter checkout; non-anchored
+  so they match at any depth)
 
 Recommended (a **uniform** `magpie-*` glob block per **active
 target dir** — [`agents.md`](agents.md) — with no per-layout
@@ -184,6 +187,8 @@ variation):
   target as defense in depth, but `verify` surfaces the
   underlying `.gitignore` gap so the operator fixes the root
   cause.
+- ⚠ if `__pycache__/` or `*.pyc` is not gitignored — byte-compiled
+  artefacts from skill scripts could be accidentally committed.
 - ⚠ if symlink patterns are not gitignored.
 
 ### 5. Symlinks point at live framework skills


### PR DESCRIPTION
## What

Framework skill scripts (e.g. `setup-status/scripts/collect_status.py`) emit
byte-compiled artefacts when run from an adopter checkout, but the adopter-facing
"expected entries" never covered them — so a fresh adoption could accidentally
commit `__pycache__/` dirs and `*.pyc` files.

## Changes

Added the two non-anchored entries (match at any depth) to all four canonical
places, kept in sync:

- **`adopt.md`** Step 7 base-entries block + post-adopt summary
- **`install-recipes.md`** bootstrap `.gitignore` heredoc
- **`verify.md`** check 4 required list + a `⚠` failure signal
- **`unadopt.md`** — a guard so unadopt **leaves them in place by default**: they
  are stock Python entries most repos carry independently of the framework, so
  removing them would break the adopter's own Python ignores

All pre-commit hooks pass (markdownlint, typos, lychee, skill-and-tool-validate).