### PR TITLE
fix(setup): add missing .github relay symlinks for two skills

### DIFF
--- a/.github/skills/magpie-issue-stale-sweep
+++ b/.github/skills/magpie-issue-stale-sweep
@@ -1,0 +1,1 @@
+../../.agents/skills/magpie-issue-stale-sweep

--- a/.github/skills/magpie-mentoring-welcome
+++ b/.github/skills/magpie-mentoring-welcome
@@ -1,0 +1,1 @@
+../../.agents/skills/magpie-mentoring-welcome


### PR DESCRIPTION
## What

The `issue-stale-sweep` and `mentoring-welcome` skills had canonical
(`.agents/skills/`) and `.claude/skills/` relays but were missing their
`.github/skills/` relays — so GitHub's skill loader could not discover them.

Surfaced by a `/magpie-setup upgrade` symlink-reconciliation pass: 43 skills in
`skills/`, but `.github/skills/` carried only 41 `magpie-*` relays.

## Changes

Added the two relay symlinks, in the same form every other `.github` relay uses:

- `.github/skills/magpie-issue-stale-sweep` → `../../.agents/skills/magpie-issue-stale-sweep`
- `.github/skills/magpie-mentoring-welcome` → `../../.agents/skills/magpie-mentoring-welcome`

Both committed as symlinks (mode `120000`) and resolve to their `SKILL.md`.
`skill-and-tool-validate` passes.