### PR TITLE
fix(template): genericize remaining hardcoded Airflow identity in _template config

### DIFF
--- a/projects/_template/mentoring-welcome-config.md
+++ b/projects/_template/mentoring-welcome-config.md
@@ -55,14 +55,15 @@ Replace `<two_stage_process_doc_url>` with the project's documented
 mentoring / triage policy URL and `<PROJECT>` with the project's display
 name (read from [`<project-config>/project.md`](project.md)).
 
-Add the rendered footer to the config as `ai_attribution_footer`:
+Add the rendered footer to the config as `ai_attribution_footer`.
+Filled-in example for Apache Airflow:
 
 ```markdown
 ai_attribution_footer: |
   ---
 
   _Note: This comment was drafted by an AI-assisted mentoring tool and may
-  contain mistakes. A Apache Airflow maintainer — a real person — will be the
+  contain mistakes. An Apache Airflow maintainer — a real person — will be the
   next to engage. We use this [two-stage process](https://github.com/apache/airflow/blob/main/contributing-docs/09_who_can_merge.rst)
   so that our maintainers' limited time is spent where it matters most:
   the conversation with you._

--- a/projects/_template/project.md
+++ b/projects/_template/project.md
@@ -705,23 +705,22 @@ scope_detection:
   # label to the CVE `product` field value, the package-name shape
   # the advisory will use, and the upstream path prefix the skill
   # uses to confirm a PR really touches that scope.
-  # ASF/Airflow default: the three existing scope labels.
+  # ASF/Airflow default: three scope labels —
+  #   airflow    product "Apache Airflow"            packageName apache-airflow                       path_prefix ^(airflow-core/|airflow/(?!providers/)|airflow-ctl/)
+  #   providers  product "Apache Airflow"            packageName apache-airflow-providers-<provider>  path_prefix ^providers/
+  #   chart      product "Apache Airflow Helm Chart" packageName apache-airflow-helm-chart            path_prefix ^chart/
   # Override when: a project with different scope axes — keep the
   # `product`/`packageName`/`path_prefix` triad shape.
   # Consumed by: security-issue-triage, generate-cve-json.
   labels:
-    airflow:
+    <scope-label>:
       product: "<Product Name>"
-      packageName: "apache-airflow"
-      path_prefix: "^(airflow-core/|airflow/(?!providers/)|airflow-ctl/)"
-    providers:
-      product: "<Product Name>"
-      packageName: "apache-airflow-providers-<provider>"
-      path_prefix: "^providers/"
-    chart:
+      packageName: "<package-name>"
+      path_prefix: "<path-prefix-regex>"
+    <secondary-scope-label>:
       product: "<Secondary Product Name>"
-      packageName: "apache-airflow-helm-chart"
-      path_prefix: "^chart/"
+      packageName: "<secondary-package-name>"
+      path_prefix: "<secondary-path-prefix-regex>"
 ```
 
 ### Release process
@@ -842,7 +841,7 @@ product:
   # Override when: any other project — use the package-registry
   # name (PyPI / npm / Maven / ...).
   # Consumed by: generate-cve-json, canned-responses templating.
-  package_name: apache-airflow
+  package_name: <package-name>
 
   # Regex matched against changed paths in an upstream PR to
   # confirm "this PR really touches the product". Used as a
@@ -851,7 +850,7 @@ product:
   # airflow/, airflow-core/, airflow-ctl/, etc.).
   # Override when: any other repo layout.
   # Consumed by: security-issue-fix, pr-management-triage.
-  code_pointer_path_prefix: "^airflow"
+  code_pointer_path_prefix: "<code-path-prefix-regex>"
 
   # Prefixes the title-normalization skill strips when normalising
   # an inbound subject line into a CVE title. Matched at the start


### PR DESCRIPTION
## What

A follow-up to #507, which genericized the `product:` values in
`projects/_template/project.md` but deliberately left the sibling values. A
`/magpie-setup upgrade` Step 6d genericity audit re-surfaced the residue; this
clears it.

## Changes

**`project.md`**

- `cve.scope_detection.labels` block: the worked Airflow example (label keys
  `airflow`/`providers`/`chart` and the concrete `packageName` / `path_prefix`
  values) is moved into the `# ASF/Airflow default:` comment, and the block
  itself becomes a generic placeholder triad (`<scope-label>` /
  `<package-name>` / `<path-prefix-regex>`).
- `release_process.package_name`: `apache-airflow` → `<package-name>`.
- `release_process.code_pointer_path_prefix`: `"^airflow"` →
  `"<code-path-prefix-regex>"`.

**`mentoring-welcome-config.md`**

- The AI-attribution footer's rendered block is now labelled explicitly as a
  "Filled-in example for Apache Airflow" (matching the file's own `Example:`
  annotation convention), so it no longer reads as the canonical default two
  lines after instructing the reader to substitute `<PROJECT>`.
- Fixes the "A Apache" → "An Apache" grammar nit.

All values preserved as documentation; only the live config values become
placeholders. Pre-commit hooks pass (markdownlint, typos, lychee,
skill-and-tool-validate).